### PR TITLE
feat(deploy): one-command Oracle Cloud installer for Cloud Shell

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -430,5 +430,6 @@ jobs:
           gh release create "$VERSION" \
             --generate-notes \
             deploy/docker-compose/*.yaml \
-            deploy/docker-compose/.env.example
+            deploy/docker-compose/.env.example \
+            deploy/oracle-cloud/oracle-cloud-install.sh
 

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -12,9 +12,12 @@
 # Optional environment:
 #   DESEC_TOKEN             deSEC API token; the apex and wildcard A records are then written
 #                           for you (prompted for, hidden, when unset and running interactively)
+#   FOLDING=1               run Folding@home 02:00-04:00 UTC nightly so the server never counts as idle
+#   FOLDING_TEAM            Folding@home team number (default 0)
+#   BUDGET_EMAIL            where the spend alert goes (default: the Oracle account's email)
 #   COMPARTMENT_ID          where to create resources (default: tenancy root)
 #   NOCTURNE_VERSION        release tag to install (default: latest)
-#   OCPUS / MEMORY_GB       A1 size (default 2 / 12; the free tier allows 4 / 24 in total)
+#   OCPUS / MEMORY_GB       A1 size (default 1 / 6; the free tier allows 4 / 24 in total)
 #   BOOT_VOLUME_GB          boot volume size (default 50; the free tier allows 200 in total)
 #   SSH_PUBLIC_KEY_FILE     key to authorise (default: generated at ~/.ssh/nocturne_oci)
 #   CAPACITY_RETRY_MINUTES  how long to keep retrying "out of host capacity" (default 30)
@@ -24,8 +27,11 @@ set -euo pipefail
 NAME="nocturne"
 COMPARTMENT_ID="${COMPARTMENT_ID:-${OCI_TENANCY:-}}"
 NOCTURNE_VERSION="${NOCTURNE_VERSION:-}"
-OCPUS="${OCPUS:-2}"
-MEMORY_GB="${MEMORY_GB:-12}"
+OCPUS="${OCPUS:-1}"
+MEMORY_GB="${MEMORY_GB:-6}"
+FOLDING="${FOLDING:-}"
+FOLDING_TEAM="${FOLDING_TEAM:-0}"
+BUDGET_EMAIL="${BUDGET_EMAIL:-}"
 BOOT_VOLUME_GB="${BOOT_VOLUME_GB:-50}"
 SSH_PUBLIC_KEY_FILE="${SSH_PUBLIC_KEY_FILE:-$HOME/.ssh/nocturne_oci.pub}"
 CAPACITY_RETRY_MINUTES="${CAPACITY_RETRY_MINUTES:-30}"
@@ -71,6 +77,34 @@ if [[ -z "$NOCTURNE_VERSION" ]]; then
 fi
 
 log "Nocturne $NOCTURNE_VERSION on $BASE_DOMAIN, region $HOME_REGION"
+
+# ── Spend alert ──────────────────────────────────────────────────────────────
+# Budgets live in the tenancy root regardless of where the resources go.
+
+log "Spend alert"
+TENANCY_ID="${OCI_TENANCY:-$COMPARTMENT_ID}"
+BUDGET_ID=$(q oci budgets budget list --compartment-id "$TENANCY_ID" --display-name "$NAME" --lifecycle-state ACTIVE --query 'data[0].id' --raw-output)
+if [[ -n "$BUDGET_ID" ]]; then
+  info "exists"
+else
+  if [[ -z "$BUDGET_EMAIL" && -n "${OCI_CS_USER_OCID:-}" ]]; then
+    BUDGET_EMAIL=$(q oci iam user get --user-id "$OCI_CS_USER_OCID" --query 'data.email' --raw-output)
+  fi
+  if [[ -z "$BUDGET_EMAIL" && -t 0 ]]; then
+    read -rp "    Email address for the spend alert: " BUDGET_EMAIL
+  fi
+  if [[ -z "$BUDGET_EMAIL" ]]; then
+    info "skipped; set BUDGET_EMAIL to be told if this account is ever charged"
+  elif BUDGET_ID=$(oci budgets budget create --compartment-id "$TENANCY_ID" --display-name "$NAME" --amount 1 --reset-period MONTHLY \
+         --target-type COMPARTMENT --targets "[\"$TENANCY_ID\"]" --query 'data.id' --raw-output 2>/dev/null) \
+       && oci budgets alert-rule create --budget-id "$BUDGET_ID" --display-name "$NAME" --type ACTUAL --threshold 1 --threshold-type ABSOLUTE \
+         --recipients "$BUDGET_EMAIL" \
+         --message "Your Nocturne server on Oracle Cloud has been charged. Everything the installer creates is within the free tier, so check the Oracle console for what changed." >/dev/null 2>&1; then
+    info "$BUDGET_EMAIL will be emailed if this account is ever charged"
+  else
+    info "could not create the budget alert; you can add one under Billing > Budgets in the console"
+  fi
+fi
 
 # ── Network ──────────────────────────────────────────────────────────────────
 
@@ -209,6 +243,7 @@ write_files:
       BASE_DOMAIN=@BASE_DOMAIN@
       PUBLIC_IP=@PUBLIC_IP@
       NOCTURNE_VERSION=@NOCTURNE_VERSION@
+      FOLDING_TEAM=@FOLDING_TEAM@
   - path: /usr/local/sbin/nocturne-up
     permissions: '0755'
     content: |
@@ -266,6 +301,100 @@ write_files:
 
       [Install]
       WantedBy=multi-user.target
+  - path: /usr/local/sbin/nocturne-folding-unpause
+    permissions: '0755'
+    content: |
+      #!/usr/bin/env python3
+      # The v8 client installs paused and only its websocket API can change that.
+      import base64, json, os, socket, sys, time
+
+      for _ in range(30):
+          try:
+              s = socket.create_connection(("127.0.0.1", 7396), timeout=5)
+              break
+          except OSError:
+              time.sleep(2)
+      else:
+          sys.exit("fah-client did not open its control port")
+
+      key = base64.b64encode(os.urandom(16)).decode()
+      s.sendall(("GET /api/websocket HTTP/1.1\r\nHost: 127.0.0.1:7396\r\nUpgrade: websocket\r\n"
+                 "Connection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n" % key).encode())
+      resp = b""
+      while b"\r\n\r\n" not in resp:
+          chunk = s.recv(4096)
+          if not chunk:
+              sys.exit("websocket handshake failed")
+          resp += chunk
+      if not resp.startswith(b"HTTP/1.1 101"):
+          sys.exit("websocket handshake refused: " + resp.split(b"\r\n")[0].decode())
+
+      payload = json.dumps({"cmd": "state", "state": "fold"}).encode()
+      mask = os.urandom(4)
+      s.sendall(bytes([0x81, 0x80 | len(payload)]) + mask + bytes(b ^ mask[i % 4] for i, b in enumerate(payload)))
+      time.sleep(2)
+      s.close()
+  - path: /usr/local/sbin/nocturne-folding-setup
+    permissions: '0755'
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      . /opt/nocturne/install.env
+
+      # Written before the package installs so its postinst keeps it instead of writing an empty one.
+      install -d -m 755 /etc/fah-client
+      cat > /etc/fah-client/config.xml <<EOF
+      <config>
+        <user v="Anonymous"/>
+        <team v="${FOLDING_TEAM}"/>
+        <cpus v="$(nproc)"/>
+        <on-idle v="false"/>
+      </config>
+      EOF
+
+      curl -fsSL -o /tmp/fah-client.deb https://download.foldingathome.org/releases/public/fah-client/debian-stable-arm64/release/latest.deb
+      DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/fah-client.deb
+      rm -f /tmp/fah-client.deb
+
+      cat > /etc/systemd/system/nocturne-folding-start.service <<EOF
+      [Unit]
+      Description=Start the nightly Folding@home window
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/systemctl start fah-client
+      ExecStart=/usr/local/sbin/nocturne-folding-unpause
+      EOF
+      cat > /etc/systemd/system/nocturne-folding-start.timer <<EOF
+      [Unit]
+      Description=Nightly Folding@home window, start
+      [Timer]
+      OnCalendar=*-*-* 02:00:00
+      [Install]
+      WantedBy=timers.target
+      EOF
+      cat > /etc/systemd/system/nocturne-folding-stop.service <<EOF
+      [Unit]
+      Description=End the nightly Folding@home window
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/systemctl stop fah-client
+      EOF
+      cat > /etc/systemd/system/nocturne-folding-stop.timer <<EOF
+      [Unit]
+      Description=Nightly Folding@home window, stop
+      [Timer]
+      OnCalendar=*-*-* 04:00:00
+      [Install]
+      WantedBy=timers.target
+      EOF
+
+      systemctl daemon-reload
+      # Runs only inside the window, never at boot.
+      systemctl disable fah-client
+      systemctl start fah-client
+      /usr/local/sbin/nocturne-folding-unpause
+      systemctl stop fah-client
+      systemctl enable --now nocturne-folding-start.timer nocturne-folding-stop.timer
 runcmd:
   # Oracle's Ubuntu image rejects inbound traffic other than SSH in the instance's
   # own iptables rules, independently of the VCN security list.
@@ -282,7 +411,9 @@ runcmd:
   - systemctl enable nocturne.service
   - systemctl start --no-block nocturne.service
 CLOUD_INIT_EOF
-  sed -i -e "s|@BASE_DOMAIN@|$BASE_DOMAIN|" -e "s|@PUBLIC_IP@|$PUBLIC_IP|" -e "s|@NOCTURNE_VERSION@|$NOCTURNE_VERSION|" "$CLOUD_INIT"
+  sed -i -e "s|@BASE_DOMAIN@|$BASE_DOMAIN|" -e "s|@PUBLIC_IP@|$PUBLIC_IP|" -e "s|@NOCTURNE_VERSION@|$NOCTURNE_VERSION|" \
+    -e "s|@FOLDING_TEAM@|$FOLDING_TEAM|" "$CLOUD_INIT"
+  [[ -z "$FOLDING" ]] || echo "  - /usr/local/sbin/nocturne-folding-setup" >> "$CLOUD_INIT"
 
   mapfile -t ADS < <(oci iam availability-domain list --compartment-id "$COMPARTMENT_ID" --query 'data[].name' --raw-output | jq -r '.[]')
   deadline=$((SECONDS + CAPACITY_RETRY_MINUTES * 60))

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -168,7 +168,8 @@ fi
 if [[ ! -f "$SSH_PUBLIC_KEY_FILE" ]]; then
   [[ "$SSH_PUBLIC_KEY_FILE" == "$HOME/.ssh/nocturne_oci.pub" ]] || die "SSH_PUBLIC_KEY_FILE $SSH_PUBLIC_KEY_FILE does not exist"
   mkdir -p "$HOME/.ssh"
-  ssh-keygen -q -t ed25519 -N '' -f "$HOME/.ssh/nocturne_oci" -C "$NAME"
+  # Cloud Shell runs in FIPS mode, which rejects Ed25519.
+  ssh-keygen -q -t rsa -b 4096 -N '' -f "$HOME/.ssh/nocturne_oci" -C "$NAME"
   info "generated an SSH key at ~/.ssh/nocturne_oci"
 fi
 

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -347,6 +347,10 @@ info "Open https://$BASE_DOMAIN to create your first site and passkey."
 info "SSH:   ssh -i ~/.ssh/nocturne_oci ubuntu@$PUBLIC_IP"
 info "Files: /opt/nocturne on the instance. Database passwords are in .env; Nocturne generated them and only it needs them."
 info "Logs:  sudo journalctl -u nocturne   and   cd /opt/nocturne && sudo docker compose logs"
+printf '\n'
+info "Back up the SSH key. It exists only in this Cloud Shell home, which Oracle deletes after six months"
+info "without a Cloud Shell session. Nocturne keeps running without it, but you lose the way onto the server."
+info "Cloud Shell menu (top left of this terminal) > Download, then enter:  .ssh/nocturne_oci"
 
 INSTANCE_KEY=$(ssh -i "${SSH_PUBLIC_KEY_FILE%.pub}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10 \
   "ubuntu@$PUBLIC_IP" "sudo sed -n 's/^INSTANCE_KEY=//p' /opt/nocturne/.env" 2>/dev/null || true)

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -288,6 +288,9 @@ CLOUD_INIT_EOF
       fi
       if grep -qi "capacity" <<<"$out"; then
         info "no Ampere A1 capacity in $ad right now"
+      elif grep -qi "TooManyRequests" <<<"$out"; then
+        info "Oracle is rate-limiting launch attempts; pausing two minutes"
+        sleep 120
       else
         die "launch failed: $out"
       fi

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -10,6 +10,8 @@
 # current state.
 #
 # Optional environment:
+#   DESEC_TOKEN             deSEC API token; the apex and wildcard A records are then written
+#                           for you (prompted for, hidden, when unset and running interactively)
 #   COMPARTMENT_ID          where to create resources (default: tenancy root)
 #   NOCTURNE_VERSION        release tag to install (default: latest)
 #   OCPUS / MEMORY_GB       A1 size (default 2 / 12; the free tier allows 4 / 24 in total)
@@ -127,10 +129,39 @@ if [[ -z "$PUBLIC_IP_ID" ]]; then
 fi
 PUBLIC_IP=$(oci network public-ip get --public-ip-id "$PUBLIC_IP_ID" --query 'data."ip-address"' --raw-output)
 
-printf '\n'
-info "Create these two DNS records at your domain provider now:"
-printf '\n      %-28s A   %s\n      %-28s A   %s\n\n' "$BASE_DOMAIN" "$PUBLIC_IP" "*.$BASE_DOMAIN" "$PUBLIC_IP"
-info "Nocturne waits until both resolve before requesting certificates. Do not proxy them through Cloudflare."
+# ── DNS ──────────────────────────────────────────────────────────────────────
+
+desec() { curl -fsS -H "Authorization: Token $DESEC_TOKEN" -H "Content-Type: application/json" "$@"; }
+
+if [[ -z "${DESEC_TOKEN:-}" && -t 0 ]]; then
+  printf '\n'
+  info "If $BASE_DOMAIN is managed at deSEC (desec.io, including free dedyn.io names), paste an"
+  info "API token and the DNS records are created for you. Otherwise press Enter to add them yourself."
+  read -rsp "    deSEC token: " DESEC_TOKEN
+  printf '\n'
+fi
+
+if [[ -n "${DESEC_TOKEN:-}" ]]; then
+  log "DNS records at deSEC"
+  # BASE_DOMAIN may sit below the zone deSEC hosts (nocturne.example.com in example.com).
+  ZONE="$BASE_DOMAIN"
+  while [[ "$ZONE" == *.* ]] && ! DOMAIN_JSON=$(desec "https://desec.io/api/v1/domains/$ZONE/" 2>/dev/null); do
+    ZONE="${ZONE#*.}"
+  done
+  [[ "$ZONE" == *.* ]] || die "no domain in this deSEC account contains $BASE_DOMAIN. Add it at desec.io first (for a free name, a dynDNS domain under dedyn.io), or run again without a token and create the records yourself."
+  SUBNAME="${BASE_DOMAIN%"$ZONE"}"
+  SUBNAME="${SUBNAME%.}"
+  TTL=$(jq -r '.minimum_ttl // 3600' <<<"$DOMAIN_JSON")
+  desec -X PUT "https://desec.io/api/v1/domains/$ZONE/rrsets/" -d "$(jq -cn --arg ip "$PUBLIC_IP" --arg s "$SUBNAME" --arg w "*${SUBNAME:+.$SUBNAME}" --argjson ttl "$TTL" \
+    '[{subname:$s,type:"A",ttl:$ttl,records:[$ip]},{subname:$w,type:"A",ttl:$ttl,records:[$ip]}]')" >/dev/null \
+    || die "could not write the DNS records at deSEC. The token needs write access to $ZONE."
+  info "$BASE_DOMAIN and *.$BASE_DOMAIN point at $PUBLIC_IP"
+else
+  printf '\n'
+  info "Create these two DNS records at your domain provider now:"
+  printf '\n      %-28s A   %s\n      %-28s A   %s\n\n' "$BASE_DOMAIN" "$PUBLIC_IP" "*.$BASE_DOMAIN" "$PUBLIC_IP"
+  info "Nocturne waits until both resolve before requesting certificates. Do not proxy them through Cloudflare."
+fi
 
 # ── SSH key ──────────────────────────────────────────────────────────────────
 

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# Nocturne on Oracle Cloud. Run from Oracle Cloud Shell:
+#
+#   BASE_DOMAIN=nocturne.example.com bash <(curl -fsSL https://github.com/nightscout/nocturne/releases/latest/download/oracle-cloud-install.sh)
+#
+# Creates a VCN with one public subnet, a reserved public IP and an Always Free
+# Ampere A1 instance whose first boot installs Docker, downloads the Nocturne
+# release bundle and starts it once DNS points at the reserved IP. Every resource
+# is looked up by name before it is created, so re-running is safe and prints the
+# current state.
+#
+# Optional environment:
+#   COMPARTMENT_ID          where to create resources (default: tenancy root)
+#   NOCTURNE_VERSION        release tag to install (default: latest)
+#   OCPUS / MEMORY_GB       A1 size (default 2 / 12; the free tier allows 4 / 24 in total)
+#   BOOT_VOLUME_GB          boot volume size (default 50; the free tier allows 200 in total)
+#   SSH_PUBLIC_KEY_FILE     key to authorise (default: generated at ~/.ssh/nocturne_oci)
+#   CAPACITY_RETRY_MINUTES  how long to keep retrying "out of host capacity" (default 30)
+
+set -euo pipefail
+
+NAME="nocturne"
+COMPARTMENT_ID="${COMPARTMENT_ID:-${OCI_TENANCY:-}}"
+NOCTURNE_VERSION="${NOCTURNE_VERSION:-}"
+OCPUS="${OCPUS:-2}"
+MEMORY_GB="${MEMORY_GB:-12}"
+BOOT_VOLUME_GB="${BOOT_VOLUME_GB:-50}"
+SSH_PUBLIC_KEY_FILE="${SSH_PUBLIC_KEY_FILE:-$HOME/.ssh/nocturne_oci.pub}"
+CAPACITY_RETRY_MINUTES="${CAPACITY_RETRY_MINUTES:-30}"
+
+log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+info() { printf '    %s\n' "$*"; }
+die()  { printf '\n\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Runs an oci query and turns JMESPath's null into an empty string so callers can
+# test "does this exist" with [[ -n ]].
+q() {
+  local out
+  out=$("$@" 2>/dev/null) || return 0
+  [[ "$out" == "null" ]] && out=""
+  printf '%s' "$out"
+}
+
+command -v oci >/dev/null || die "the oci command is not available. Open Cloud Shell from the Oracle Cloud console (terminal icon, top right) and run this there."
+command -v jq >/dev/null || die "jq is not available"
+[[ -n "$COMPARTMENT_ID" ]] || die "COMPARTMENT_ID is not set and OCI_TENANCY is empty. Are you in Cloud Shell?"
+
+if [[ -z "${BASE_DOMAIN:-}" ]]; then
+  read -rp "Domain Nocturne should answer on (e.g. nocturne.example.com): " BASE_DOMAIN
+fi
+BASE_DOMAIN="${BASE_DOMAIN,,}"
+[[ "$BASE_DOMAIN" =~ ^([a-z0-9-]+\.)+[a-z]{2,}$ ]] || die "BASE_DOMAIN must be a domain name with at least two labels, not an IP address"
+
+# Always Free compute only exists in the tenancy's home region.
+HOME_REGION=$(oci iam region-subscription list --query 'data[?"is-home-region"] | [0]."region-name"' --raw-output)
+export OCI_CLI_REGION="$HOME_REGION"
+
+if [[ -z "$NOCTURNE_VERSION" ]]; then
+  # The redirect target of /releases/latest names the tag without touching the rate-limited API.
+  NOCTURNE_VERSION=$(curl -fsS -o /dev/null -w '%{redirect_url}' https://github.com/nightscout/nocturne/releases/latest | sed 's|.*/tag/||')
+  [[ "$NOCTURNE_VERSION" == v* ]] || die "could not look up the latest Nocturne release; set NOCTURNE_VERSION"
+fi
+
+log "Nocturne $NOCTURNE_VERSION on $BASE_DOMAIN, region $HOME_REGION"
+
+# ── Network ──────────────────────────────────────────────────────────────────
+
+log "Network"
+VCN_ID=$(q oci network vcn list --compartment-id "$COMPARTMENT_ID" --display-name "$NAME" --lifecycle-state AVAILABLE --query 'data[0].id' --raw-output)
+if [[ -z "$VCN_ID" ]]; then
+  VCN_ID=$(oci network vcn create --compartment-id "$COMPARTMENT_ID" --display-name "$NAME" --dns-label "$NAME" \
+    --cidr-block 10.0.0.0/16 --wait-for-state AVAILABLE --query 'data.id' --raw-output)
+  info "created VCN"
+else
+  info "VCN exists"
+fi
+
+IGW_ID=$(q oci network internet-gateway list --compartment-id "$COMPARTMENT_ID" --vcn-id "$VCN_ID" --lifecycle-state AVAILABLE --query 'data[0].id' --raw-output)
+if [[ -z "$IGW_ID" ]]; then
+  IGW_ID=$(oci network internet-gateway create --compartment-id "$COMPARTMENT_ID" --vcn-id "$VCN_ID" --display-name "$NAME" \
+    --is-enabled true --wait-for-state AVAILABLE --query 'data.id' --raw-output)
+  info "created internet gateway"
+fi
+
+RT_ID=$(oci network vcn get --vcn-id "$VCN_ID" --query 'data."default-route-table-id"' --raw-output)
+if [[ "$(oci network route-table get --rt-id "$RT_ID" --query 'length(data."route-rules")')" == "0" ]]; then
+  oci network route-table update --rt-id "$RT_ID" --force \
+    --route-rules "[{\"destination\":\"0.0.0.0/0\",\"destinationType\":\"CIDR_BLOCK\",\"networkEntityId\":\"$IGW_ID\"}]" >/dev/null
+  info "added default route"
+fi
+
+SL_ID=$(oci network vcn get --vcn-id "$VCN_ID" --query 'data."default-security-list-id"' --raw-output)
+if ! oci network security-list get --security-list-id "$SL_ID" \
+     --query 'data."ingress-security-rules"[?protocol==`"6"` && "tcp-options"."destination-port-range".min==`443`]' \
+     | jq -e 'length > 0' >/dev/null; then
+  oci network security-list update --security-list-id "$SL_ID" --force --ingress-security-rules '[
+    {"protocol":"6","source":"0.0.0.0/0","tcpOptions":{"destinationPortRange":{"min":22,"max":22}}},
+    {"protocol":"6","source":"0.0.0.0/0","tcpOptions":{"destinationPortRange":{"min":80,"max":80}}},
+    {"protocol":"6","source":"0.0.0.0/0","tcpOptions":{"destinationPortRange":{"min":443,"max":443}}},
+    {"protocol":"17","source":"0.0.0.0/0","udpOptions":{"destinationPortRange":{"min":443,"max":443}}},
+    {"protocol":"1","source":"0.0.0.0/0","icmpOptions":{"type":3,"code":4}},
+    {"protocol":"1","source":"10.0.0.0/16","icmpOptions":{"type":3}}
+  ]' >/dev/null
+  info "opened ports 80 and 443"
+fi
+
+SUBNET_ID=$(q oci network subnet list --compartment-id "$COMPARTMENT_ID" --vcn-id "$VCN_ID" --display-name "$NAME" --lifecycle-state AVAILABLE --query 'data[0].id' --raw-output)
+if [[ -z "$SUBNET_ID" ]]; then
+  SUBNET_ID=$(oci network subnet create --compartment-id "$COMPARTMENT_ID" --vcn-id "$VCN_ID" --display-name "$NAME" --dns-label "$NAME" \
+    --cidr-block 10.0.0.0/24 --route-table-id "$RT_ID" --security-list-ids "[\"$SL_ID\"]" \
+    --wait-for-state AVAILABLE --query 'data.id' --raw-output)
+  info "created subnet"
+fi
+
+# ── Reserved public IP ───────────────────────────────────────────────────────
+# Reserved rather than ephemeral so the address survives a stop/start and the
+# user's DNS records stay valid. Created before the instance so the DNS records
+# can be added while it boots.
+
+log "Public IP"
+PUBLIC_IP_ID=$(q oci network public-ip list --compartment-id "$COMPARTMENT_ID" --scope REGION --lifetime RESERVED \
+  --query "data[?\"display-name\"=='$NAME'] | [0].id" --raw-output)
+if [[ -z "$PUBLIC_IP_ID" ]]; then
+  PUBLIC_IP_ID=$(oci network public-ip create --compartment-id "$COMPARTMENT_ID" --lifetime RESERVED --display-name "$NAME" \
+    --query 'data.id' --raw-output)
+  info "reserved a public IP"
+fi
+PUBLIC_IP=$(oci network public-ip get --public-ip-id "$PUBLIC_IP_ID" --query 'data."ip-address"' --raw-output)
+
+printf '\n'
+info "Create these two DNS records at your domain provider now:"
+printf '\n      %-28s A   %s\n      %-28s A   %s\n\n' "$BASE_DOMAIN" "$PUBLIC_IP" "*.$BASE_DOMAIN" "$PUBLIC_IP"
+info "Nocturne waits until both resolve before requesting certificates. Do not proxy them through Cloudflare."
+
+# ── SSH key ──────────────────────────────────────────────────────────────────
+
+if [[ ! -f "$SSH_PUBLIC_KEY_FILE" ]]; then
+  [[ "$SSH_PUBLIC_KEY_FILE" == "$HOME/.ssh/nocturne_oci.pub" ]] || die "SSH_PUBLIC_KEY_FILE $SSH_PUBLIC_KEY_FILE does not exist"
+  mkdir -p "$HOME/.ssh"
+  ssh-keygen -q -t ed25519 -N '' -f "$HOME/.ssh/nocturne_oci" -C "$NAME"
+  info "generated an SSH key at ~/.ssh/nocturne_oci"
+fi
+
+# ── Instance ─────────────────────────────────────────────────────────────────
+
+log "Instance"
+INSTANCE_ID=$(q oci compute instance list --compartment-id "$COMPARTMENT_ID" --display-name "$NAME" \
+  --query 'data[?"lifecycle-state"!=`"TERMINATED"` && "lifecycle-state"!=`"TERMINATING"`] | [0].id' --raw-output)
+
+if [[ -z "$INSTANCE_ID" ]]; then
+  IMAGE_ID=$(oci compute image list --compartment-id "$COMPARTMENT_ID" --operating-system "Canonical Ubuntu" --operating-system-version "24.04" \
+    --shape "VM.Standard.A1.Flex" --sort-by TIMECREATED --sort-order DESC --query 'data[0].id' --raw-output)
+  [[ -n "$IMAGE_ID" && "$IMAGE_ID" != "null" ]] || die "no Ubuntu 24.04 image for VM.Standard.A1.Flex in $HOME_REGION"
+
+  CLOUD_INIT=$(mktemp)
+  trap 'rm -f "$CLOUD_INIT"' EXIT
+  cat > "$CLOUD_INIT" <<'CLOUD_INIT_EOF'
+#cloud-config
+package_update: true
+write_files:
+  - path: /opt/nocturne/install.env
+    permissions: '0600'
+    content: |
+      BASE_DOMAIN=@BASE_DOMAIN@
+      PUBLIC_IP=@PUBLIC_IP@
+      NOCTURNE_VERSION=@NOCTURNE_VERSION@
+  - path: /usr/local/sbin/nocturne-up
+    permissions: '0755'
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      . /opt/nocturne/install.env
+      cd /opt/nocturne
+      log() { echo "[nocturne] $*"; }
+
+      if [[ ! -f docker-compose.yaml ]]; then
+        log "downloading Nocturne $NOCTURNE_VERSION"
+        base="https://github.com/nightscout/nocturne/releases/download/$NOCTURNE_VERSION"
+        curl -fsSL -o docker-compose.yaml "$base/docker-compose.yaml"
+        curl -fsSL -o default.env.example "$base/default.env.example"
+      fi
+
+      if [[ ! -f .env ]]; then
+        log "generating secrets"
+        gen() { openssl rand -hex 24; }
+        sed -e "s|^BASE_DOMAIN=.*|BASE_DOMAIN=$BASE_DOMAIN|" \
+            -e "s|^INSTANCE_KEY=.*|INSTANCE_KEY=$(gen)|" \
+            -e "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=$(gen)|" \
+            -e "s|^POSTGRES_APP_PASSWORD=.*|POSTGRES_APP_PASSWORD=$(gen)|" \
+            -e "s|^POSTGRES_MIGRATOR_PASSWORD=.*|POSTGRES_MIGRATOR_PASSWORD=$(gen)|" \
+            -e "s|^POSTGRES_WEB_PASSWORD=.*|POSTGRES_WEB_PASSWORD=$(gen)|" \
+            default.env.example > .env
+        chmod 600 .env
+        if grep -qE '^(BASE_DOMAIN|INSTANCE_KEY|POSTGRES_[A-Z_]*PASSWORD)=$' .env; then
+          log "a required value in .env is still empty; the release's .env.example has changed shape"
+          exit 1
+        fi
+      fi
+
+      resolves_here() { getent ahostsv4 "$1" 2>/dev/null | awk '{print $1}' | grep -qx "$PUBLIC_IP"; }
+      until resolves_here "$BASE_DOMAIN" && resolves_here "dns-check.$BASE_DOMAIN"; do
+        log "waiting for DNS: $BASE_DOMAIN and *.$BASE_DOMAIN must point at $PUBLIC_IP"
+        sleep 30
+      done
+
+      log "starting"
+      docker compose up -d
+  - path: /etc/systemd/system/nocturne.service
+    content: |
+      [Unit]
+      Description=Nocturne
+      Requires=docker.service
+      After=docker.service network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      TimeoutStartSec=infinity
+      ExecStart=/usr/local/sbin/nocturne-up
+
+      [Install]
+      WantedBy=multi-user.target
+runcmd:
+  # Oracle's Ubuntu image rejects inbound traffic other than SSH in the instance's
+  # own iptables rules, independently of the VCN security list.
+  - |
+    if [ -f /etc/iptables/rules.v4 ]; then
+      sed -i '/-A INPUT -j REJECT/i -A INPUT -p tcp -m state --state NEW -m tcp --dport 80 -j ACCEPT' /etc/iptables/rules.v4
+      sed -i '/-A INPUT -j REJECT/i -A INPUT -p tcp -m state --state NEW -m tcp --dport 443 -j ACCEPT' /etc/iptables/rules.v4
+      sed -i '/-A INPUT -j REJECT/i -A INPUT -p udp -m udp --dport 443 -j ACCEPT' /etc/iptables/rules.v4
+      netfilter-persistent reload
+    fi
+  - curl -fsSL https://get.docker.com | sh
+  - systemctl enable --now docker
+  - systemctl daemon-reload
+  - systemctl enable nocturne.service
+  - systemctl start --no-block nocturne.service
+CLOUD_INIT_EOF
+  sed -i -e "s|@BASE_DOMAIN@|$BASE_DOMAIN|" -e "s|@PUBLIC_IP@|$PUBLIC_IP|" -e "s|@NOCTURNE_VERSION@|$NOCTURNE_VERSION|" "$CLOUD_INIT"
+
+  mapfile -t ADS < <(oci iam availability-domain list --compartment-id "$COMPARTMENT_ID" --query 'data[].name' --raw-output | jq -r '.[]')
+  deadline=$((SECONDS + CAPACITY_RETRY_MINUTES * 60))
+  while [[ -z "$INSTANCE_ID" ]]; do
+    for ad in "${ADS[@]}"; do
+      info "launching in $ad"
+      if out=$(oci compute instance launch --compartment-id "$COMPARTMENT_ID" --availability-domain "$ad" --display-name "$NAME" \
+          --shape "VM.Standard.A1.Flex" --shape-config "{\"ocpus\":$OCPUS,\"memoryInGBs\":$MEMORY_GB}" \
+          --image-id "$IMAGE_ID" --subnet-id "$SUBNET_ID" --assign-public-ip false \
+          --boot-volume-size-in-gbs "$BOOT_VOLUME_GB" \
+          --ssh-authorized-keys-file "$SSH_PUBLIC_KEY_FILE" --user-data-file "$CLOUD_INIT" \
+          --wait-for-state RUNNING --query 'data.id' --raw-output 2>&1); then
+        INSTANCE_ID="$out"
+        info "instance is running"
+        break
+      fi
+      if grep -qi "capacity" <<<"$out"; then
+        info "no Ampere A1 capacity in $ad right now"
+      else
+        die "launch failed: $out"
+      fi
+    done
+    [[ -n "$INSTANCE_ID" ]] && break
+    (( SECONDS < deadline )) || die "no Ampere A1 capacity in any availability domain after $CAPACITY_RETRY_MINUTES minutes. This is common on the free tier: re-run later (everything created so far is reused), or try a smaller size with OCPUS=1 MEMORY_GB=6."
+    info "retrying in 60 seconds"
+    sleep 60
+  done
+else
+  info "instance exists"
+fi
+
+VNIC_ID=$(oci compute instance list-vnics --instance-id "$INSTANCE_ID" --query 'data[0].id' --raw-output)
+PRIVATE_IP_ID=$(oci network private-ip list --vnic-id "$VNIC_ID" --query 'data[0].id' --raw-output)
+if [[ "$(q oci network public-ip get --public-ip-id "$PUBLIC_IP_ID" --query 'data."assigned-entity-id"' --raw-output)" != "$PRIVATE_IP_ID" ]]; then
+  oci network public-ip update --public-ip-id "$PUBLIC_IP_ID" --private-ip-id "$PRIVATE_IP_ID" >/dev/null
+  info "attached the reserved IP"
+fi
+
+# ── Wait for Nocturne ────────────────────────────────────────────────────────
+
+log "Waiting for https://$BASE_DOMAIN"
+info "The instance installs Docker, then waits for your DNS records before starting."
+info "This usually takes 3 to 5 minutes once DNS is in place."
+deadline=$((SECONDS + 15 * 60))
+until curl -fsS -o /dev/null --max-time 10 "https://$BASE_DOMAIN/api/v1/status.json"; do
+  if (( SECONDS >= deadline )); then
+    printf '\n'
+    info "Not answering yet. That is expected if the DNS records are new. Check again with:"
+    info "  curl https://$BASE_DOMAIN/api/v1/status.json"
+    info "or re-run this script, which is safe and skips everything that already exists."
+    break
+  fi
+  sleep 15
+done
+
+printf '\n'
+log "Done"
+info "Open https://$BASE_DOMAIN to create your first site and passkey."
+info "SSH:  ssh -i ~/.ssh/nocturne_oci ubuntu@$PUBLIC_IP"
+info "Files on the instance: /opt/nocturne (secrets are in .env; Nocturne generated them, you do not need to know them)."
+info "Logs: sudo journalctl -u nocturne  and  cd /opt/nocturne && sudo docker compose logs"

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -47,11 +47,18 @@ command -v oci >/dev/null || die "the oci command is not available. Open Cloud S
 command -v jq >/dev/null || die "jq is not available"
 [[ -n "$COMPARTMENT_ID" ]] || die "COMPARTMENT_ID is not set and OCI_TENANCY is empty. Are you in Cloud Shell?"
 
