### PR TITLE
feat(portal): cookieless Plausible analytics for the docs and the donate links

### DIFF
--- a/.github/workflows/portal-pages.yml
+++ b/.github/workflows/portal-pages.yml
@@ -79,6 +79,9 @@ jobs:
           VITE_DEMO_ENABLED: 'true'
           VITE_DEMO_WEB_URL: 'https://demo.nocturne.run'
           VITE_SCALAR_API_URL: 'https://nocturne.run'
+          # Unset in a fork or a self-hosted build, which then ships no tracker at all.
+          # The site of this name has to exist in Plausible first; CE cannot create it.
+          VITE_PLAUSIBLE_DOMAIN: ${{ vars.PLAUSIBLE_PORTAL_DOMAIN }}
         run: pnpm run build
 
       - name: Upload artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -215,6 +215,9 @@ jobs:
           pnpm --filter @nightscout/glucose-chart                --filter @nocturne/coach                run check
       - name: Bot unit tests
         run: pnpm --filter @nocturne/bot run test
+      # The portal's `check` needs the generated client, but its vitest suites do not.
+      - name: Portal unit tests
+        run: pnpm --filter @nocturne/portal run test
       - name: Documentation screenshots
         run: |
           pnpm --filter @nocturne/screenshots run check

--- a/src/Web/packages/portal/package.json
+++ b/src/Web/packages/portal/package.json
@@ -9,7 +9,8 @@
 		"dev": "node scripts/generate-sdk-manifest.mjs && node scripts/sync-screenshots.mjs && vite dev",
 		"build": "node scripts/generate-sdk-manifest.mjs && node scripts/sync-screenshots.mjs && vite build",
 		"preview": "vite preview",
