### PR TITLE
docs(portal): reorder the Oracle guide and ground the system requirements

### DIFF
--- a/deploy/oracle-cloud/oracle-cloud-install.sh
+++ b/deploy/oracle-cloud/oracle-cloud-install.sh
@@ -442,7 +442,7 @@ CLOUD_INIT_EOF
       fi
     done
     [[ -n "$INSTANCE_ID" ]] && break
-    (( SECONDS < deadline )) || die "no Ampere A1 capacity in any availability domain after $CAPACITY_RETRY_MINUTES minutes. This is common on the free tier: re-run later (everything created so far is reused), or try a smaller size with OCPUS=1 MEMORY_GB=6."
+    (( SECONDS < deadline )) || die "no Ampere A1 capacity in any availability domain after $CAPACITY_RETRY_MINUTES minutes. This is common on the free tier: re-run later (everything created so far is reused), or keep trying for longer with CAPACITY_RETRY_MINUTES=180."
     info "retrying in 60 seconds"
     sleep 60
   done

--- a/src/Web/packages/portal/src/content/docs/getting-started.svx
+++ b/src/Web/packages/portal/src/content/docs/getting-started.svx
@@ -15,7 +15,7 @@ Get Nocturne up and running in just a few minutes.
 Before you begin, make sure you have:
 
 - Docker and Docker Compose installed
-- A server or VPS with at least 1 GB RAM
+- A server or VPS with at least 2 GB RAM and 10 GB of free storage
 - A domain name with a DNS record pointing at the server
 
 ## Step 1: Deploy

--- a/src/Web/packages/portal/src/lib/components/docs/SystemRequirements.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/SystemRequirements.svelte
@@ -1,4 +1,4 @@
-<div class="overflow-x-auto mb-8">
+<div class="overflow-x-auto mb-4">
     <table class="w-full text-sm">
         <thead>
             <tr class="border-b border-border">
@@ -10,8 +10,13 @@
         <tbody class="text-muted-foreground">
             <tr class="border-b border-border/50">
                 <td class="py-2 pr-4">RAM</td>
-                <td class="py-2 pr-4">1 GB</td>
-                <td class="py-2">2 GB+</td>
+                <td class="py-2 pr-4">2 GB</td>
+                <td class="py-2">4 GB+</td>
+            </tr>
+            <tr class="border-b border-border/50">
+                <td class="py-2 pr-4">CPU</td>
+                <td class="py-2 pr-4">1 core</td>
+                <td class="py-2">2 cores+</td>
             </tr>
             <tr class="border-b border-border/50">
                 <td class="py-2 pr-4">Storage</td>
@@ -31,3 +36,32 @@
         </tbody>
     </table>
 </div>
+<details class="mb-8">
+    <summary class="text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground">Where these numbers come from</summary>
+    <div class="text-sm text-muted-foreground mt-2 space-y-2">
+        <p>
+            Measured on a production deployment serving 76 sites, then scaled down to a
+            single-site install. The stack is six containers: PostgreSQL, the API, the web
+            frontend, the gateway, the TLS proxy and the updater.
+        </p>
+        <p>
+            <strong>Memory.</strong> Those six use roughly 1 to 1.5 GB between them at rest,
+            most of it PostgreSQL and the API. 2 GB leaves little spare once the operating
+            system is accounted for, which is why it is the floor rather than a comfortable
+            target; the extra memory at 4 GB is used by PostgreSQL as disk cache and is the
+            single cheapest thing you can give it.
+        </p>
+        <p>
+            <strong>CPU.</strong> The API is the only component that does sustained work. One
+            core is enough for a single site, and the whole 76-site deployment above draws
+            about 1.3 cores in total, so headroom here matters less than it looks.
+        </p>
+        <p>
+            <strong>Storage.</strong> The container images account for about 2.5 GB before any
+            data. A single CGM writes roughly 105,000 glucose readings a year, which with
+            indexes and write-ahead logs comes to well under 1 GB per year. 10 GB fits the
+            images and several years of one person's data; 20 GB is for households, longer
+            history, or an imported Nightscout database.
+        </p>
+    </div>
+</details>