+CONFIG="$HOME/.nocturne-oci/config"
+if [[ -z "${BASE_DOMAIN:-}" && -f "$CONFIG" ]]; then
+  . "$CONFIG"
+  info "using $BASE_DOMAIN from $CONFIG (set BASE_DOMAIN to override)"
+fi
 if [[ -z "${BASE_DOMAIN:-}" ]]; then
   read -rp "Domain Nocturne should answer on (e.g. nocturne.example.com): " BASE_DOMAIN
 fi
 BASE_DOMAIN="${BASE_DOMAIN,,}"
 [[ "$BASE_DOMAIN" =~ ^([a-z0-9-]+\.)+[a-z]{2,}$ ]] || die "BASE_DOMAIN must be a domain name with at least two labels, not an IP address"
+mkdir -p "$(dirname "$CONFIG")"
+printf 'BASE_DOMAIN=%s\n' "$BASE_DOMAIN" > "$CONFIG"
 
 # Always Free compute only exists in the tenancy's home region.
 HOME_REGION=$(oci iam region-subscription list --query 'data[?"is-home-region"] | [0]."region-name"' --raw-output)
@@ -132,8 +139,12 @@ PUBLIC_IP=$(oci network public-ip get --public-ip-id "$PUBLIC_IP_ID" --query 'da
 # ── DNS ──────────────────────────────────────────────────────────────────────
 
 desec() { curl -fsS -H "Authorization: Token $DESEC_TOKEN" -H "Content-Type: application/json" "$@"; }
+resolves_to_ip() { getent ahostsv4 "$1" 2>/dev/null | awk '{print $1}' | grep -qx "$PUBLIC_IP"; }
 
-if [[ -z "${DESEC_TOKEN:-}" && -t 0 ]]; then
+if resolves_to_ip "$BASE_DOMAIN" && resolves_to_ip "dns-check.$BASE_DOMAIN"; then
+  DNS_READY=1
+  info "DNS already points at $PUBLIC_IP"
+elif [[ -z "${DESEC_TOKEN:-}" && -t 0 ]]; then
   printf '\n'
   info "If $BASE_DOMAIN is managed at deSEC (desec.io, including free dedyn.io names), paste an"
   info "API token and the DNS records are created for you. Otherwise press Enter to add them yourself."
@@ -141,7 +152,9 @@ if [[ -z "${DESEC_TOKEN:-}" && -t 0 ]]; then
   printf '\n'
 fi
 
-if [[ -n "${DESEC_TOKEN:-}" ]]; then
+if [[ -n "${DNS_READY:-}" ]]; then
+  :
+elif [[ -n "${DESEC_TOKEN:-}" ]]; then
   log "DNS records at deSEC"
   # BASE_DOMAIN may sit below the zone deSEC hosts (nocturne.example.com in example.com).
   ZONE="$BASE_DOMAIN"

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -83,7 +83,7 @@ log "Nocturne $NOCTURNE_VERSION on $BASE_DOMAIN, region $HOME_REGION"
 
 log "Spend alert"
 TENANCY_ID="${OCI_TENANCY:-$COMPARTMENT_ID}"
-BUDGET_ID=$(q oci budgets budget list --compartment-id "$TENANCY_ID" --display-name "$NAME" --lifecycle-state ACTIVE --query 'data[0].id' --raw-output)
+BUDGET_ID=$(q oci budgets budget budget list --compartment-id "$TENANCY_ID" --display-name "$NAME" --lifecycle-state ACTIVE --query 'data[0].id' --raw-output)
 if [[ -n "$BUDGET_ID" ]]; then
   info "exists"
 else
@@ -95,10 +95,10 @@ else
   fi
   if [[ -z "$BUDGET_EMAIL" ]]; then
     info "skipped; set BUDGET_EMAIL to be told if this account is ever charged"
-  elif out=$(oci budgets budget create --compartment-id "$TENANCY_ID" --display-name "$NAME" --amount 1 --reset-period MONTHLY \
+  elif out=$(oci budgets budget budget create --compartment-id "$TENANCY_ID" --display-name "$NAME" --amount 1 --reset-period MONTHLY \
          --target-type COMPARTMENT --targets "[\"$TENANCY_ID\"]" --query 'data.id' --raw-output 2>&1) \
        && BUDGET_ID="$out" \
-       && out=$(oci budgets alert-rule create --budget-id "$BUDGET_ID" --display-name "$NAME" --type ACTUAL --threshold 1 --threshold-type ABSOLUTE \
+       && out=$(oci budgets budget alert-rule create --budget-id "$BUDGET_ID" --display-name "$NAME" --type ACTUAL --threshold 1 --threshold-type ABSOLUTE \
          --recipients "$BUDGET_EMAIL" \
          --message "Your Nocturne server on Oracle Cloud has been charged. Everything the installer creates is within the free tier, so check the Oracle console for what changed." 2>&1); then
     info "$BUDGET_EMAIL will be emailed if this account is ever charged"

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -95,14 +95,16 @@ else
   fi
   if [[ -z "$BUDGET_EMAIL" ]]; then
     info "skipped; set BUDGET_EMAIL to be told if this account is ever charged"
-  elif BUDGET_ID=$(oci budgets budget create --compartment-id "$TENANCY_ID" --display-name "$NAME" --amount 1 --reset-period MONTHLY \
-         --target-type COMPARTMENT --targets "[\"$TENANCY_ID\"]" --query 'data.id' --raw-output 2>/dev/null) \
-       && oci budgets alert-rule create --budget-id "$BUDGET_ID" --display-name "$NAME" --type ACTUAL --threshold 1 --threshold-type ABSOLUTE \
+  elif out=$(oci budgets budget create --compartment-id "$TENANCY_ID" --display-name "$NAME" --amount 1 --reset-period MONTHLY \
+         --target-type COMPARTMENT --targets "[\"$TENANCY_ID\"]" --query 'data.id' --raw-output 2>&1) \
+       && BUDGET_ID="$out" \
+       && out=$(oci budgets alert-rule create --budget-id "$BUDGET_ID" --display-name "$NAME" --type ACTUAL --threshold 1 --threshold-type ABSOLUTE \
          --recipients "$BUDGET_EMAIL" \
-         --message "Your Nocturne server on Oracle Cloud has been charged. Everything the installer creates is within the free tier, so check the Oracle console for what changed." >/dev/null 2>&1; then
+         --message "Your Nocturne server on Oracle Cloud has been charged. Everything the installer creates is within the free tier, so check the Oracle console for what changed." 2>&1); then
     info "$BUDGET_EMAIL will be emailed if this account is ever charged"
   else
-    info "could not create the budget alert; you can add one under Billing > Budgets in the console"
+    info "could not create the budget alert; you can add one under Billing > Budgets in the console. Oracle said:"
+    info "  $(grep -m1 '"message"' <<<"$out" || head -1 <<<"$out")"
   fi
 fi
 

--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -328,6 +328,18 @@ done
 printf '\n'
 log "Done"
 info "Open https://$BASE_DOMAIN to create your first site and passkey."
-info "SSH:  ssh -i ~/.ssh/nocturne_oci ubuntu@$PUBLIC_IP"
-info "Files on the instance: /opt/nocturne (secrets are in .env; Nocturne generated them, you do not need to know them)."
-info "Logs: sudo journalctl -u nocturne  and  cd /opt/nocturne && sudo docker compose logs"
+info "SSH:   ssh -i ~/.ssh/nocturne_oci ubuntu@$PUBLIC_IP"
+info "Files: /opt/nocturne on the instance. Database passwords are in .env; Nocturne generated them and only it needs them."
+info "Logs:  sudo journalctl -u nocturne   and   cd /opt/nocturne && sudo docker compose logs"
+
+INSTANCE_KEY=$(ssh -i "${SSH_PUBLIC_KEY_FILE%.pub}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10 \
+  "ubuntu@$PUBLIC_IP" "sudo sed -n 's/^INSTANCE_KEY=//p' /opt/nocturne/.env" 2>/dev/null || true)
+printf '\n'
+if [[ -n "$INSTANCE_KEY" ]]; then
+  info "Your instance key. It is the master credential for this installation, used for administrative"
+  info "API access and account recovery. Save it in a password manager now; it is shown again on re-runs."
+  printf '\n      %s\n' "$INSTANCE_KEY"
+else
+  info "The instance key was not readable yet. Re-run this script later to see it, or read it with:"
+  info "  ssh -i ~/.ssh/nocturne_oci ubuntu@$PUBLIC_IP sudo grep ^INSTANCE_KEY= /opt/nocturne/.env"
+fi

--- a/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
+++ b/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
@@ -18,6 +18,7 @@
                 { href: "/docs/installation", label: "Overview" },
                 { href: "/docs/installation/docker-compose", label: "Docker Compose" },
                 { href: "/docs/installation/portainer", label: "Portainer" },
+                { href: "/docs/installation/oracle-cloud", label: "Oracle Cloud" },
                 { href: "/docs/installation/byo-postgres", label: "Bring Your Own PostgreSQL" },
                 { href: "/docs/installation/reverse-proxy", label: "Bring Your Own Reverse Proxy" },
             ],

--- a/src/Web/packages/portal/src/routes/docs/installation/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/+page.svelte
@@ -110,6 +110,33 @@
     </a>
 
     <a
+      href="/docs/installation/oracle-cloud"
+      class="p-6 rounded-xl border border-border/60 bg-card/50 hover:bg-card hover:border-primary/30 transition-colors group"
+    >
+      <div class="flex items-start gap-4">
+        <div
+          class="w-12 h-12 rounded-lg bg-red-500/15 flex items-center justify-center shrink-0"
+        >
+          <Cloud class="w-7 h-7 text-red-600" />
+        </div>
+        <div class="flex-1">
+          <h3
+            class="text-lg font-semibold mb-1 group-hover:text-primary transition-colors"
+          >
+            Oracle Cloud
+          </h3>
+          <p class="text-sm text-muted-foreground">
+            One command in the browser sets up a free server, HTTPS and Nocturne.
+            No SSH or Docker knowledge needed.
+          </p>
+        </div>
+        <ArrowRight
+          class="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors mt-1"
+        />
+      </div>
+    </a>
+
+    <a
       href="/docs/installation/byo-postgres"
       class="p-6 rounded-xl border border-border/60 bg-card/50 hover:bg-card hover:border-primary/30 transition-colors group"
     >

--- a/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
@@ -119,8 +119,8 @@
     <p class="text-muted-foreground mb-8">
         Ampere A1 servers are popular and regions often run out. The script tries every
         availability domain in your region, and keeps retrying for 30 minutes. If it gives up,
-        run the same command again later. Everything it already created is reused. A smaller
-        server is easier to place:
+        run it again later. It remembers your domain, so the command no longer needs it, and
+        everything already created is reused. A smaller server is easier to place:
     </p>
     <CodeBlock code={"OCPUS=1 MEMORY_GB=6 " + runCommand} class="mb-8" />
 

--- a/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
@@ -30,10 +30,33 @@
             creates are within the Always Free allowance, so nothing is charged.
         </li>
         <li>
-            A domain name you control, and access to its DNS settings. Nocturne gives every
-            site its own subdomain, so a free dynamic-DNS hostname is not enough.
+            A domain name. Nocturne gives every site its own subdomain, so the DNS provider
+            must support wildcard records. If you do not have a domain, a free one from deSEC
+            works well; see below.
         </li>
     </ul>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">No domain yet? Get one from deSEC</h2>
+    <p class="text-muted-foreground mb-4">
+        <a href="https://desec.io" class="text-primary hover:underline">deSEC</a> is a non-profit
+        DNS provider that gives out free names under <strong>dedyn.io</strong>. With one of those,
+        the installer creates the DNS records for you and there is nothing to configure by hand.
+    </p>
+    <ol class="list-decimal list-inside space-y-2 text-muted-foreground mb-8">
+        <li>Create an account at desec.io and confirm your email address.</li>
+        <li>
+            Under <strong>Domains</strong>, add a dynDNS domain and pick a name. Your domain is
+            then <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">yourname.dedyn.io</code>.
+        </li>
+        <li>
+            Under <strong>Token management</strong>, create a token and copy it. The installer
+            asks for it and hides what you paste. You can delete the token afterwards.
+        </li>
+    </ol>
+    <p class="text-muted-foreground mb-8">
+        The same works for a domain you already own if its DNS is hosted at deSEC. If it is
+        hosted elsewhere, you add two records by hand in Step 3.
+    </p>
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Step 1: Open Cloud Shell</h2>
     <p class="text-muted-foreground mb-8">
@@ -53,8 +76,10 @@
     <CodeBlock code={runCommand} class="mb-4" />
     <p class="text-muted-foreground mb-4">
         The script creates a network, reserves a public IP address, and starts a server.
-        Early on it prints two DNS records for you to create. Do that while it continues
-        working; the server waits for them before it requests certificates.
+        Early on it asks for a deSEC token. Paste one and the DNS records are created for you;
+        press Enter instead and it prints two records for you to create by hand. Either way it
+        keeps working while the server boots and waits for the records before it requests
+        certificates.
     </p>
     <details class="mb-8">
         <summary class="text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground">What the script does</summary>
@@ -70,8 +95,9 @@
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Step 3: Add the DNS records</h2>
     <p class="text-muted-foreground mb-4">
-        At your domain provider, create two <strong>A</strong> records pointing at the IP address
-        the script printed:
+        Skip this step if you gave the installer a deSEC token. Otherwise, at your domain
+        provider, create two <strong>A</strong> records pointing at the IP address the script
+        printed:
     </p>
     <CodeBlock code={"nocturne.example.com      A   <the IP address>\n*.nocturne.example.com    A   <the IP address>"} class="mb-4" />
     <p class="text-muted-foreground mb-8">

--- a/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
@@ -140,6 +140,13 @@
             credential for this installation, used for administrative API access and account
             recovery. Save it in a password manager. Running the script again shows it again.
         </li>
+        <li>
+            Download the SSH key the script created. It lives only in your Cloud Shell home,
+            which Oracle deletes after six months without a Cloud Shell session. Use the Cloud
+            Shell menu, <strong>Download</strong>, and enter
+            <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">.ssh/nocturne_oci</code>.
+            Nocturne keeps running without it, but it is your only way onto the server.
+        </li>
         <li>Updates are automatic. Watchtower checks for new Nocturne images daily.</li>
         <li>Nocturne starts again by itself when the server reboots.</li>
         <li>

--- a/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+    import { Cloud } from "@lucide/svelte";
+    import NextSteps from "$lib/components/docs/NextSteps.svelte";
+    import SupportNocturne from "$lib/components/docs/SupportNocturne.svelte";
+    import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+    import installScript from "$lib/release/oracle-cloud/oracle-cloud-install.sh?raw";
+
+    const runCommand =
+        "BASE_DOMAIN=nocturne.example.com bash <(curl -fsSL https://github.com/nightscout/nocturne/releases/latest/download/oracle-cloud-install.sh)";
+</script>
+
+<div class="max-w-3xl">
+    <div class="flex items-center gap-4 mb-4">
+        <div class="w-12 h-12 rounded-lg bg-red-500/15 flex items-center justify-center shrink-0">
+            <Cloud class="w-7 h-7 text-red-600" />
+        </div>
+        <h1 class="text-4xl font-bold tracking-tight">Oracle Cloud</h1>
+    </div>
+    <p class="text-lg text-muted-foreground mb-8">
+        Run Nocturne on Oracle Cloud's Always Free tier. One command in the browser sets
+        up the server, the network, HTTPS and Nocturne itself. No SSH or Docker knowledge
+        needed.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">What you need</h2>
+    <ul class="list-disc list-inside space-y-2 text-muted-foreground mb-8">
+        <li>
+            An <a href="https://www.oracle.com/cloud/free/" class="text-primary hover:underline">Oracle Cloud account</a>.
+            Sign-up asks for a payment card to verify your identity. The resources this guide
+            creates are within the Always Free allowance, so nothing is charged.
+        </li>
+        <li>
+            A domain name you control, and access to its DNS settings. Nocturne gives every
+            site its own subdomain, so a free dynamic-DNS hostname is not enough.
+        </li>
+    </ul>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">Step 1: Open Cloud Shell</h2>
+    <p class="text-muted-foreground mb-8">
+        Sign in to the <a href="https://cloud.oracle.com" class="text-primary hover:underline">Oracle Cloud console</a>
+        and click the terminal icon in the top-right toolbar, labelled <strong>Developer tools</strong>,
+        then <strong>Cloud Shell</strong>. A terminal opens at the bottom of the page. It is already
+        signed in as you, so there is nothing to install or configure.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">Step 2: Run the installer</h2>
+    <p class="text-muted-foreground mb-4">
+        Paste this into Cloud Shell, replacing
+        <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">nocturne.example.com</code>
+        with your domain. Nocturne will answer on that name and every site you create gets a
+        subdomain under it, so pick something you are happy to keep.
+    </p>
+    <CodeBlock code={runCommand} class="mb-4" />
+    <p class="text-muted-foreground mb-4">
+        The script creates a network, reserves a public IP address, and starts a server.
+        Early on it prints two DNS records for you to create. Do that while it continues
+        working; the server waits for them before it requests certificates.
+    </p>
+    <details class="mb-8">
+        <summary class="text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground">What the script does</summary>
+        <ul class="list-disc list-inside space-y-1 text-sm text-muted-foreground mt-2 mb-2">
+            <li>Creates a virtual network with ports 80 and 443 open, in your home region</li>
+            <li>Reserves a public IP address so it never changes</li>
+            <li>Generates an SSH key in your Cloud Shell home if you do not have one</li>
+            <li>Starts an Ampere A1 server with 2 cores and 12 GB of memory, retrying when Oracle has no free capacity</li>
+            <li>On the server: opens the firewall, installs Docker, downloads the Nocturne release bundle, generates the database passwords and starts everything once DNS resolves</li>
+        </ul>
+        <CodeBlock code={installScript} class="mt-2" maxHeight="400px" />
+    </details>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">Step 3: Add the DNS records</h2>
+    <p class="text-muted-foreground mb-4">
+        At your domain provider, create two <strong>A</strong> records pointing at the IP address
+        the script printed:
+    </p>
+    <CodeBlock code={"nocturne.example.com      A   <the IP address>\n*.nocturne.example.com    A   <the IP address>"} class="mb-4" />
+    <p class="text-muted-foreground mb-8">
+        The second one is a wildcard. It makes every site's subdomain resolve without a record
+        each. If you use Cloudflare, leave the proxy off for both records, shown as a grey cloud.
+        Cloudflare's proxy cannot carry the certificates Nocturne issues for its own subdomains.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">Step 4: Create your first site</h2>
+    <p class="text-muted-foreground mb-8">
+        Once the script reports that Nocturne is answering, open
+        <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">https://your-domain</code>
+        in a browser. You are taken to the setup page to name your first site and register a
+        passkey, which is your phone's or computer's built-in unlock. Register a second device
+        as soon as you can, because there is no password to fall back on.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">If Oracle has no free capacity</h2>
+    <p class="text-muted-foreground mb-8">
+        Ampere A1 servers are popular and regions often run out. The script tries every
+        availability domain in your region, and keeps retrying for 30 minutes. If it gives up,
+        run the same command again later. Everything it already created is reused. A smaller
+        server is easier to place:
+    </p>
+    <CodeBlock code={"OCPUS=1 MEMORY_GB=6 " + runCommand} class="mb-8" />
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">Keeping it free</h2>
+    <p class="text-muted-foreground mb-8">
+        Oracle reclaims Always Free servers on trial accounts that look idle for a week. A
+        Nocturne server collecting readings is rarely that quiet, but to remove the risk you
+        can upgrade the account to Pay As You Go. Always Free resources stay free after the
+        upgrade, and are then exempt from reclamation. Nothing in this guide exceeds the
+        free allowance.
+    </p>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">Afterwards</h2>
+    <ul class="list-disc list-inside space-y-2 text-muted-foreground mb-8">
+        <li>Updates are automatic. Watchtower checks for new Nocturne images daily.</li>
+        <li>Nocturne starts again by itself when the server reboots.</li>
+        <li>
+            To get a shell on the server, run the SSH command the script printed. Everything
+            lives in <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">/opt/nocturne</code>.
+        </li>
+        <li>
+            Nothing backs up your data automatically. In the Oracle console, under Block
+            Storage, you can take a backup of the server's boot volume at any time. The free
+            tier includes five volume backups, so take them by hand and delete old ones rather
+            than attaching a scheduled policy.
+        </li>
+        <li>
+            To remove everything, terminate the instance in the Oracle console, then delete the
+            reserved public IP and the <strong>nocturne</strong> virtual cloud network.
+        </li>
+    </ul>
+
+    <h2 class="text-2xl font-bold mt-8 mb-4">Next Steps</h2>
+    <NextSteps />
+
+    <SupportNocturne />
+</div>

--- a/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
@@ -135,6 +135,11 @@
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Afterwards</h2>
     <ul class="list-disc list-inside space-y-2 text-muted-foreground mb-8">
+        <li>
+            The script ends by printing your <strong>instance key</strong>. It is the master
+            credential for this installation, used for administrative API access and account
+            recovery. Save it in a password manager. Running the script again shows it again.
+        </li>
         <li>Updates are automatic. Watchtower checks for new Nocturne images daily.</li>
         <li>Nocturne starts again by itself when the server reboots.</li>
         <li>

--- a/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { Cloud } from "@lucide/svelte";
+    import * as RadioGroup from "@nocturne/ui/ui/radio-group";
     import NextSteps from "$lib/components/docs/NextSteps.svelte";
     import SupportNocturne from "$lib/components/docs/SupportNocturne.svelte";
     import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
@@ -7,6 +8,8 @@
 
     const runCommand =
         "BASE_DOMAIN=nocturne.example.com bash <(curl -fsSL https://github.com/nightscout/nocturne/releases/latest/download/oracle-cloud-install.sh)";
+
+    let idlePlan = $state("payg");
 </script>
 
 <div class="max-w-3xl">
@@ -75,8 +78,8 @@
     </p>
     <CodeBlock code={runCommand} class="mb-4" />
     <p class="text-muted-foreground mb-4">
-        The script creates a network, reserves a public IP address, and starts a server.
-        Early on it asks for a deSEC token. Paste one and the DNS records are created for you;
+        The script sets up a spending alert to your Oracle account email, creates a network,
+        reserves a public IP address, and starts a server. Early on it asks for a deSEC token. Paste one and the DNS records are created for you;
         press Enter instead and it prints two records for you to create by hand. Either way it
         keeps working while the server boots and waits for the records before it requests
         certificates.
@@ -84,10 +87,12 @@
     <details class="mb-8">
         <summary class="text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground">What the script does</summary>
         <ul class="list-disc list-inside space-y-1 text-sm text-muted-foreground mt-2 mb-2">
+            <li>Sets up a spending alert that emails you if the account is ever charged</li>
             <li>Creates a virtual network with ports 80 and 443 open, in your home region</li>
             <li>Reserves a public IP address so it never changes</li>
             <li>Generates an SSH key in your Cloud Shell home if you do not have one</li>
-            <li>Starts an Ampere A1 server with 2 cores and 12 GB of memory, retrying when Oracle has no free capacity</li>
+            <li>Starts an Ampere A1 server with 1 core and 6 GB of memory, retrying when Oracle has no free capacity</li>
+            <li>Optionally installs Folding@home on a nightly schedule; see "Keeping it free" below</li>
             <li>On the server: opens the firewall, installs Docker, downloads the Nocturne release bundle, generates the database passwords and starts everything once DNS resolves</li>
         </ul>
         <CodeBlock code={installScript} class="mt-2" maxHeight="400px" />
@@ -125,13 +130,83 @@
     <CodeBlock code={"OCPUS=1 MEMORY_GB=6 " + runCommand} class="mb-8" />
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Keeping it free</h2>
-    <p class="text-muted-foreground mb-8">
-        Oracle reclaims Always Free servers on trial accounts that look idle for a week. A
-        Nocturne server collecting readings is rarely that quiet, but to remove the risk you
-        can upgrade the account to Pay As You Go. Always Free resources stay free after the
-        upgrade, and are then exempt from reclamation. Nothing in this guide exceeds the
-        free allowance.
+    <p class="text-muted-foreground mb-4">
+        Oracle switches off Always Free servers on trial accounts that it judges idle for seven
+        days in a row. Its measure is whether the processor, network and memory each stayed
+        below 20 percent of capacity for nearly all of that week. A Nocturne server for one
+        person does very little work by that yardstick, so left alone it is likely to be
+        stopped after its first quiet week. You have two ways to prevent that. Pick one before
+        you run the installer.
     </p>
+    <RadioGroup.Root bind:value={idlePlan} class="grid gap-3 mb-4">
+        <label
+            for="plan-payg"
+            class="flex items-start gap-3 rounded-xl border border-border/60 bg-card/50 p-4 cursor-pointer hover:border-primary/30"
+        >
+            <RadioGroup.Item value="payg" id="plan-payg" class="mt-1" />
+            <span>
+                <span class="font-semibold">Upgrade the account to Pay As You Go</span>
+                <span class="block text-sm text-muted-foreground">
+                    Recommended. Nothing changes about what you pay, and Oracle stops treating
+                    the server as reclaimable.
+                </span>
+            </span>
+        </label>
+        <label
+            for="plan-folding"
+            class="flex items-start gap-3 rounded-xl border border-border/60 bg-card/50 p-4 cursor-pointer hover:border-primary/30"
+        >
+            <RadioGroup.Item value="folding" id="plan-folding" class="mt-1" />
+            <span>
+                <span class="font-semibold">Stay on the trial and donate spare time to Folding@home</span>
+                <span class="block text-sm text-muted-foreground">
+                    The server does two hours of disease research each night, which keeps it
+                    clearly in use.
+                </span>
+            </span>
+        </label>
+    </RadioGroup.Root>
+
+    {#if idlePlan === "payg"}
+        <p class="text-muted-foreground mb-4">
+            In the Oracle console, open <strong>Billing &amp; Cost Management</strong>, then
+            <strong>Upgrade and Manage Payment</strong>, and choose Pay As You Go. Your card is
+            already on file from sign-up. Always Free resources stay free after the upgrade, and
+            Oracle's own terms exempt Pay As You Go accounts from idle reclamation. Everything
+            this installer creates is within the free allowance, so the upgrade does not by
+            itself cost anything.
+        </p>
+        <p class="text-muted-foreground mb-8">
+            What changes is that the card <em>can</em> now be charged if something outside the
+            free tier is ever created. To make sure that never goes unnoticed, the installer sets
+            up a spending alert that emails you the moment the account is billed one unit of your
+            currency. Upgrading also tends to end the "no free capacity" errors, since paying
+            accounts are served first when servers are scarce.
+        </p>
+    {:else}
+        <p class="text-muted-foreground mb-4">
+            <a href="https://foldingathome.org" class="text-primary hover:underline">Folding@home</a>
+            is a research project that simulates how proteins fold, to help understand diseases
+            such as Alzheimer's, cancer and, yes, diabetes. With this option the installer adds
+            its client to the server and runs it from 02:00 to 04:00 UTC each night. Two hours a
+            day of real computation is well above Oracle's idle threshold, so the server is never
+            a candidate for reclamation, and the time goes to something useful.
+        </p>
+        <p class="text-muted-foreground mb-4">
+            The client runs at the lowest priority the system has, so Nocturne and its alarms
+            always come first. It is one more piece of software with network access on a server
+            that holds your health data, which is why it is a choice rather than the default. To
+            choose it, add <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">FOLDING=1</code>
+            to the command in Step 2:
+        </p>
+        <CodeBlock code={"FOLDING=1 " + runCommand} class="mb-4" />
+        <p class="text-muted-foreground mb-8">
+            Work is contributed anonymously by default. To count it towards a team, add
+            <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">FOLDING_TEAM=&lt;number&gt;</code>
+            as well. Trial accounts cannot be charged, but the installer still creates the
+            spending alert in case the account is upgraded later.
+        </p>
+    {/if}
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Afterwards</h2>
     <ul class="list-disc list-inside space-y-2 text-muted-foreground mb-8">

--- a/src/Web/packages/portal/vite.config.ts
+++ b/src/Web/packages/portal/vite.config.ts
@@ -78,6 +78,14 @@ function releaseAssets(): Plugin {
         }
       }
 
+      const oracleInstaller = resolve(deployRoot, 'oracle-cloud/oracle-cloud-install.sh');
+      if (existsSync(oracleInstaller)) {
+        mkdirSync(resolve(dest, 'oracle-cloud'), { recursive: true });
+        cpSync(oracleInstaller, resolve(dest, 'oracle-cloud/oracle-cloud-install.sh'));
+      } else {
+        this.warn(`release-assets: oracle-cloud-install.sh not found at ${oracleInstaller}; skipping`);
+      }
+
       // Copy standalone docs assets (e.g. BYO Postgres bootstrap script)
       const docsRoot = resolve(__dirname, '../../../../docs');
       const bootstrapSql = resolve(docsRoot, 'postgres/bootstrap-roles.sql');


### PR DESCRIPTION
## Summary

Adds `deploy/oracle-cloud/oracle-cloud-install.sh`, a script run from Oracle Cloud Shell that stands up Nocturne on an Always Free Ampere A1 instance, plus a portal installation page for it.

```
BASE_DOMAIN=nocturne.example.com bash <(curl -fsSL https://github.com/nightscout/nocturne/releases/latest/download/oracle-cloud-install.sh)
```

What the script does, in the tenancy's home region:

- A $1 budget with an `ACTUAL`/`ABSOLUTE` alert rule emailing the account's address, so a later Pay As You Go upgrade can never bill silently
- VCN, internet gateway, default route and a public subnet with 22/80/443 (and 443/udp) open
- A reserved public IP, created before the instance so DNS can be handled while it boots
- DNS: prompts (hidden input) for a deSEC API token, or reads `DESEC_TOKEN`. With one, it finds the zone the account hosts that contains `BASE_DOMAIN` and PUTs the apex and wildcard A records at the domain's `minimum_ttl`. Without one, it prints the two records for the user to create. Skipped entirely when both already resolve to the reserved IP.
- An RSA SSH key in the Cloud Shell home if the user has none (Cloud Shell is FIPS-mode; Ed25519 is refused)
- `VM.Standard.A1.Flex`, 1 OCPU / 6 GB by default, retrying across availability domains on "out of host capacity" and pausing on Oracle's launch rate limit, for up to 30 minutes
- Cloud-init on the instance: opens 80/443 in Oracle's per-instance iptables rules, installs Docker, downloads the pinned release bundle, generates `INSTANCE_KEY` and the four Postgres passwords locally, waits until the apex and a wildcard probe resolve to the reserved IP, then `docker compose up -d`
- A `nocturne.service` oneshot that runs on every boot. The release bundle has no `restart:` policies, so without this the stack does not come back after a reboot.
- `FOLDING=1` (opt-in): installs the Folding@home v8 arm64 client, configured Anonymous / `FOLDING_TEAM`, and runs it 02:00-04:00 UTC via systemd timers. Oracle reclaims trial-account Always Free instances whose CPU, network and memory all sit under 20% at the 95th percentile for 7 days; a single-user Nocturne is likely to. Two hours of real work a night clears that honestly. The v8 client installs paused and only its local websocket can unpause it, so a stdlib Python script sends `{"cmd":"state","state":"fold"}` once at setup and at each nightly start.
- Ends by printing the instance key (read over SSH) and telling the user to download the SSH key, since Oracle deletes idle Cloud Shell homes after six months.

Every OCI resource is looked up by display name first, so re-running the script is safe and doubles as a status check. `BASE_DOMAIN` is remembered in `~/.nocturne-oci/config` after the first run.

Also:

- `docker-publish.yml` attaches the script to the release so the `releases/latest/download` URL works
- Portal: `/docs/installation/oracle-cloud`, with a "No domain yet? Get one from deSEC" section and a radio-button "Keeping it free" section that explains idle reclamation and lets the reader choose between the Pay As You Go upgrade and the Folding@home option; a card on the installation index; sidebar entry; and the vite `release-assets` plugin copies the script so the page can embed it

## Verification

- `bash -n` on the script and on every embedded script; the Python unpause script compiles; the cloud-init YAML parses and is 6.7 KB against OCI's 16 KB user-data cap
- Portal `pnpm run check` and `pnpm run build` pass; the page prerenders with the script inlined
- Latest-release lookup uses the `/releases/latest` redirect rather than the API, verified to return `v0.2.6`
- deSEC API shapes checked against the current docs; Folding@home config option names, default paused state, websocket path and message format, and idle core priority checked against the fah-client-bastet source; the arm64 package URL checked against the download index
- **Partially run for real** (Rhys, ap-melbourne-1): network, reserved IP and deSEC record creation succeeded; instance launch has so far hit only capacity and rate-limit errors, so the instance-side cloud-init, the Folding@home setup and the budget creation have not yet executed.

## Notes for review

- `default.env.example` is the asset name GitHub gives the uploaded `.env.example`; the boot script downloads it by that name.
- The docs page states Oracle's reclamation criteria and the five-free-volume-backups allowance from Oracle's published terms; worth a second look before publishing.
- The script does not create the deSEC domain; fresh tokens lack `perm_create_domain` and dedyn.io names are limited to one per account, so the docs have the user add it in the UI first.
- Secrets are generated on the instance rather than passed through user-data, so instance metadata holds only `BASE_DOMAIN`, the IP, the version and the folding team number.