-		"check": "node scripts/generate-sdk-manifest.mjs && svelte-kit sync && svelte-check-native --tsconfig ./tsconfig.json"
+		"check": "node scripts/generate-sdk-manifest.mjs && svelte-kit sync && svelte-check-native --tsconfig ./tsconfig.json",
+		"test": "svelte-kit sync && vitest run"
 	},
 	"devDependencies": {
 		"@lucide/svelte": "^0.555.0",
@@ -35,7 +36,8 @@
 		"tailwind-variants": "^3.2.2",
 		"tailwindcss": "^4.1.7",
 		"typescript": "^5.8.3",
-		"vite": "^7.2.6"
+		"vite": "^7.2.6",
+		"vitest": "^4.1.6"
 	},
 	"dependencies": {
 		"@nocturne/app": "workspace:*",

--- a/src/Web/packages/portal/src/lib/analytics.test.ts
+++ b/src/Web/packages/portal/src/lib/analytics.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { DOCS_SECTION_IDS, allowedProps, pageviewUrl } from './analytics';
+import { DOCS_NAV_SECTIONS } from './data/docs-nav';
+
+describe('allowedProps', () => {
+  it('keeps a value the event declares', () => {
+    expect(allowedProps('Support Tier Click', { tier: 'patron' })).toEqual({ tier: 'patron' });
+  });
+
+  it('drops a value outside the declared set', () => {
+    expect(allowedProps('Support Tier Click', { tier: 'benefactor' })).toEqual({});
+  });
+
+  it('drops a key the event does not declare', () => {
+    expect(allowedProps('Donate Click', { email: 'someone@example.com' })).toEqual({});
+  });
+
+  it('drops a key inherited from Object.prototype', () => {
+    expect(allowedProps('Donate Click', { constructor: 'anything' })).toEqual({});
+  });
+
+  it('keeps the declared key and drops the rest', () => {
+    expect(allowedProps('Docs Copy', { kind: 'code', page: '/docs/installation' })).toEqual({
+      kind: 'code',
+    });
+  });
+});
+
+describe('pageviewUrl', () => {
+  it('keeps the path and drops an unlisted query parameter', () => {
+    expect(pageviewUrl(new URL('https://getnocturne.dev/docs?locale=de'))).toBe(
+      'https://getnocturne.dev/docs',
+    );
+  });
+
+  it('keeps campaign parameters', () => {
+    expect(
+      pageviewUrl(new URL('https://getnocturne.dev/?utm_source=discord&utm_medium=chat')),
+    ).toBe('https://getnocturne.dev/?utm_source=discord&utm_medium=chat');
+  });
+
+  it('drops the fragment', () => {
+    expect(pageviewUrl(new URL('https://getnocturne.dev/get-involved#donate'))).toBe(
+      'https://getnocturne.dev/get-involved',
+    );
+  });
+});
+
+describe('docs navigation', () => {
+  // `DocsNavSection.id` is typed against DOCS_SECTION_IDS, but this package's `check` script
+  // typechecks neither .ts nor .svelte, so nothing in CI enforces that binding. This does.
+  it('reports every sidebar section', () => {
+    const sidebar = DOCS_NAV_SECTIONS.map((section) => section.id).sort();
+    expect(sidebar).toEqual([...DOCS_SECTION_IDS].sort());
+  });
+
+  it('declares each section once', () => {
+    const ids = DOCS_NAV_SECTIONS.map((section) => section.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('an event name that is not in the table', () => {
+  it('reports no properties instead of throwing', () => {
+    const unknown = 'Docs Navigation' as Parameters<typeof allowedProps>[0];
+    expect(() => allowedProps(unknown, { section: 'sdks' })).not.toThrow();
+    expect(allowedProps(unknown, { section: 'sdks' })).toEqual({});
+  });
+});

--- a/src/Web/packages/portal/src/lib/analytics.ts
+++ b/src/Web/packages/portal/src/lib/analytics.ts
@@ -1,0 +1,137 @@
+/**
+ * Plausible tracking for the portal.
+ *
+ * The portal is served by GitHub Pages, which cannot reverse-proxy anything, so unlike the
+ * marketing site — which serves the tracker first-party under /stats via the YARP gateway —
+ * this has to name the analytics host absolutely. Ad blockers that match on hostname will
+ * therefore stop some of these events; there is no way around that on Pages.
+ *
+ * Tracking is off unless VITE_PLAUSIBLE_DOMAIN is set at build time, so a self-hosted or
+ * local build of the portal makes no request to anything.
+ */
+import { PLAUSIBLE_DOMAIN, PLAUSIBLE_HOST } from '$lib/config';
+
+export const PLAUSIBLE_ENABLED = PLAUSIBLE_DOMAIN !== '';
+
+// The manual variant sends no pageview of its own, so every URL Plausible sees is one
+// `pageviewUrl` built.
+export const PLAUSIBLE_SCRIPT_SRC = `${PLAUSIBLE_HOST}/js/script.manual.js`;
+export const PLAUSIBLE_EVENT_API = `${PLAUSIBLE_HOST}/api/event`;
+
+/** Sidebar sections, as reported by `Docs Nav`. `docs-nav.ts` is the source of these ids. */
+export const DOCS_SECTION_IDS = [
+  'getting-started',
+  'installation',
+  'authentication',
+  'sharing',
+  'food',
+  'alerts',
+  'bots',
+  'configuration',
+  'observability',
+  'windows-widget',
+  'connecting-apps',
+  'sdks',
+  'api-reference',
+] as const;
+
+/**
+ * Off-site destinations worth counting, never a raw href. Links inside a /get-involved lane
+ * card are excluded: they report `Get Involved Lane`, whose id already names the destination.
+ */
+export const OUTBOUND_DESTINATIONS = [
+  'github',
+  'github-labels',
+  'discord',
+  'demo',
+] as const;
+
+/**
+ * The complete set of event names and, for each, every property key with the closed set of
+ * values it may take. `track` drops anything absent from this table, so no page title, doc
+ * heading, copied command, generated password or href can leave the browser as a property.
+ *
+ * Plausible attaches the current page URL to every custom event, so none of these needs a
+ * `page` property — filter the dashboard by page instead.
+ */
+const ALLOWED_PROPS = {
+  // --- Donations -------------------------------------------------------------------
+  /** One-off giving: an outbound click to a donation destination. */
+  'Donate Click': { destination: ['foundation'] },
+  /** Recurring giving: a click through to one of the Stripe subscription tiers. */
+  'Support Tier Click': { tier: ['supporter', 'sustainer', 'patron'] },
+  /** A card on /get-involved. `donate` is an in-page jump, not an outbound click. */
+  'Get Involved Lane': {
+    lane: ['translate', 'support', 'donate', 'docs', 'peer', 'spread', 'sponsor', 'data'],
+  },
+
+  // --- Docs engagement -------------------------------------------------------------
+  /** Someone took a command or config off a docs page — the page did its job. */
+  'Docs Copy': { kind: ['code', 'password'] },
+  /** Sidebar navigation, which a pageview alone cannot attribute. */
+  'Docs Nav': { section: DOCS_SECTION_IDS },
+  /** How far down a page the reader actually got. Fires once per milestone per pageview. */
+  'Docs Scroll': { depth: ['25', '50', '75', '100'] },
+
+  // --- Everything else -------------------------------------------------------------
+  /** A click off the site. Not fired by anything that already reports its own event. */
+  'Outbound Click': { destination: OUTBOUND_DESTINATIONS },
+} as const satisfies Record<string, Record<string, readonly string[]>>;
+
+export type AnalyticsEvent = keyof typeof ALLOWED_PROPS;
+
+/**
+ * The only query parameters a reported URL may keep. Plausible discards the rest at ingest,
+ * but the URL still has to leave the browser first.
+ */
+const KEPT_QUERY_PARAMS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'ref',
+];
+
+declare global {
+  interface Window {
+    plausible?: (event: string, options?: { u?: string; props?: Record<string, string> }) => void;
+  }
+}
+
+export function allowedProps(
+  event: AnalyticsEvent,
+  props: Record<string, string> = {},
+): Record<string, string> {
+  // `?? {}` rather than a bare lookup: this package's `check` typechecks neither .svelte nor
+  // .ts, so a misspelled event name reaches here at runtime, and indexing `undefined` in the
+  // filter below would throw out of whatever click handler called it. Unknown event, no props.
+  const allowed: Record<string, readonly string[]> = ALLOWED_PROPS[event] ?? {};
+  return Object.fromEntries(
+    Object.entries(props).filter(
+      // hasOwn, not `allowed[key]?.`: a property named `constructor` would otherwise
+      // resolve to an Object.prototype member.
+      ([key, value]) => Object.hasOwn(allowed, key) && allowed[key].includes(value),
+    ),
+  );
+}
+
+export function pageviewUrl(url: URL): string {
+  const kept = new URLSearchParams();
+  for (const name of KEPT_QUERY_PARAMS) {
+    for (const value of url.searchParams.getAll(name)) kept.append(name, value);
+  }
+  const query = kept.toString();
+  return `${url.origin}${url.pathname}${query ? `?${query}` : ''}`;
+}
+
+export function track(event: AnalyticsEvent, props?: Record<string, string>): void {
+  window.plausible?.(event, {
+    u: pageviewUrl(new URL(window.location.href)),
+    props: allowedProps(event, props),
+  });
+}
+
+export function trackPageview(url: URL): void {
+  window.plausible?.('pageview', { u: pageviewUrl(url) });
+}

--- a/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
+++ b/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
@@ -1,124 +1,25 @@
 <script lang="ts">
     import { page } from "$app/state";
     import { Rocket, Download, Settings, Shield, Share2, Bell, Bot, Code2, KeyRound, Activity, LayoutGrid, Package, Utensils, ChevronRight, ChevronDown } from "@lucide/svelte";
+    import { DOCS_NAV_SECTIONS, type DocsSectionId } from "$lib/data/docs-nav";
+    import { track } from "$lib/analytics";
 
-    const navSections = [
-        {
-            title: "Getting Started",
-            icon: Rocket,
-            items: [
-                { href: "/docs", label: "Overview" },
-                { href: "/docs/getting-started", label: "Quick Start" },
-            ],
-        },
-        {
-            title: "Installation",
-            icon: Download,
-            items: [
-                { href: "/docs/installation", label: "Overview" },
-                { href: "/docs/installation/docker-compose", label: "Docker Compose" },
-                { href: "/docs/installation/portainer", label: "Portainer" },
-                { href: "/docs/installation/oracle-cloud", label: "Oracle Cloud" },
-                { href: "/docs/installation/byo-postgres", label: "Bring Your Own PostgreSQL" },
-                { href: "/docs/installation/reverse-proxy", label: "Bring Your Own Reverse Proxy" },
-            ],
-        },
-        {
-            title: "Authentication",
-            icon: Shield,
-            items: [
-                { href: "/docs/authentication", label: "Overview" },
-                { href: "/docs/authentication/passkeys", label: "Passkeys & fallbacks" },
-                { href: "/docs/authentication/request-membership", label: "Request membership" },
-                { href: "/docs/authentication/google", label: "Sign in with Google" },
-                { href: "/docs/authentication/github", label: "Sign in with GitHub" },
-                { href: "/docs/authentication/oidc", label: "Generic OIDC" },
-            ],
-        },
-        {
-            title: "Sharing & Privacy",
-            icon: Share2,
-            items: [
-                { href: "/docs/sharing", label: "Overview" },
-                { href: "/docs/sharing/public-link", label: "Public share link" },
-                { href: "/docs/sharing/members", label: "Member accounts & invites" },
-                { href: "/docs/sharing/guest-links", label: "Temporary guest links" },
-                { href: "/docs/sharing/clock", label: "Clocks" },
-            ],
-        },
-        {
-            title: "Food & Carbs",
-            icon: Utensils,
-            items: [
-                { href: "/docs/food", label: "Overview" },
-                { href: "/docs/food/carbs", label: "Carb entries" },
-                { href: "/docs/food/catalog", label: "The food catalog" },
-                { href: "/docs/food/meals", label: "Meals & attribution" },
-                { href: "/docs/food/deduplication", label: "Duplicate carbs" },
-            ],
-        },
-        {
-            title: "Alerts",
-            icon: Bell,
-            items: [
-                { href: "/docs/alerts/email", label: "Email (Resend)" },
-            ],
-        },
-        {
-            title: "Chat Bots",
-            icon: Bot,
-            items: [
-                { href: "/docs/bots", label: "Overview" },
-                { href: "/docs/bots/discord", label: "Discord" },
-                { href: "/docs/bots/slack", label: "Slack" },
-                { href: "/docs/bots/telegram", label: "Telegram" },
-                { href: "/docs/bots/whatsapp", label: "WhatsApp" },
-            ],
-        },
-        {
-            title: "Configuration",
-            icon: Settings,
-            items: [
-                { href: "/docs/configuration", label: "Configuration Guide" },
-            ],
-        },
-        {
-            title: "Observability",
-            icon: Activity,
-            items: [
-                { href: "/docs/observability", label: "OpenTelemetry" },
-            ],
-        },
-        {
-            title: "Windows Widget",
-            icon: LayoutGrid,
-            items: [
-                { href: "/docs/windows-widget", label: "Overview & setup" },
-            ],
-        },
-        {
-            title: "Connecting Apps",
-            icon: KeyRound,
-            items: [
-                { href: "/docs/connecting-apps", label: "App authorization (PKCE)" },
-                { href: "/docs/connecting-apps/device-flow", label: "Mobile & device flow" },
-            ],
-        },
-        {
-            title: "SDKs",
-            icon: Package,
-            items: [
-                { href: "/docs/sdks", label: "Official SDKs" },
-            ],
-        },
-        {
-            title: "API Reference",
-            icon: Code2,
-            items: [
-                { href: "/scalar", label: "Interactive API Docs" },
-            ],
-        },
-    ];
+    // Exhaustive by type: a new section in docs-nav.ts will not compile until it has an icon.
+    const ICONS: Record<DocsSectionId, typeof Rocket> = {
+        "getting-started": Rocket,
+        installation: Download,
+        authentication: Shield,
+        sharing: Share2,
+        food: Utensils,
+        alerts: Bell,
+        bots: Bot,
+        configuration: Settings,
+        observability: Activity,
+        "windows-widget": LayoutGrid,
+        "connecting-apps": KeyRound,
+        sdks: Package,
+        "api-reference": Code2,
+    };
 
     const isActive = (href: string) => {
         return page.url.pathname === href;
@@ -130,12 +31,13 @@
 </script>
 
 <nav class="space-y-6">
-    {#each navSections as section}
+    {#each DOCS_NAV_SECTIONS as section (section.id)}
+        {@const Icon = ICONS[section.id]}
         <div>
             <div
                 class="flex items-center gap-2 text-sm font-semibold text-foreground mb-2"
             >
-                <section.icon class="w-4 h-4" />
+                <Icon class="w-4 h-4" />
                 {section.title}
                 {#if isSectionActive(section.items)}
                     <ChevronDown class="w-3 h-3 ml-auto" />
@@ -144,10 +46,11 @@
                 {/if}
             </div>
             <ul class="space-y-1 ml-6">
-                {#each section.items as item}
+                {#each section.items as item (item.href)}
                     <li>
                         <a
                             href={item.href}
+                            onclick={() => track("Docs Nav", { section: section.id })}
                             class="flex items-center gap-2 py-1.5 text-sm transition-colors {isActive(item.href)
                                 ? 'text-primary font-medium'
                                 : 'text-muted-foreground hover:text-foreground'}"

--- a/src/Web/packages/portal/src/lib/components/SiteFooter.svelte
+++ b/src/Web/packages/portal/src/lib/components/SiteFooter.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { Github, Heart } from "@lucide/svelte";
     import LanguageSelector from "./LanguageSelector.svelte";
+    import { track } from "$lib/analytics";
 </script>
 
 <footer class="border-t border-border/40 bg-muted/30">
@@ -113,6 +114,7 @@
                             href="https://discord.gg/sKEhtHeb2z"
                             target="_blank"
                             rel="noopener noreferrer"
+                            onclick={() => track("Outbound Click", { destination: "discord" })}
                             class="text-sm text-muted-foreground hover:text-foreground transition-colors"
                         >
                             Discord
@@ -123,6 +125,7 @@
                             href="https://github.com/nightscout/nocturne"
                             target="_blank"
                             rel="noopener noreferrer"
+                            onclick={() => track("Outbound Click", { destination: "github" })}
                             class="text-sm text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1.5"
                         >
                             <Github class="w-4 h-4" />

--- a/src/Web/packages/portal/src/lib/components/docs/CopyButton.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/CopyButton.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
     import { Copy, Check, X } from "@lucide/svelte";
     import { copyToClipboard } from "@nocturne/ui/utils";
+    import { track } from "$lib/analytics";
 
     interface Props {
         text: string;
         label?: string;
+        /** What was copied. Only the kind is reported, never the text itself. */
+        kind?: "code" | "password";
     }
 
-    let { text, label = "Copy to clipboard" }: Props = $props();
+    let { text, label = "Copy to clipboard", kind = "code" }: Props = $props();
 
     let copied = $state(false);
     let failed = $state(false);
@@ -20,6 +23,7 @@
         }
         failed = false;
         copied = true;
+        track("Docs Copy", { kind });
         if (timer !== undefined) clearTimeout(timer);
         timer = setTimeout(() => {
             copied = false;

--- a/src/Web/packages/portal/src/lib/components/docs/DocsScrollDepth.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/DocsScrollDepth.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { afterNavigate } from "$app/navigation";
+    import { track } from "$lib/analytics";
+
+    const MILESTONES = [25, 50, 75, 100] as const;
+
+    // A page whose content is still arriving (fonts, images, the mdsvex body) is shorter than
+    // it will be, and measuring it then would report depths the reader never reached. Nothing
+    // is measured until the layout has had this long to settle.
+    const SETTLE_MS = 1000;
+
+    let reached = new Set<number>();
+    let settled = false;
+    let settleTimer: ReturnType<typeof setTimeout> | undefined;
+
+    function report() {
+        if (!settled) return;
+
+        const doc = document.documentElement;
+        const scrollable = doc.scrollHeight - window.innerHeight;
+        // A page shorter than the viewport is entirely on screen, so it is read to the end.
+        const percent =
+            scrollable <= 0 ? 100 : Math.min(100, (window.scrollY / scrollable) * 100);
+
+        for (const milestone of MILESTONES) {
+            if (percent >= milestone && !reached.has(milestone)) {
+                reached.add(milestone);
+                track("Docs Scroll", { depth: String(milestone) });
+            }
+        }
+    }
+
+    function restart() {
+        reached = new Set();
+        settled = false;
+        clearTimeout(settleTimer);
+        settleTimer = setTimeout(() => {
+            settled = true;
+            report();
+        }, SETTLE_MS);
+    }
+
+    onMount(() => {
+        let queued = false;
+        const onScroll = () => {
+            if (queued) return;
+            queued = true;
+            requestAnimationFrame(() => {
+                queued = false;
+                report();
+            });
+        };
+
+        window.addEventListener("scroll", onScroll, { passive: true });
+        window.addEventListener("resize", onScroll, { passive: true });
+        return () => {
+            clearTimeout(settleTimer);
+            window.removeEventListener("scroll", onScroll);
+            window.removeEventListener("resize", onScroll);
+        };
+    });
+
+    // Each docs page is its own set of milestones. The layout survives navigation between
+    // sibling pages, so the tally has to be cleared here rather than on mount.
+    afterNavigate(restart);
+</script>

--- a/src/Web/packages/portal/src/lib/components/docs/PasswordGenerator.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/PasswordGenerator.svelte
@@ -69,7 +69,7 @@
                 <RefreshCw class="h-4 w-4" />
             </button>
 
-            <CopyButton text={password} label="Copy {label} to clipboard" />
+            <CopyButton text={password} kind="password" label="Copy {label} to clipboard" />
         </div>
     </div>
 

--- a/src/Web/packages/portal/src/lib/components/docs/SupportNocturne.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/SupportNocturne.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { Heart, ArrowUpRight } from "@lucide/svelte";
     import { LINKS } from "$lib/data/links";
+    import { track } from "$lib/analytics";
 
     // Matches the portal accent used on the get-involved page. Not the
     // --glucose-in-range token, which theme packs swap to green.
@@ -10,6 +11,7 @@
 
     const TIERS = [
         {
+            tier: "supporter",
             amount: "US$10",
             name: "Supporter",
             desc: "Covers the hosting behind the docs, the container registry, and the release pipeline.",
@@ -17,6 +19,7 @@
             featured: false,
         },
         {
+            tier: "sustainer",
             amount: "US$20",
             name: "Sustainer",
             desc: "Adds test hardware: pumps, CGM transmitters, and phones the connectors are verified against.",
@@ -24,6 +27,7 @@
             featured: true,
         },
         {
+            tier: "patron",
             amount: "US$50",
             name: "Patron",
             desc: "Funds sustained maintainer time on connectors, security updates, and support.",
@@ -50,6 +54,7 @@
                 href={tier.href}
                 target="_blank"
                 rel="noopener noreferrer"
+                onclick={() => track("Support Tier Click", { tier: tier.tier })}
                 class="group flex flex-col p-5 rounded-xl border transition-colors {tier.featured
                     ? 'sn-featured'
                     : 'border-border/60 bg-card/50 hover:bg-card'}"
@@ -90,6 +95,7 @@
             href={LINKS.donate}
             target="_blank"
             rel="noopener noreferrer"
+            onclick={() => track("Donate Click", { destination: "foundation" })}
             class="font-semibold hover:underline"
             style="color: {ACCENT}">Nightscout Foundation</a
         >.

--- a/src/Web/packages/portal/src/lib/config.ts
+++ b/src/Web/packages/portal/src/lib/config.ts
@@ -4,3 +4,10 @@ export const DEMO_WEB_URL = import.meta.env.VITE_DEMO_WEB_URL || "";
 // Base URL of the hosted Nocturne API that serves the OpenAPI specs consumed by
 // the embedded Scalar reference at /scalar. Defaults to the production deployment.
 export const SCALAR_API_URL = import.meta.env.VITE_SCALAR_API_URL || "https://nocturne.run";
+
+// Plausible analytics. Empty domain disables tracking entirely — the layout then injects no
+// script tag and the browser makes no request — so only the deploy workflow turns it on.
+// The host is absolute because GitHub Pages cannot proxy it first-party (see analytics.ts).
+export const PLAUSIBLE_DOMAIN = import.meta.env.VITE_PLAUSIBLE_DOMAIN || "";
+export const PLAUSIBLE_HOST =
+  import.meta.env.VITE_PLAUSIBLE_HOST || "https://stats.nocturne.run";

--- a/src/Web/packages/portal/src/lib/data/docs-nav.ts
+++ b/src/Web/packages/portal/src/lib/data/docs-nav.ts
@@ -1,0 +1,122 @@
+import type { DOCS_SECTION_IDS } from "$lib/analytics";
+
+export type DocsSectionId = (typeof DOCS_SECTION_IDS)[number];
+
+export type DocsNavItem = { href: string; label: string };
+
+export type DocsNavSection = {
+    /** Stable id reported as the `section` property of a `Docs Nav` event. */
+    id: DocsSectionId;
+    title: string;
+    items: DocsNavItem[];
+};
+
+/**
+ * The docs sidebar, as data. Icons live in DocsSidebar.svelte rather than here so that this
+ * module stays free of Svelte imports and can be unit-tested under plain node.
+ */
+export const DOCS_NAV_SECTIONS: DocsNavSection[] = [
+    {
+        id: "getting-started",
+        title: "Getting Started",
+        items: [
+            { href: "/docs", label: "Overview" },
+            { href: "/docs/getting-started", label: "Quick Start" },
+        ],
+    },
+    {
+        id: "installation",
+        title: "Installation",
+        items: [
+            { href: "/docs/installation", label: "Overview" },
+            { href: "/docs/installation/docker-compose", label: "Docker Compose" },
+            { href: "/docs/installation/portainer", label: "Portainer" },
+            { href: "/docs/installation/oracle-cloud", label: "Oracle Cloud" },
+            { href: "/docs/installation/byo-postgres", label: "Bring Your Own PostgreSQL" },
+            { href: "/docs/installation/reverse-proxy", label: "Bring Your Own Reverse Proxy" },
+        ],
+    },
+    {
+        id: "authentication",
+        title: "Authentication",
+        items: [
+            { href: "/docs/authentication", label: "Overview" },
+            { href: "/docs/authentication/passkeys", label: "Passkeys & fallbacks" },
+            { href: "/docs/authentication/request-membership", label: "Request membership" },
+            { href: "/docs/authentication/google", label: "Sign in with Google" },
+            { href: "/docs/authentication/github", label: "Sign in with GitHub" },
+            { href: "/docs/authentication/oidc", label: "Generic OIDC" },
+        ],
+    },
+    {
+        id: "sharing",
+        title: "Sharing & Privacy",
+        items: [
+            { href: "/docs/sharing", label: "Overview" },
+            { href: "/docs/sharing/public-link", label: "Public share link" },
+            { href: "/docs/sharing/members", label: "Member accounts & invites" },
+            { href: "/docs/sharing/guest-links", label: "Temporary guest links" },
+            { href: "/docs/sharing/clock", label: "Clocks" },
+        ],
+    },
+    {
+        id: "food",
+        title: "Food & Carbs",
+        items: [
+            { href: "/docs/food", label: "Overview" },
+            { href: "/docs/food/carbs", label: "Carb entries" },
+            { href: "/docs/food/catalog", label: "The food catalog" },
+            { href: "/docs/food/meals", label: "Meals & attribution" },
+            { href: "/docs/food/deduplication", label: "Duplicate carbs" },
+        ],
+    },
+    {
+        id: "alerts",
+        title: "Alerts",
+        items: [{ href: "/docs/alerts/email", label: "Email (Resend)" }],
+    },
+    {
+        id: "bots",
+        title: "Chat Bots",
+        items: [
+            { href: "/docs/bots", label: "Overview" },
+            { href: "/docs/bots/discord", label: "Discord" },
+            { href: "/docs/bots/slack", label: "Slack" },
+            { href: "/docs/bots/telegram", label: "Telegram" },
+            { href: "/docs/bots/whatsapp", label: "WhatsApp" },
+        ],
+    },
+    {
+        id: "configuration",
+        title: "Configuration",
+        items: [{ href: "/docs/configuration", label: "Configuration Guide" }],
+    },
+    {
+        id: "observability",
+        title: "Observability",
+        items: [{ href: "/docs/observability", label: "OpenTelemetry" }],
+    },
+    {
+        id: "windows-widget",
+        title: "Windows Widget",
+        items: [{ href: "/docs/windows-widget", label: "Overview & setup" }],
+    },
+    {
+        id: "connecting-apps",
+        title: "Connecting Apps",
+        items: [
+            { href: "/docs/connecting-apps", label: "App authorization (PKCE)" },
+            { href: "/docs/connecting-apps/device-flow", label: "Mobile & device flow" },
+        ],
+    },
+    {
+        id: "sdks",
+        title: "SDKs",
+        items: [{ href: "/docs/sdks", label: "Official SDKs" }],
+    },
+    {
+        id: "api-reference",
+        title: "API Reference",
+        items: [{ href: "/scalar", label: "Interactive API Docs" }],
+    },
+];

--- a/src/Web/packages/portal/src/routes/+layout.svelte
+++ b/src/Web/packages/portal/src/routes/+layout.svelte
@@ -2,9 +2,41 @@
     import "../app.css";
     import SiteHeader from "$lib/components/SiteHeader.svelte";
     import SiteFooter from "$lib/components/SiteFooter.svelte";
+    import { afterNavigate } from "$app/navigation";
+    import { PLAUSIBLE_DOMAIN } from "$lib/config";
+    import {
+        PLAUSIBLE_ENABLED,
+        PLAUSIBLE_EVENT_API,
+        PLAUSIBLE_SCRIPT_SRC,
+        trackPageview,
+    } from "$lib/analytics";
 
     let { children } = $props();
+
+    // Fires after the initial load as well, so the manual tracker needs no mount hook.
+    afterNavigate(({ to }) => {
+        if (to) trackPageview(to.url);
+    });
 </script>
+
+<svelte:head>
+    {#if PLAUSIBLE_ENABLED}
+        <!-- Queues calls made before the deferred script runs; it drains the queue on load. -->
+        <script>
+            window.plausible =
+                window.plausible ||
+                function () {
+                    (window.plausible.q = window.plausible.q || []).push(arguments);
+                };
+        </script>
+        <script
+            defer
+            data-domain={PLAUSIBLE_DOMAIN}
+            data-api={PLAUSIBLE_EVENT_API}
+            src={PLAUSIBLE_SCRIPT_SRC}
+        ></script>
+    {/if}
+</svelte:head>
 
 <div
     class="min-h-screen flex flex-col bg-linear-to-br from-background via-background to-primary/5"

--- a/src/Web/packages/portal/src/routes/demo/+page.svelte
+++ b/src/Web/packages/portal/src/routes/demo/+page.svelte
@@ -2,6 +2,7 @@
     import { Button } from "@nocturne/ui/ui/button";
     import { ExternalLink } from "@lucide/svelte";
     import { DEMO_ENABLED, DEMO_WEB_URL } from "$lib/config";
+    import { track } from "$lib/analytics";
 </script>
 
 <svelte:head>
@@ -27,6 +28,7 @@
                 href={DEMO_WEB_URL}
                 target="_blank"
                 rel="noopener noreferrer"
+                onclick={() => track("Outbound Click", { destination: "demo" })}
                 size="lg"
                 class="gap-2 text-base"
             >

--- a/src/Web/packages/portal/src/routes/docs/+layout.svelte
+++ b/src/Web/packages/portal/src/routes/docs/+layout.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
     import DocsSidebar from "$lib/components/DocsSidebar.svelte";
+    import DocsScrollDepth from "$lib/components/docs/DocsScrollDepth.svelte";
     import { Button } from "@nocturne/ui/ui/button";
     import { Menu, X } from "@lucide/svelte";
 
     let { children } = $props();
     let sidebarOpen = $state(false);
 </script>
+
+<DocsScrollDepth />
 
 <div class="container mx-auto px-4 py-8">
     <div class="flex gap-8">

--- a/src/Web/packages/portal/src/routes/get-involved/+page.svelte
+++ b/src/Web/packages/portal/src/routes/get-involved/+page.svelte
@@ -16,6 +16,7 @@
   } from "@lucide/svelte";
   import { onMount } from "svelte";
   import { LINKS } from "$lib/data/links";
+  import { track } from "$lib/analytics";
   import SupportNocturne from "$lib/components/docs/SupportNocturne.svelte";
 
   const ACCENT = "oklch(0.6 0.118 184.704)";
@@ -23,11 +24,12 @@
   const STATS = [
     { value: "100%", label: "Built by volunteers" },
     { value: "22+", label: "Devices & apps connected" },
-    { value: "0", label: "Ads, trackers, or paywalls" },
+    { value: "0", label: "Ads, cookies, or paywalls" },
     { value: "24/7", label: "Community support" },
   ];
 
   type Lane = {
+    /** Also the `lane` property of a `Get Involved Lane` event; see ALLOWED_PROPS. */
     id: string;
     icon: typeof Globe;
     accent: string;
@@ -269,6 +271,7 @@
           href={LINKS.discord}
           target="_blank"
           rel="noopener noreferrer"
+          onclick={() => track("Outbound Click", { destination: "discord" })}
           class="inline-flex items-center justify-center gap-2 rounded-lg font-medium text-[15px] h-[46px] px-6 whitespace-nowrap no-underline cursor-pointer transition-all duration-150 bg-transparent border border-border text-foreground hover:bg-accent"
         >
           <MessageCircle class="w-4 h-4" /> Join the Discord
@@ -310,6 +313,7 @@
           href={lane.href}
           target={opensNewTab(lane) ? "_blank" : undefined}
           rel={opensNewTab(lane) ? "noopener noreferrer" : undefined}
+          onclick={() => track("Get Involved Lane", { lane: lane.id })}
           class="gi-lane-card flex flex-row items-start gap-4 bg-card border border-border rounded-xl p-5 transition-[border-color,transform] duration-200 no-underline text-inherit"
           class:gi-lane-highlight={lane.highlight}
           style="--lane-accent: {lane.accent}"
@@ -362,6 +366,7 @@
         href={LINKS.githubLabel}
         target="_blank"
         rel="noopener noreferrer"
+        onclick={() => track("Outbound Click", { destination: "github-labels" })}
         class="inline-flex items-center justify-center gap-2 rounded-lg font-medium text-sm h-[38px] px-4 whitespace-nowrap no-underline cursor-pointer transition-all duration-150 bg-transparent border border-border text-foreground hover:bg-accent"
       >
         Open the tracker <ExternalLink class="w-3.5 h-3.5" />
@@ -407,6 +412,7 @@
             href={LINKS.githubLabel}
             target="_blank"
             rel="noopener noreferrer"
+            onclick={() => track("Outbound Click", { destination: "github-labels" })}
             class="font-semibold underline"
             style="color: {ACCENT}">View them on GitHub</a
           >.
@@ -419,6 +425,7 @@
             href={LINKS.discord}
             target="_blank"
             rel="noopener noreferrer"
+            onclick={() => track("Outbound Click", { destination: "discord" })}
             class="font-semibold underline"
             style="color: {ACCENT}">ask in the Discord</a
           >.
@@ -429,6 +436,7 @@
             href={issue.url}
             target="_blank"
             rel="noopener noreferrer"
+            onclick={() => track("Outbound Click", { destination: "github" })}
             class="gi-issue-row flex items-center gap-3.5 px-[18px] py-[13px] border-b border-border transition-[background] duration-150 cursor-pointer no-underline text-inherit hover:bg-[color-mix(in_oklch,var(--card),transparent_20%)] last:border-b-0"
           >
             <div class="gi-issue-dot shrink-0 w-3.5 h-3.5 rounded-full relative mt-[3px]" style="border: 2px solid {ACCENT}">
@@ -469,6 +477,7 @@
           href={LINKS.githubLabel}
           target="_blank"
           rel="noopener noreferrer"
+          onclick={() => track("Outbound Click", { destination: "github-labels" })}
           class="inline-flex items-center justify-center gap-2 rounded-lg font-medium text-sm h-[38px] px-4 whitespace-nowrap no-underline cursor-pointer transition-all duration-150 bg-transparent border border-border text-foreground hover:bg-accent"
         >
           View all on GitHub <ExternalLink class="w-3.5 h-3.5" />
@@ -504,6 +513,7 @@
           href={LINKS.donate}
           target="_blank"
           rel="noopener noreferrer"
+          onclick={() => track("Donate Click", { destination: "foundation" })}
           class="inline-flex items-center justify-center gap-2 rounded-lg font-medium text-[15px] h-[46px] px-6 whitespace-nowrap no-underline cursor-pointer transition-all duration-150 text-white hover:brightness-108"
           style="background: {ACCENT}"
         >

--- a/src/Web/packages/portal/vitest.config.ts
+++ b/src/Web/packages/portal/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+// Deliberately not the SvelteKit plugin: these suites cover plain modules, so they run without
+// the generated API client, which this package's `check` needs and CI does not produce for it.
+// `svelte-kit sync` still has to run first — the package tsconfig extends the one it writes.
+export default defineConfig({
+  resolve: {
+    alias: {
+      $lib: resolve(import.meta.dirname, 'src/lib'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -698,6 +698,9 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/browser-playwright@4.1.6)(happy-dom@20.9.0)(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0))
 
   packages/screenshots:
     devDependencies:


### PR DESCRIPTION
The portal had no analytics, so which docs pages get read, whether a page was useful enough for someone to take a command off it, and how many readers reach the donation tiers were all invisible.

## What is reported

Pageviews, plus the things a pageview cannot see:

| Event | Properties | Answers |
|---|---|---|
| `Support Tier Click` | `tier` = supporter / sustainer / patron | which subscription tier people pick |
| `Donate Click` | `destination` = foundation | one-off giving |
| `Get Involved Lane` | `lane` (8 ids) | which contribution path appeals |
| `Docs Copy` | `kind` = code / password | a page was good enough to take a command off |
| `Docs Nav` | `section` (13 ids) | sidebar navigation, which pageviews cannot attribute |
| `Docs Scroll` | `depth` = 25 / 50 / 75 / 100 | where long install guides lose people |
| `Outbound Click` | `destination` = github / github-labels / discord / demo | clicks off the site |

Plausible attaches the page URL to every custom event, so none of them carries a page property — filter by page in the dashboard instead.

## Privacy

Every property is checked against a closed enumeration at runtime, and reported URLs keep only the campaign parameters, so no page title, doc heading, copied command, generated password or href leaves the browser. Plausible CE sets no cookies.

Tracking is **off unless `VITE_PLAUSIBLE_DOMAIN` is set at build time**. With it unset the layout injects no script tag and the built site contains no reference to the analytics host at all — verified by building both ways — so forks and self-hosted portals ship nothing.

The get-involved page claimed "0 Ads, trackers, or paywalls", which this would have made false. It reads "0 Ads, cookies, or paywalls" now.

## Why the host is absolute

The portal deploys to GitHub Pages, which cannot reverse-proxy. The marketing site serves its tracker first-party under `/stats` via the gateway; that is not available here, so this names `stats.nocturne.run` directly and a hostname-matching blocker will stop some events.

## Notes for review

The docs sidebar moves to `src/lib/data/docs-nav.ts` as plain data — icons stay in the component, keyed by section id so a new section will not compile without one. All 37 nav items and 13 section titles are byte-identical to before.

Two things the tooling forced:

- `allowedProps` treats an unknown event as "no properties" rather than indexing `undefined`. This package's `check` runs `svelte-check-native`, which reports `53 FILES 0 ERRORS` while being blind to both `.ts` and `.svelte` — a wrong return type and a bogus event name both pass it, though real `tsc` catches both. A misspelled event name therefore reaches runtime, and would otherwise throw out of a click handler. **This looks wider than this PR and probably deserves its own issue.**
- The new vitest suite runs in the `web-typecheck` job rather than under the portal's own `check`, which needs the generated API client; a pure-node suite does not.

Tests are mutation-checked: a drifted sidebar id, a widened tier set, and an unlisted query parameter becoming kept are each caught.