--- a/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/oracle-cloud/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Cloud } from "@lucide/svelte";
-    import * as RadioGroup from "@nocturne/ui/ui/radio-group";
+    import Callout from "@nocturne/cms/components/Callout.svelte";
     import NextSteps from "$lib/components/docs/NextSteps.svelte";
     import SupportNocturne from "$lib/components/docs/SupportNocturne.svelte";
     import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
@@ -8,8 +8,6 @@
 
     const runCommand =
         "BASE_DOMAIN=nocturne.example.com bash <(curl -fsSL https://github.com/nightscout/nocturne/releases/latest/download/oracle-cloud-install.sh)";
-
-    let idlePlan = $state("payg");
 </script>
 
 <div class="max-w-3xl">
@@ -37,6 +35,10 @@
             must support wildcard records. If you do not have a domain, a free one from deSEC
             works well; see below.
         </li>
+        <li>
+            A decision about how to keep the server from being reclaimed as idle. It changes
+            the command you run, so make it before you start.
+        </li>
     </ul>
 
     <h2 class="text-2xl font-bold mt-8 mb-4">No domain yet? Get one from deSEC</h2>
@@ -61,6 +63,70 @@
         hosted elsewhere, you add two records by hand in Step 3.
     </p>
 
+    <h2 class="text-2xl font-bold mt-8 mb-4">Before you start: keeping it free</h2>
+    <p class="text-muted-foreground mb-4">
+        Oracle switches off Always Free servers on trial accounts that it judges idle for seven
+        days in a row. Its measure is whether the processor, network and memory each stayed
+        below 20 percent of capacity for nearly all of that week. A Nocturne server for one
+        person does very little work by that yardstick, so left alone it is likely to be
+        stopped after its first quiet week. There are two ways to prevent that, and one of them
+        changes the command in Step 2, so pick now rather than later.
+    </p>
+    <Callout type="tip" title="Which one should you pick?">
+        Pay As You Go suits most people: it is a single change in the Oracle console, adds
+        nothing to the server, and paying accounts are served first when Ampere capacity is
+        scarce. The trade-off is that the card already on file <em>can</em> be charged if
+        anything outside the free allowance is ever created. Choose Folding@home instead if you
+        would rather the account stay a trial that cannot be billed at all, and you do not mind
+        a second piece of software with network access on the server that holds your health
+        data.
+    </Callout>
+    <details class="mb-3">
+        <summary class="text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground">
+            Option 1: upgrade the account to Pay As You Go (recommended)
+        </summary>
+        <p class="text-sm text-muted-foreground mt-2 mb-2">
+            In the Oracle console, open <strong>Billing &amp; Cost Management</strong>, then
+            <strong>Upgrade and Manage Payment</strong>, and choose Pay As You Go. Your card is
+            already on file from sign-up. Always Free resources stay free after the upgrade, and
+            Oracle's own terms exempt Pay As You Go accounts from idle reclamation. Everything
+            this installer creates is within the free allowance, so the upgrade does not by
+            itself cost anything.
+        </p>
+        <p class="text-sm text-muted-foreground mb-2">
+            What changes is that the card can now be charged if something outside the free tier
+            is ever created. To make sure that never goes unnoticed, the installer sets up a
+            spending alert that emails you the moment the account is billed one unit of your
+            currency. Nothing needs adding to the command in Step 2.
+        </p>
+    </details>
+    <details class="mb-8">
+        <summary class="text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground">
+            Option 2: stay on the trial and donate spare time to Folding@home
+        </summary>
+        <p class="text-sm text-muted-foreground mt-2 mb-2">
+            <a href="https://foldingathome.org" class="text-primary hover:underline">Folding@home</a>
+            is a research project that simulates how proteins fold, to help understand diseases
+            such as Alzheimer's, cancer and, yes, diabetes. With this option the installer adds
+            its client to the server and runs it from 02:00 to 04:00 UTC each night. Two hours a
+            day of real computation is well above Oracle's idle threshold, so the server is never
+            a candidate for reclamation, and the time goes to something useful.
+        </p>
+        <p class="text-sm text-muted-foreground mb-2">
+            The client runs at the lowest priority the system has, so Nocturne and its alarms
+            always come first. To choose this option, add
+            <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">FOLDING=1</code>
+            to the command in Step 2:
+        </p>
+        <CodeBlock code={"FOLDING=1 " + runCommand} class="mb-2" />
+        <p class="text-sm text-muted-foreground mb-2">
+            Work is contributed anonymously by default. To count it towards a team, add
+            <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">FOLDING_TEAM=&lt;number&gt;</code>
+            as well. Trial accounts cannot be charged, but the installer still creates the
+            spending alert in case the account is upgraded later.
+        </p>
+    </details>
+
     <h2 class="text-2xl font-bold mt-8 mb-4">Step 1: Open Cloud Shell</h2>
     <p class="text-muted-foreground mb-8">
         Sign in to the <a href="https://cloud.oracle.com" class="text-primary hover:underline">Oracle Cloud console</a>
@@ -74,17 +140,18 @@
         Paste this into Cloud Shell, replacing
         <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">nocturne.example.com</code>
         with your domain. Nocturne will answer on that name and every site you create gets a
-        subdomain under it, so pick something you are happy to keep.
+        subdomain under it, so pick something you are happy to keep. If you chose Folding@home
+        above, add <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">FOLDING=1</code> in
+        front.
     </p>
     <CodeBlock code={runCommand} class="mb-4" />
     <p class="text-muted-foreground mb-4">
-        The script sets up a spending alert to your Oracle account email, creates a network,
-        reserves a public IP address, and starts a server. Early on it asks for a deSEC token. Paste one and the DNS records are created for you;
+        Early on it asks for a deSEC token. Paste one and the DNS records are created for you;
         press Enter instead and it prints two records for you to create by hand. Either way it
-        keeps working while the server boots and waits for the records before it requests
+        keeps working while the server boots, and waits for the records before it requests
         certificates.
     </p>
-    <details class="mb-8">
+    <details class="mb-4">
         <summary class="text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground">What the script does</summary>
         <ul class="list-disc list-inside space-y-1 text-sm text-muted-foreground mt-2 mb-2">
             <li>Sets up a spending alert that emails you if the account is ever charged</li>
@@ -92,11 +159,24 @@
             <li>Reserves a public IP address so it never changes</li>
             <li>Generates an SSH key in your Cloud Shell home if you do not have one</li>
             <li>Starts an Ampere A1 server with 1 core and 6 GB of memory, retrying when Oracle has no free capacity</li>
-            <li>Optionally installs Folding@home on a nightly schedule; see "Keeping it free" below</li>
+            <li>Installs Folding@home on a nightly schedule if you asked for it above</li>
             <li>On the server: opens the firewall, installs Docker, downloads the Nocturne release bundle, generates the database passwords and starts everything once DNS resolves</li>
         </ul>
         <CodeBlock code={installScript} class="mt-2" maxHeight="400px" />
     </details>
+    <Callout type="warning" title="If Oracle has no free capacity">
+        <p class="mb-2">
+            Ampere A1 servers are popular and regions often run out. The installer tries every
+            availability domain in your region and keeps retrying for 30 minutes. It already
+            asks for the smallest size the installer offers, 1 core and 6 GB, so there is
+            nothing smaller to fall back to. If it gives up, run the command again
+            later: it remembers your domain, so the command no longer needs it, and everything
+            already created is reused. Upgrading to Pay As You Go also tends to end these
+            errors, since paying accounts are served first when servers are scarce.
+        </p>
+        <p class="mb-2">To have it keep trying for longer instead of re-running by hand:</p>
+        <CodeBlock code={"CAPACITY_RETRY_MINUTES=180 " + runCommand} />
+    </Callout>
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Step 3: Add the DNS records</h2>
     <p class="text-muted-foreground mb-4">
@@ -119,94 +199,6 @@
         passkey, which is your phone's or computer's built-in unlock. Register a second device
         as soon as you can, because there is no password to fall back on.
     </p>
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">If Oracle has no free capacity</h2>
-    <p class="text-muted-foreground mb-8">
-        Ampere A1 servers are popular and regions often run out. The script tries every
-        availability domain in your region, and keeps retrying for 30 minutes. If it gives up,
-        run it again later. It remembers your domain, so the command no longer needs it, and
-        everything already created is reused. A smaller server is easier to place:
-    </p>
-    <CodeBlock code={"OCPUS=1 MEMORY_GB=6 " + runCommand} class="mb-8" />
-
-    <h2 class="text-2xl font-bold mt-8 mb-4">Keeping it free</h2>
-    <p class="text-muted-foreground mb-4">
-        Oracle switches off Always Free servers on trial accounts that it judges idle for seven
-        days in a row. Its measure is whether the processor, network and memory each stayed
-        below 20 percent of capacity for nearly all of that week. A Nocturne server for one
-        person does very little work by that yardstick, so left alone it is likely to be
-        stopped after its first quiet week. You have two ways to prevent that. Pick one before
-        you run the installer.
-    </p>
-    <RadioGroup.Root bind:value={idlePlan} class="grid gap-3 mb-4">
-        <label
-            for="plan-payg"
-            class="flex items-start gap-3 rounded-xl border border-border/60 bg-card/50 p-4 cursor-pointer hover:border-primary/30"
-        >
-            <RadioGroup.Item value="payg" id="plan-payg" class="mt-1" />
-            <span>
-                <span class="font-semibold">Upgrade the account to Pay As You Go</span>
-                <span class="block text-sm text-muted-foreground">
-                    Recommended. Nothing changes about what you pay, and Oracle stops treating
-                    the server as reclaimable.
-                </span>
-            </span>
-        </label>
-        <label
-            for="plan-folding"
-            class="flex items-start gap-3 rounded-xl border border-border/60 bg-card/50 p-4 cursor-pointer hover:border-primary/30"
-        >
-            <RadioGroup.Item value="folding" id="plan-folding" class="mt-1" />
-            <span>
-                <span class="font-semibold">Stay on the trial and donate spare time to Folding@home</span>
-                <span class="block text-sm text-muted-foreground">
-                    The server does two hours of disease research each night, which keeps it
-                    clearly in use.
-                </span>
-            </span>
-        </label>
-    </RadioGroup.Root>
-
-    {#if idlePlan === "payg"}
-        <p class="text-muted-foreground mb-4">
-            In the Oracle console, open <strong>Billing &amp; Cost Management</strong>, then
-            <strong>Upgrade and Manage Payment</strong>, and choose Pay As You Go. Your card is
-            already on file from sign-up. Always Free resources stay free after the upgrade, and
-            Oracle's own terms exempt Pay As You Go accounts from idle reclamation. Everything
-            this installer creates is within the free allowance, so the upgrade does not by
-            itself cost anything.
-        </p>
-        <p class="text-muted-foreground mb-8">
-            What changes is that the card <em>can</em> now be charged if something outside the
-            free tier is ever created. To make sure that never goes unnoticed, the installer sets
-            up a spending alert that emails you the moment the account is billed one unit of your
-            currency. Upgrading also tends to end the "no free capacity" errors, since paying
-            accounts are served first when servers are scarce.
-        </p>
-    {:else}
-        <p class="text-muted-foreground mb-4">
-            <a href="https://foldingathome.org" class="text-primary hover:underline">Folding@home</a>
-            is a research project that simulates how proteins fold, to help understand diseases
-            such as Alzheimer's, cancer and, yes, diabetes. With this option the installer adds
-            its client to the server and runs it from 02:00 to 04:00 UTC each night. Two hours a
-            day of real computation is well above Oracle's idle threshold, so the server is never
-            a candidate for reclamation, and the time goes to something useful.
-        </p>
-        <p class="text-muted-foreground mb-4">
-            The client runs at the lowest priority the system has, so Nocturne and its alarms
-            always come first. It is one more piece of software with network access on a server
-            that holds your health data, which is why it is a choice rather than the default. To
-            choose it, add <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">FOLDING=1</code>
-            to the command in Step 2:
-        </p>
-        <CodeBlock code={"FOLDING=1 " + runCommand} class="mb-4" />
-        <p class="text-muted-foreground mb-8">
-            Work is contributed anonymously by default. To count it towards a team, add
-            <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">FOLDING_TEAM=&lt;number&gt;</code>
-            as well. Trial accounts cannot be charged, but the installer still creates the
-            spending alert in case the account is upgraded later.
-        </p>
-    {/if}
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Afterwards</h2>
     <ul class="list-disc list-inside space-y-2 text-muted-foreground mb-8">

--- a/src/Web/packages/portal/src/routes/faq/+page.svelte
+++ b/src/Web/packages/portal/src/routes/faq/+page.svelte
@@ -38,7 +38,7 @@
             questions: [
                 {
                     question: "What are the system requirements?",
-                    answer: "Nocturne runs in Docker, so any system that runs Docker (Linux, Windows, macOS) can host it. For a single user, a small VPS with 1 GB of RAM is enough. For families or several users, 2 GB or more is recommended. You also need a domain name pointed at the server.",
+                    answer: "Nocturne runs in Docker, so any system that runs Docker (Linux, Windows, macOS) can host it. For a single user, 2 GB of RAM and one CPU core will run it, though 4 GB is more comfortable because PostgreSQL uses the spare memory as disk cache. Allow 10 GB of storage, most of which is the container images. For families or several sites, 4 GB or more is recommended. You also need a domain name pointed at the server.",
                 },
                 {
                     question: "Can I run Nocturne on a Raspberry Pi?",


### PR DESCRIPTION
Follow-up to #1259, on the docs it shipped.

## The Oracle Cloud guide

"Keeping it free" sat after the install steps, but the choice it describes has to
be made before the first run — Folding@home is enabled by an environment variable
on the install command, so finding out about it afterwards means re-running. It now
sits ahead of Step 1 as **Before you start**, with:

- a callout giving the actual trade-off between Pay As You Go and Folding@home,
  which the page never stated — it described both options without saying why you'd
  pick one
- the per-option detail collapsed into two dropdowns, now that the callout carries
  the decision (this replaces the radio group, which existed only to swap two blocks
  of prose)
- **If Oracle has no free capacity** demoted from a top-level heading to a callout
  inside Step 2, so it stops competing with the numbered steps

## A no-op piece of advice

Both the guide and the installer's own failure message suggested retrying with
`OCPUS=1 MEMORY_GB=6` as "a smaller server". Those are already the defaults
(`OCPUS="${OCPUS:-1}"`, `MEMORY_GB="${MEMORY_GB:-6}"`), so the suggestion did
nothing. Both now point at `CAPACITY_RETRY_MINUTES`, which does.

## System requirements

The published figures were not derived from anything. They're now measured off a
running deployment serving 76 sites:

| | measured (76 sites) | image |
|---|---|---|
| postgres | 1.51 GiB, 18% CPU | 645 MB |
| nocturne-api | 665 MiB, 88% CPU | 504 MB |
| nocturne-web | 133 MiB | 746 MB |
| gateway | 107 MiB | 198 MB |
| caddy | 17 MiB | 154 MB |

Two things don't transfer to a self-host box: that PostgreSQL is tuned
(`shared_buffers=1GB`) where the bundle ships stock defaults, and that the API is
serving all 76 sites. Discounting both puts a single site at 1-1.5 GB, so the old
1 GB minimum was too low — the floor is **2 GB**, and **4 GB** is comfortable
because PostgreSQL spends the difference on disk cache.

A **CPU row** is new: the API is the only component doing sustained work, and all
76 sites together draw ~1.3 cores, so one core is genuinely enough for one site.

**Storage is unchanged at 10/20 GB** — it turned out to be defensible. Images are
~2.2 GB before any data and one CGM writes ~105k readings a year (the deployment
above holds 22 GB across 76 sites, ~290 MB each), so 10 GB really does fit the
images plus several years for one person. The derivation is now recorded in a
"Where these numbers come from" dropdown so it isn't re-guessed later.

The FAQ and the getting-started page repeated the 1 GB claim, so they move too —
all three drifted apart precisely because nothing tied them together.

## Checks

`pnpm --filter @nocturne/portal build` passes; the new copy is verified present in
the prerendered `installation.html`, `docker-compose.html`, `faq.html` and
`getting-started.html`.

https://claude.ai/code/session_01HuEugfm7Dvc75ydnqsM2xr
