### PR TITLE
fix(connectors): bound tenant syncs process-wide and stagger the pollers

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -915,6 +915,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IDevicePublisher, DevicePublisher>();
         services.AddScoped<IMetadataPublisher, MetadataPublisher>();
         services.AddScoped<IConnectorPublisher, InProcessConnectorPublisher>();
+        services.AddSingleton(ConnectorSyncBudget.FromConfiguration(configuration));
         services.AddConnectors(
             configuration,
             pollingService: typeof(ConnectorBackgroundService<,>)

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -915,11 +915,11 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IDevicePublisher, DevicePublisher>();
         services.AddScoped<IMetadataPublisher, MetadataPublisher>();
         services.AddScoped<IConnectorPublisher, InProcessConnectorPublisher>();
-        services.AddSingleton(ConnectorSyncBudget.FromConfiguration(configuration));
         services.AddConnectors(
             configuration,
             pollingService: typeof(ConnectorBackgroundService<,>)
         );
+        services.AddSingleton(ConnectorSyncBudget.FromConfiguration(configuration, services));
 
         // Demo service health monitor
         services.AddHttpClient("DemoServiceHealth");

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -70,7 +70,7 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     /// Initialises a new <see cref="ConnectorBackgroundService{TConfig}"/>.
     /// </summary>
     /// <param name="serviceProvider">Root DI service provider; a new scope is created per tenant sync.</param>
-    /// <param name="budget">The singleton shared by every poller in the process.</param>
+    /// <param name="budget">The process-wide budget.</param>
     /// <param name="logger">Logger instance.</param>
     protected ConnectorBackgroundService(
         IServiceProvider serviceProvider,
@@ -129,7 +129,7 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     protected virtual TimeSpan RealtimeSupervisionInterval => TimeSpan.FromMinutes(5);
 
     /// <summary>
-    /// Delay before the first poll tick, letting the application fully start. The poller's stagger
+    /// Delay before the first poll tick, letting the application fully start. The poller's phase
     /// offset from <see cref="ConnectorSyncBudget.NextStartupOffset"/> is added on top. Overridable
     /// for tests.
     /// </summary>
@@ -288,7 +288,7 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var startupDelay = StartupDelay + _budget.NextStartupOffset();
+        var startupDelay = StartupDelay + _budget.NextStartupOffset(PollInterval);
         if (startupDelay > TimeSpan.Zero)
             await Task.Delay(startupDelay, stoppingToken);
 
@@ -349,9 +349,7 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
         // Sync tenants concurrently so each tenant is independent: one tenant's slow or failing sync
         // must never delay or block another's. Each tenant already runs in its own DI scope (own
-        // DbContext, own tenant context), so concurrent execution is isolated. MaxConcurrentTenantSyncs
-        // caps this connector's share of the ConnectorSyncBudget, and PerTenantSyncTimeout bounds how
-        // long any single tenant can hold a slot.
+        // DbContext, own tenant context), so concurrent execution is isolated.
         await Parallel.ForEachAsync(
             tenants,
             new ParallelOptions
@@ -362,7 +360,7 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
             async (tenant, ct) =>
             {
                 // Waiting for a slot is not the tenant's time, so the timeout starts once one is held.
-                using var lease = await _budget.AcquireAsync(ct);
+                using var lease = await AcquireSlotAsync(tenant.Slug, ct);
 
                 using var tenantCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 tenantCts.CancelAfter(PerTenantSyncTimeout);
@@ -389,6 +387,30 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
                         ConnectorName, tenant.Slug);
                 }
             });
+    }
+
+    /// <summary>
+    /// How long a tenant may queue for a budget slot before the wait is reported. A saturated budget
+    /// otherwise shows only as syncs running late.
+    /// </summary>
+    protected virtual TimeSpan SlotWaitWarningAfter => TimeSpan.FromSeconds(30);
+
+    private async Task<ConnectorSyncBudget.Lease> AcquireSlotAsync(string tenantSlug, CancellationToken stoppingToken)
+    {
+        var acquire = _budget.AcquireAsync(stoppingToken);
+        if (acquire.IsCompleted)
+            return await acquire;
+
+        var pending = acquire.AsTask();
+        var started = DateTime.UtcNow;
+        while (await Task.WhenAny(pending, Task.Delay(SlotWaitWarningAfter, stoppingToken)) != pending)
+        {
+            Logger.LogWarning(
+                "{ConnectorName} sync for tenant {TenantSlug} has waited {Waited} for a sync slot; {InFlight} of {Slots} in use",
+                ConnectorName, tenantSlug, DateTime.UtcNow - started, _budget.InFlight, _budget.Slots);
+        }
+
+        return await pending;
     }
 
     private async Task SyncForTenantAsync(Guid tenantId, string tenantSlug, string displayName, CancellationToken stoppingToken)

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -50,8 +50,10 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
     /// <summary>
     /// Maximum number of tenants this connector syncs concurrently. Tenants sync in parallel so one
-    /// tenant's slow or failing sync never blocks another's; this only caps resource use (DB
-    /// connections, outbound requests). Overridable for tests.
+    /// tenant's slow or failing sync never blocks another's. This is one connector's share of the
+    /// <see cref="ConnectorSyncBudget"/> every poller draws on, so a connector whose tenants are all
+    /// stuck cannot take every slot from the others; the budget is what bounds the total. Overridable
+    /// for tests.
     /// </summary>
     protected virtual int MaxConcurrentTenantSyncs => 8;
 
@@ -62,17 +64,22 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     /// </summary>
     protected virtual TimeSpan PerTenantSyncTimeout => TimeSpan.FromMinutes(3);
 
+    private readonly ConnectorSyncBudget _budget;
+
     /// <summary>
     /// Initialises a new <see cref="ConnectorBackgroundService{TConfig}"/>.
     /// </summary>
     /// <param name="serviceProvider">Root DI service provider; a new scope is created per tenant sync.</param>
+    /// <param name="budget">The singleton shared by every poller in the process.</param>
     /// <param name="logger">Logger instance.</param>
     protected ConnectorBackgroundService(
         IServiceProvider serviceProvider,
+        ConnectorSyncBudget budget,
         ILogger logger
     )
     {
         ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _budget = budget ?? throw new ArgumentNullException(nameof(budget));
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -122,7 +129,9 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     protected virtual TimeSpan RealtimeSupervisionInterval => TimeSpan.FromMinutes(5);
 
     /// <summary>
-    /// Delay before the first poll tick, letting the application fully start. Overridable for tests.
+    /// Delay before the first poll tick, letting the application fully start. The poller's stagger
+    /// offset from <see cref="ConnectorSyncBudget.NextStartupOffset"/> is added on top. Overridable
+    /// for tests.
     /// </summary>
     protected virtual TimeSpan StartupDelay => TimeSpan.FromSeconds(5);
 
@@ -279,8 +288,9 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        if (StartupDelay > TimeSpan.Zero)
-            await Task.Delay(StartupDelay, stoppingToken);
+        var startupDelay = StartupDelay + _budget.NextStartupOffset();
+        if (startupDelay > TimeSpan.Zero)
+            await Task.Delay(startupDelay, stoppingToken);
 
         Logger.LogInformation(
             "{ConnectorName} connector background service started",
@@ -340,8 +350,8 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         // Sync tenants concurrently so each tenant is independent: one tenant's slow or failing sync
         // must never delay or block another's. Each tenant already runs in its own DI scope (own
         // DbContext, own tenant context), so concurrent execution is isolated. MaxConcurrentTenantSyncs
-        // only caps resource use (DB connections, outbound requests), and PerTenantSyncTimeout bounds
-        // how long any single tenant can hold a slot.
+        // caps this connector's share of the ConnectorSyncBudget, and PerTenantSyncTimeout bounds how
+        // long any single tenant can hold a slot.
         await Parallel.ForEachAsync(
             tenants,
             new ParallelOptions
@@ -351,6 +361,9 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
             },
             async (tenant, ct) =>
             {
+                // Waiting for a slot is not the tenant's time, so the timeout starts once one is held.
+                using var lease = await _budget.AcquireAsync(ct);
+
                 using var tenantCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 tenantCts.CancelAfter(PerTenantSyncTimeout);
 
@@ -495,8 +508,9 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 /// </summary>
 public class ConnectorBackgroundService<TService, TConfig>(
     IServiceProvider serviceProvider,
+    ConnectorSyncBudget budget,
     ILogger<ConnectorBackgroundService<TService, TConfig>> logger)
-    : ConnectorBackgroundService<TConfig>(serviceProvider, logger)
+    : ConnectorBackgroundService<TConfig>(serviceProvider, budget, logger)
     where TService : class, IConnectorService<TConfig>
     where TConfig : BaseConnectorConfiguration
 {

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorSyncBudget.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorSyncBudget.cs
@@ -1,0 +1,102 @@
+using Microsoft.Extensions.Configuration;
+using Nocturne.Connectors.Core.Extensions;
+
+namespace Nocturne.API.Services.BackgroundServices;
+
+/// <summary>
+/// The process-wide bound on how many tenant syncs may run at once, and the phase offsets that keep
+/// the connector pollers' ticks apart. One instance is shared by every
+/// <see cref="ConnectorBackgroundService{TConfig}"/>.
+/// </summary>
+/// <remarks>
+/// Each poller fans out over every active tenant with its own per-service cap, and every tenant sync
+/// opens its own DI scope and database connection. With one poller per installed connector and every
+/// poller on the same clock, the connections in flight at a tick peak at
+/// <c>connectors × per-service cap</c> regardless of tenant count — enough to exhaust a Postgres
+/// <c>max_connections</c> of 100 and refuse the request path with "too many clients already". The
+/// lease bounds that total to <see cref="MaxConcurrentTenantSyncs"/> whatever the connector count;
+/// the stagger spreads the pollers across the poll interval so they rarely contend for it.
+/// </remarks>
+public sealed class ConnectorSyncBudget : IDisposable
+{
+    /// <summary>
+    /// Configuration key under the shared connector defaults, <c>Connectors:Settings</c>, overriding
+    /// <see cref="DefaultMaxConcurrentTenantSyncs"/>. Size it against the <c>MaxPoolSize</c> the
+    /// request path has to share the server with, and remember a sync may hold more than one
+    /// connection while its repositories write.
+    /// </summary>
+    public const string MaxConcurrentTenantSyncsKey = "MaxConcurrentTenantSyncs";
+
+    /// <summary>
+    /// A quarter of the default Npgsql pool of 100: thirteen pollers' lookup scopes plus this many
+    /// syncs fit under it with room for requests, and the tenant work of a tick still clears in
+    /// well under the interval.
+    /// </summary>
+    public const int DefaultMaxConcurrentTenantSyncs = 24;
+
+    /// <summary>
+    /// Gap between consecutive pollers' first ticks. Thirteen pollers on a one-minute interval spread
+    /// across 48 seconds of it; the per-tenant interval check means a later first tick delays no
+    /// tenant's sync by more than this.
+    /// </summary>
+    public static readonly TimeSpan DefaultStartupStagger = TimeSpan.FromSeconds(4);
+
+    private readonly SemaphoreSlim _slots;
+    private int _pollersStarted;
+
+    public ConnectorSyncBudget(
+        int maxConcurrentTenantSyncs = DefaultMaxConcurrentTenantSyncs,
+        TimeSpan? startupStagger = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxConcurrentTenantSyncs, 1);
+
+        MaxConcurrentTenantSyncs = maxConcurrentTenantSyncs;
+        StartupStagger = startupStagger ?? DefaultStartupStagger;
+        _slots = new SemaphoreSlim(maxConcurrentTenantSyncs, maxConcurrentTenantSyncs);
+    }
+
+    /// <summary>
+    /// Resolves the budget a host runs on: <see cref="MaxConcurrentTenantSyncsKey"/> from the shared
+    /// connector settings, else <see cref="DefaultMaxConcurrentTenantSyncs"/>.
+    /// </summary>
+    public static ConnectorSyncBudget FromConfiguration(IConfiguration configuration) =>
+        new(configuration.GlobalConnectorSettings.GetValue<int?>(MaxConcurrentTenantSyncsKey)
+            ?? DefaultMaxConcurrentTenantSyncs);
+
+    public int MaxConcurrentTenantSyncs { get; }
+
+    public TimeSpan StartupStagger { get; }
+
+    /// <summary>Tenant syncs currently holding a slot.</summary>
+    public int InFlight => MaxConcurrentTenantSyncs - _slots.CurrentCount;
+
+    /// <summary>
+    /// Waits for a slot and holds it until the returned lease is disposed. Acquire it around the whole
+    /// of a tenant's sync, including the config load — that scope opens a connection too.
+    /// </summary>
+    public async ValueTask<Lease> AcquireAsync(CancellationToken cancellationToken)
+    {
+        await _slots.WaitAsync(cancellationToken);
+        return new Lease(_slots);
+    }
+
+    /// <summary>
+    /// The additional startup delay for the next poller to start: zero for the first, then one
+    /// <see cref="StartupStagger"/> more for each after it.
+    /// </summary>
+    public TimeSpan NextStartupOffset() =>
+        StartupStagger * (Interlocked.Increment(ref _pollersStarted) - 1);
+
+    public void Dispose() => _slots.Dispose();
+
+    /// <summary>A held slot; disposing returns it.</summary>
+    public struct Lease(SemaphoreSlim slots) : IDisposable
+    {
+        private SemaphoreSlim? _slots = slots;
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _slots, null)?.Release();
+        }
+    }
+}

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorSyncBudget.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorSyncBudget.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Nocturne.Connectors.Core.Extensions;
 
 namespace Nocturne.API.Services.BackgroundServices;
@@ -10,65 +11,75 @@ namespace Nocturne.API.Services.BackgroundServices;
 /// </summary>
 /// <remarks>
 /// Each poller fans out over every active tenant with its own per-service cap, and every tenant sync
-/// opens its own DI scope and database connection. With one poller per installed connector and every
-/// poller on the same clock, the connections in flight at a tick peak at
+/// opens its own DI scope and at least one database connection. With one poller per installed
+/// connector and every poller on the same clock, the connections in flight at a tick peak at
 /// <c>connectors × per-service cap</c> regardless of tenant count — enough to exhaust a Postgres
 /// <c>max_connections</c> of 100 and refuse the request path with "too many clients already". The
-/// lease bounds that total to <see cref="MaxConcurrentTenantSyncs"/> whatever the connector count;
-/// the stagger spreads the pollers across the poll interval so they rarely contend for it.
+/// lease bounds that total to <see cref="Slots"/> whatever the connector count; the stagger spreads
+/// the pollers' first ticks evenly across the poll interval so they rarely contend for it.
 /// </remarks>
-public sealed class ConnectorSyncBudget : IDisposable
+public sealed class ConnectorSyncBudget
 {
     /// <summary>
     /// Configuration key under the shared connector defaults, <c>Connectors:Settings</c>, overriding
-    /// <see cref="DefaultMaxConcurrentTenantSyncs"/>. Size it against the <c>MaxPoolSize</c> the
-    /// request path has to share the server with, and remember a sync may hold more than one
-    /// connection while its repositories write.
+    /// <see cref="DefaultSlots"/>. Size it against the <c>MaxPoolSize</c> the request path has to
+    /// share the server with; a sync may hold more than one connection while its repositories write.
     /// </summary>
-    public const string MaxConcurrentTenantSyncsKey = "MaxConcurrentTenantSyncs";
+    public const string SlotsKey = "SyncSlots";
 
-    /// <summary>
-    /// A quarter of the default Npgsql pool of 100: thirteen pollers' lookup scopes plus this many
-    /// syncs fit under it with room for requests, and the tenant work of a tick still clears in
-    /// well under the interval.
-    /// </summary>
-    public const int DefaultMaxConcurrentTenantSyncs = 24;
-
-    /// <summary>
-    /// Gap between consecutive pollers' first ticks. Thirteen pollers on a one-minute interval spread
-    /// across 48 seconds of it; the per-tenant interval check means a later first tick delays no
-    /// tenant's sync by more than this.
-    /// </summary>
-    public static readonly TimeSpan DefaultStartupStagger = TimeSpan.FromSeconds(4);
+    /// <summary>A quarter of the default Npgsql pool of 100.</summary>
+    public const int DefaultSlots = 24;
 
     private readonly SemaphoreSlim _slots;
     private int _pollersStarted;
 
-    public ConnectorSyncBudget(
-        int maxConcurrentTenantSyncs = DefaultMaxConcurrentTenantSyncs,
-        TimeSpan? startupStagger = null)
+    /// <param name="pollerCount">
+    /// How many pollers share the budget; the poll interval is divided into this many phases.
+    /// </param>
+    public ConnectorSyncBudget(int slots = DefaultSlots, int pollerCount = 1)
     {
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxConcurrentTenantSyncs, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(slots, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(pollerCount, 1);
 
-        MaxConcurrentTenantSyncs = maxConcurrentTenantSyncs;
-        StartupStagger = startupStagger ?? DefaultStartupStagger;
-        _slots = new SemaphoreSlim(maxConcurrentTenantSyncs, maxConcurrentTenantSyncs);
+        Slots = slots;
+        PollerCount = pollerCount;
+        _slots = new SemaphoreSlim(slots, slots);
     }
 
     /// <summary>
-    /// Resolves the budget a host runs on: <see cref="MaxConcurrentTenantSyncsKey"/> from the shared
-    /// connector settings, else <see cref="DefaultMaxConcurrentTenantSyncs"/>.
+    /// Resolves the budget a host runs on: <see cref="SlotsKey"/> from the shared connector settings,
+    /// else <see cref="DefaultSlots"/>, over the pollers already registered in
+    /// <paramref name="services"/>.
     /// </summary>
-    public static ConnectorSyncBudget FromConfiguration(IConfiguration configuration) =>
-        new(configuration.GlobalConnectorSettings.GetValue<int?>(MaxConcurrentTenantSyncsKey)
-            ?? DefaultMaxConcurrentTenantSyncs);
+    public static ConnectorSyncBudget FromConfiguration(IConfiguration configuration, IServiceCollection services) =>
+        new(
+            configuration.GlobalConnectorSettings.GetValue<int?>(SlotsKey) ?? DefaultSlots,
+            Math.Max(1, CountPollers(services)));
 
-    public int MaxConcurrentTenantSyncs { get; }
+    /// <summary>Hosted services registered in <paramref name="services"/> that are connector pollers.</summary>
+    public static int CountPollers(IServiceCollection services) =>
+        services.Count(descriptor =>
+            descriptor.ServiceType == typeof(IHostedService)
+            && descriptor.ImplementationType is { } implementation
+            && IsPoller(implementation));
 
-    public TimeSpan StartupStagger { get; }
+    private static bool IsPoller(Type type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(ConnectorBackgroundService<>))
+                return true;
+        }
+
+        return false;
+    }
+
+    public int Slots { get; }
+
+    public int PollerCount { get; }
 
     /// <summary>Tenant syncs currently holding a slot.</summary>
-    public int InFlight => MaxConcurrentTenantSyncs - _slots.CurrentCount;
+    public int InFlight => Slots - _slots.CurrentCount;
 
     /// <summary>
     /// Waits for a slot and holds it until the returned lease is disposed. Acquire it around the whole
@@ -81,15 +92,20 @@ public sealed class ConnectorSyncBudget : IDisposable
     }
 
     /// <summary>
-    /// The additional startup delay for the next poller to start: zero for the first, then one
-    /// <see cref="StartupStagger"/> more for each after it.
+    /// The additional startup delay for the next poller to start: the poll interval divided into
+    /// <see cref="PollerCount"/> phases, handed out in start order. A poller beyond the count wraps
+    /// onto the first phase.
     /// </summary>
-    public TimeSpan NextStartupOffset() =>
-        StartupStagger * (Interlocked.Increment(ref _pollersStarted) - 1);
+    public TimeSpan NextStartupOffset(TimeSpan pollInterval)
+    {
+        var ordinal = (Interlocked.Increment(ref _pollersStarted) - 1) % PollerCount;
+        return pollInterval * ordinal / PollerCount;
+    }
 
-    public void Dispose() => _slots.Dispose();
-
-    /// <summary>A held slot; disposing returns it.</summary>
+    /// <summary>
+    /// A held slot; disposing returns it. Dispose the instance the lease was acquired into — a copy
+    /// is a second token over the same slot.
+    /// </summary>
     public struct Lease(SemaphoreSlim slots) : IDisposable
     {
         private SemaphoreSlim? _slots = slots;

--- a/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
@@ -41,7 +41,7 @@ public class NightscoutConnectorBackgroundService
     private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(10);
 
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
-    /// <param name="budget">The singleton shared by every poller in the process.</param>
+    /// <param name="budget">The process-wide budget.</param>
     /// <param name="logger">Logger instance for this background service.</param>
     public NightscoutConnectorBackgroundService(
         IServiceProvider serviceProvider,

--- a/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
@@ -41,12 +41,14 @@ public class NightscoutConnectorBackgroundService
     private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(10);
 
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
+    /// <param name="budget">The singleton shared by every poller in the process.</param>
     /// <param name="logger">Logger instance for this background service.</param>
     public NightscoutConnectorBackgroundService(
         IServiceProvider serviceProvider,
+        ConnectorSyncBudget budget,
         ILogger<NightscoutConnectorBackgroundService> logger
     )
-        : base(serviceProvider, logger) { }
+        : base(serviceProvider, budget, logger) { }
 
     /// <inheritdoc />
     protected override async Task StartRealtimeListenersAsync(CancellationToken cancellationToken)

--- a/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
@@ -21,12 +21,14 @@ public class NocturneRemoteConnectorBackgroundService
     private readonly ConcurrentDictionary<Guid, HubConnection> _hubConnections = new();
 
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
+    /// <param name="budget">The singleton shared by every poller in the process.</param>
     /// <param name="logger">Logger instance for this background service.</param>
     public NocturneRemoteConnectorBackgroundService(
         IServiceProvider serviceProvider,
+        ConnectorSyncBudget budget,
         ILogger<NocturneRemoteConnectorBackgroundService> logger
     )
-        : base(serviceProvider, logger) { }
+        : base(serviceProvider, budget, logger) { }
 
     /// <inheritdoc />
     protected override async Task StartRealtimeListenersAsync(CancellationToken cancellationToken)

--- a/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
@@ -21,7 +21,7 @@ public class NocturneRemoteConnectorBackgroundService
     private readonly ConcurrentDictionary<Guid, HubConnection> _hubConnections = new();
 
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
-    /// <param name="budget">The singleton shared by every poller in the process.</param>
+    /// <param name="budget">The process-wide budget.</param>
     /// <param name="logger">Logger instance for this background service.</param>
     public NocturneRemoteConnectorBackgroundService(
         IServiceProvider serviceProvider,

--- a/src/API/Nocturne.API/appsettings.example.json
+++ b/src/API/Nocturne.API/appsettings.example.json
@@ -29,7 +29,7 @@
     "Settings": {
       // Tenant syncs in flight at once across every connector poller; each holds at least one
       // pooled connection for its duration. Lower it before lowering MaxPoolSize above.
-      // "MaxConcurrentTenantSyncs": 24
+      // "SyncSlots": 24
     }
   },
 

--- a/src/API/Nocturne.API/appsettings.example.json
+++ b/src/API/Nocturne.API/appsettings.example.json
@@ -25,6 +25,14 @@
     // "StatementTimeoutSeconds": 30 // server-side backstop; 0 disables
   },
 
+  "Connectors": {
+    "Settings": {
+      // Tenant syncs in flight at once across every connector poller; each holds at least one
+      // pooled connection for its duration. Lower it before lowering MaxPoolSize above.
+      // "MaxConcurrentTenantSyncs": 24
+    }
+  },
+
   // Authentication
   "Jwt": {
     "Issuer": "nocturne",

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorPollingRegistrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorPollingRegistrationTests.cs
@@ -243,6 +243,7 @@ public class ConnectorPollingRegistrationTests
     private sealed class ExposedPoller(IServiceProvider serviceProvider)
         : ConnectorBackgroundService<RecordingConnectorService, PollingTestConfiguration>(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<ConnectorBackgroundService<RecordingConnectorService, PollingTestConfiguration>>.Instance)
     {
         public Task<SyncResult> SyncAsync(

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -83,6 +83,7 @@ public class ConnectorBackgroundServiceTests
             if (n <= _hangFirstNCalls)
                 await Task.Delay(Timeout.Infinite, cancellationToken);
 
+            cancellationToken.ThrowIfCancellationRequested();
             _onSyncCompleted?.Invoke();
             return _syncResult;
         }
@@ -193,7 +194,8 @@ public class ConnectorBackgroundServiceTests
     private static IServiceProvider BuildServiceProvider(
         string connectionString,
         Mock<IConnectorConfigurationService> configServiceMock,
-        TestConnectorConfig config)
+        TestConnectorConfig config,
+        Action? onConfigLoad = null)
     {
         var services = new ServiceCollection();
 
@@ -224,7 +226,7 @@ public class ConnectorBackgroundServiceTests
 
         // Register config loader that returns the test config
         services.AddScoped<IConnectorConfigurationLoader<TestConnectorConfig>>(
-            _ => new TestConfigLoader(config));
+            _ => new TestConfigLoader(config, onConfigLoad));
 
         return services.BuildServiceProvider();
     }
@@ -706,7 +708,9 @@ public class ConnectorBackgroundServiceTests
     /// <summary>
     /// The budget is process-wide: a tenant sync in one poller holds a slot that a tenant sync in
     /// another poller has to wait for. Per-poller caps alone let the total climb with the connector
-    /// count, which is what exhausted Postgres connections in production.
+    /// count, which is what exhausted Postgres connections in production. The slot gates the tenant's
+    /// DI scope and config load, not just the sync proper — the config load is the connection the
+    /// unconfigured majority of tenants open.
     /// </summary>
     [Fact]
     public async Task SyncAllTenants_SharesTheBudgetAcrossPollers_ASecondPollerWaitsForASlot()
@@ -716,9 +720,75 @@ public class ConnectorBackgroundServiceTests
 
         var configServiceMock = BuildEnabledConfigMock();
         var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 };
+
+        var budget = new ConnectorSyncBudget(slots: 1);
+        using var firstCts = new CancellationTokenSource();
+
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = new TestConnectorBackgroundService(
+            BuildServiceProvider(connStr, configServiceMock, config),
+            new SyncResult { Success = true },
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSync: () => firstStarted.TrySetResult(),
+            perTenantTimeout: TimeSpan.FromSeconds(30),
+            hangFirstNCalls: 1,
+            budget: budget);
+
+        var secondConfigLoads = 0;
+        var secondDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var second = new TestConnectorBackgroundService(
+            BuildServiceProvider(connStr, configServiceMock, config,
+                onConfigLoad: () => Interlocked.Increment(ref secondConfigLoads)),
+            new SyncResult { Success = true },
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSyncCompleted: () => secondDone.TrySetResult(),
+            budget: budget);
+
+        var firstRun = first.ExecuteOnceAsync(firstCts.Token);
+        try
+        {
+            (await Task.WhenAny(firstStarted.Task, Task.Delay(TimeSpan.FromSeconds(5))))
+                .Should().Be(firstStarted.Task, "the first poller must take the only slot");
+
+            var secondRun = second.ExecuteOnceAsync(CancellationToken.None);
+
+            (await Task.WhenAny(secondDone.Task, Task.Delay(TimeSpan.FromMilliseconds(500))))
+                .Should().NotBe(secondDone.Task,
+                    "the second poller's tenant must wait while the first poller holds the slot");
+            secondConfigLoads.Should().Be(0, "the slot must be held before the tenant's scope loads config");
+            budget.InFlight.Should().Be(1);
+
+            firstCts.Cancel();
+
+            (await Task.WhenAny(secondDone.Task, Task.Delay(TimeSpan.FromSeconds(5))))
+                .Should().Be(secondDone.Task, "the slot the first poller released must go to the second");
+            await secondRun;
+            secondConfigLoads.Should().Be(1);
+        }
+        finally
+        {
+            firstCts.Cancel();
+            try { await firstRun; } catch (OperationCanceledException) { }
+        }
+
+        budget.InFlight.Should().Be(0, "every lease must be returned once the syncs are over");
+    }
+
+    /// <summary>
+    /// Queueing for a slot is not the tenant's time: its <c>PerTenantSyncTimeout</c> starts once the
+    /// slot is held, so a tenant that waited longer than the timeout still gets its full sync.
+    /// </summary>
+    [Fact]
+    public async Task SyncAllTenants_StartsThePerTenantTimeout_OnlyOnceASlotIsHeld()
+    {
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+
+        var configServiceMock = BuildEnabledConfigMock();
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 };
         var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
 
-        using var budget = new ConnectorSyncBudget(maxConcurrentTenantSyncs: 1);
+        var budget = new ConnectorSyncBudget(slots: 1);
         using var firstCts = new CancellationTokenSource();
 
         var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -737,6 +807,7 @@ public class ConnectorBackgroundServiceTests
             new SyncResult { Success = true },
             NullLogger<TestConnectorBackgroundService>.Instance,
             onSyncCompleted: () => secondDone.TrySetResult(),
+            perTenantTimeout: TimeSpan.FromMilliseconds(200),
             budget: budget);
 
         var firstRun = first.ExecuteOnceAsync(firstCts.Token);
@@ -747,15 +818,13 @@ public class ConnectorBackgroundServiceTests
 
             var secondRun = second.ExecuteOnceAsync(CancellationToken.None);
 
-            (await Task.WhenAny(secondDone.Task, Task.Delay(TimeSpan.FromMilliseconds(500))))
-                .Should().NotBe(secondDone.Task,
-                    "the second poller's tenant must wait while the first poller holds the slot");
-            budget.InFlight.Should().Be(1);
-
+            // Hold the slot for well over the second poller's timeout before releasing it.
+            await Task.Delay(TimeSpan.FromMilliseconds(800));
             firstCts.Cancel();
 
             (await Task.WhenAny(secondDone.Task, Task.Delay(TimeSpan.FromSeconds(5))))
-                .Should().Be(secondDone.Task, "the slot the first poller released must go to the second");
+                .Should().Be(secondDone.Task,
+                    "a tenant that queued longer than its timeout must still run once it holds a slot");
             await secondRun;
         }
         finally
@@ -763,12 +832,10 @@ public class ConnectorBackgroundServiceTests
             firstCts.Cancel();
             try { await firstRun; } catch (OperationCanceledException) { }
         }
-
-        budget.InFlight.Should().Be(0, "every lease must be returned once the syncs are over");
     }
 
     /// <summary>
-    /// A poller's first tick waits its stagger offset on top of <c>StartupDelay</c>, so pollers that
+    /// A poller's first tick waits its phase offset on top of <c>StartupDelay</c>, so pollers that
     /// start together do not tick together. <see cref="ExecuteAsync_RunsListenerSupervisionFromThePollLoop"/>
     /// is the control: the first poller on a budget has no offset and ticks at once.
     /// </summary>
@@ -783,16 +850,16 @@ public class ConnectorBackgroundServiceTests
             BuildEnabledConfigMock(),
             new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 });
 
-        using var budget = new ConnectorSyncBudget(startupStagger: TimeSpan.FromHours(1));
-        budget.NextStartupOffset();
+        var budget = new ConnectorSyncBudget(pollerCount: 2);
+        budget.NextStartupOffset(TimeSpan.FromHours(1));
 
-        var sut = new PollLoopWiringService(serviceProvider, budget);
+        var sut = new PollLoopWiringService(serviceProvider, budget, pollInterval: TimeSpan.FromHours(1));
         await sut.StartAsync(CancellationToken.None);
         try
         {
             await Task.Delay(TimeSpan.FromMilliseconds(300));
 
-            sut.Events.Should().BeEmpty("the second poller on a budget waits a stagger before its first tick");
+            sut.Events.Should().BeEmpty("the second of two pollers waits half the poll interval before its first tick");
         }
         finally
         {
@@ -1073,7 +1140,10 @@ public class ConnectorBackgroundServiceTests
     /// Runs the real ExecuteAsync poll loop with test-fast intervals, recording listener-startup
     /// passes and sync cycles in order.
     /// </summary>
-    private sealed class PollLoopWiringService(IServiceProvider serviceProvider, ConnectorSyncBudget? budget = null)
+    private sealed class PollLoopWiringService(
+        IServiceProvider serviceProvider,
+        ConnectorSyncBudget? budget = null,
+        TimeSpan? pollInterval = null)
         : ConnectorBackgroundService<TestConnectorConfig>(serviceProvider, budget ?? new ConnectorSyncBudget(), NullLogger.Instance)
     {
         private readonly TaskCompletionSource _secondSupervisionPass =
@@ -1087,7 +1157,7 @@ public class ConnectorBackgroundServiceTests
 
         protected override TimeSpan StartupDelay => TimeSpan.Zero;
 
-        protected override TimeSpan PollInterval => TimeSpan.FromMilliseconds(20);
+        protected override TimeSpan PollInterval => pollInterval ?? TimeSpan.FromMilliseconds(20);
 
         protected override TimeSpan RealtimeSupervisionInterval => TimeSpan.Zero;
 
@@ -1199,10 +1269,14 @@ public class ConnectorBackgroundServiceTests
     /// <summary>
     /// Concrete config loader that returns a preconfigured TestConnectorConfig.
     /// </summary>
-    private sealed class TestConfigLoader(TestConnectorConfig config) : IConnectorConfigurationLoader<TestConnectorConfig>
+    private sealed class TestConfigLoader(TestConnectorConfig config, Action? onLoad = null)
+        : IConnectorConfigurationLoader<TestConnectorConfig>
     {
         public Task<TestConnectorConfig> LoadForTenantAsync(CancellationToken ct)
-            => Task.FromResult(config);
+        {
+            onLoad?.Invoke();
+            return Task.FromResult(config);
+        }
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -52,8 +52,9 @@ public class ConnectorBackgroundServiceTests
             Action<IServiceProvider>? onSyncScope = null,
             TimeSpan? perTenantTimeout = null,
             int hangFirstNCalls = 0,
-            Action? onSyncCompleted = null)
-            : base(serviceProvider, logger)
+            Action? onSyncCompleted = null,
+            ConnectorSyncBudget? budget = null)
+            : base(serviceProvider, budget ?? new ConnectorSyncBudget(), logger)
         {
             _syncResult = syncResult;
             _onSync = onSync;
@@ -702,6 +703,103 @@ public class ConnectorBackgroundServiceTests
         }
     }
 
+    /// <summary>
+    /// The budget is process-wide: a tenant sync in one poller holds a slot that a tenant sync in
+    /// another poller has to wait for. Per-poller caps alone let the total climb with the connector
+    /// count, which is what exhausted Postgres connections in production.
+    /// </summary>
+    [Fact]
+    public async Task SyncAllTenants_SharesTheBudgetAcrossPollers_ASecondPollerWaitsForASlot()
+    {
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+
+        var configServiceMock = BuildEnabledConfigMock();
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        using var budget = new ConnectorSyncBudget(maxConcurrentTenantSyncs: 1);
+        using var firstCts = new CancellationTokenSource();
+
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = new TestConnectorBackgroundService(
+            serviceProvider,
+            new SyncResult { Success = true },
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSync: () => firstStarted.TrySetResult(),
+            perTenantTimeout: TimeSpan.FromSeconds(30),
+            hangFirstNCalls: 1,
+            budget: budget);
+
+        var secondDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var second = new TestConnectorBackgroundService(
+            serviceProvider,
+            new SyncResult { Success = true },
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSyncCompleted: () => secondDone.TrySetResult(),
+            budget: budget);
+
+        var firstRun = first.ExecuteOnceAsync(firstCts.Token);
+        try
+        {
+            (await Task.WhenAny(firstStarted.Task, Task.Delay(TimeSpan.FromSeconds(5))))
+                .Should().Be(firstStarted.Task, "the first poller must take the only slot");
+
+            var secondRun = second.ExecuteOnceAsync(CancellationToken.None);
+
+            (await Task.WhenAny(secondDone.Task, Task.Delay(TimeSpan.FromMilliseconds(500))))
+                .Should().NotBe(secondDone.Task,
+                    "the second poller's tenant must wait while the first poller holds the slot");
+            budget.InFlight.Should().Be(1);
+
+            firstCts.Cancel();
+
+            (await Task.WhenAny(secondDone.Task, Task.Delay(TimeSpan.FromSeconds(5))))
+                .Should().Be(secondDone.Task, "the slot the first poller released must go to the second");
+            await secondRun;
+        }
+        finally
+        {
+            firstCts.Cancel();
+            try { await firstRun; } catch (OperationCanceledException) { }
+        }
+
+        budget.InFlight.Should().Be(0, "every lease must be returned once the syncs are over");
+    }
+
+    /// <summary>
+    /// A poller's first tick waits its stagger offset on top of <c>StartupDelay</c>, so pollers that
+    /// start together do not tick together. <see cref="ExecuteAsync_RunsListenerSupervisionFromThePollLoop"/>
+    /// is the control: the first poller on a budget has no offset and ticks at once.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WaitsThePollersStaggerOffsetBeforeItsFirstTick()
+    {
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(
+            connStr,
+            BuildEnabledConfigMock(),
+            new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 });
+
+        using var budget = new ConnectorSyncBudget(startupStagger: TimeSpan.FromHours(1));
+        budget.NextStartupOffset();
+
+        var sut = new PollLoopWiringService(serviceProvider, budget);
+        await sut.StartAsync(CancellationToken.None);
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(300));
+
+            sut.Events.Should().BeEmpty("the second poller on a budget waits a stagger before its first tick");
+        }
+        finally
+        {
+            await sut.StopAsync(CancellationToken.None);
+        }
+    }
+
     [Fact]
     public async Task SyncForTenant_IsCancelled_WhenItExceedsPerTenantTimeout()
     {
@@ -975,8 +1073,8 @@ public class ConnectorBackgroundServiceTests
     /// Runs the real ExecuteAsync poll loop with test-fast intervals, recording listener-startup
     /// passes and sync cycles in order.
     /// </summary>
-    private sealed class PollLoopWiringService(IServiceProvider serviceProvider)
-        : ConnectorBackgroundService<TestConnectorConfig>(serviceProvider, NullLogger.Instance)
+    private sealed class PollLoopWiringService(IServiceProvider serviceProvider, ConnectorSyncBudget? budget = null)
+        : ConnectorBackgroundService<TestConnectorConfig>(serviceProvider, budget ?? new ConnectorSyncBudget(), NullLogger.Instance)
     {
         private readonly TaskCompletionSource _secondSupervisionPass =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1032,7 +1130,8 @@ public class ConnectorBackgroundServiceTests
     /// Exposes the base class's real-time supervision hooks and counts listener-startup passes.
     /// </summary>
     private sealed class SupervisedListenerService(ILogger logger, TimeSpan supervisionInterval)
-        : ConnectorBackgroundService<TestConnectorConfig>(new ServiceCollection().BuildServiceProvider(), logger)
+        : ConnectorBackgroundService<TestConnectorConfig>(
+            new ServiceCollection().BuildServiceProvider(), new ConnectorSyncBudget(), logger)
     {
         private int _startCount;
 

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorSyncBudgetTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorSyncBudgetTests.cs
@@ -1,6 +1,9 @@
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Nocturne.API.Services.BackgroundServices;
+using Nocturne.Connectors.Core.Extensions;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.BackgroundServices;
@@ -10,9 +13,9 @@ public class ConnectorSyncBudgetTests
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
-    public void Constructor_RejectsABudgetNoSyncCouldFit(int size)
+    public void Constructor_RejectsABudgetNoSyncCouldFit(int slots)
     {
-        var construct = () => new ConnectorSyncBudget(size);
+        var construct = () => new ConnectorSyncBudget(slots);
 
         construct.Should().Throw<ArgumentOutOfRangeException>();
     }
@@ -20,7 +23,7 @@ public class ConnectorSyncBudgetTests
     [Fact]
     public async Task AcquireAsync_HoldsAtTheBudget_UntilALeaseIsReturned()
     {
-        using var budget = new ConnectorSyncBudget(maxConcurrentTenantSyncs: 1);
+        var budget = new ConnectorSyncBudget(slots: 1);
 
         var held = await budget.AcquireAsync(CancellationToken.None);
         var waiting = budget.AcquireAsync(CancellationToken.None).AsTask();
@@ -42,7 +45,7 @@ public class ConnectorSyncBudgetTests
     [Fact]
     public async Task Lease_DisposedTwice_ReturnsTheSlotOnce()
     {
-        using var budget = new ConnectorSyncBudget(maxConcurrentTenantSyncs: 1);
+        var budget = new ConnectorSyncBudget(slots: 1);
 
         var lease = await budget.AcquireAsync(CancellationToken.None);
         lease.Dispose();
@@ -54,7 +57,7 @@ public class ConnectorSyncBudgetTests
     [Fact]
     public async Task AcquireAsync_CancelledWhileWaiting_LeavesTheHeldSlotAlone()
     {
-        using var budget = new ConnectorSyncBudget(maxConcurrentTenantSyncs: 1);
+        var budget = new ConnectorSyncBudget(slots: 1);
         using var cts = new CancellationTokenSource();
 
         using var held = await budget.AcquireAsync(CancellationToken.None);
@@ -67,35 +70,64 @@ public class ConnectorSyncBudgetTests
     }
 
     [Fact]
-    public void NextStartupOffset_IsOneStaggerMoreForEachPollerAfterTheFirst()
+    public void NextStartupOffset_DividesThePollIntervalAmongThePollers_InStartOrder()
     {
-        using var budget = new ConnectorSyncBudget(startupStagger: TimeSpan.FromSeconds(4));
+        var budget = new ConnectorSyncBudget(pollerCount: 4);
+        var interval = TimeSpan.FromSeconds(60);
 
-        budget.NextStartupOffset().Should().Be(TimeSpan.Zero);
-        budget.NextStartupOffset().Should().Be(TimeSpan.FromSeconds(4));
-        budget.NextStartupOffset().Should().Be(TimeSpan.FromSeconds(8));
+        budget.NextStartupOffset(interval).Should().Be(TimeSpan.Zero);
+        budget.NextStartupOffset(interval).Should().Be(TimeSpan.FromSeconds(15));
+        budget.NextStartupOffset(interval).Should().Be(TimeSpan.FromSeconds(30));
+        budget.NextStartupOffset(interval).Should().Be(TimeSpan.FromSeconds(45));
+        budget.NextStartupOffset(interval).Should().Be(TimeSpan.Zero, "a poller beyond the count wraps");
     }
 
     [Fact]
     public void FromConfiguration_WithNothingSet_RunsOnTheDefault()
     {
-        using var budget = ConnectorSyncBudget.FromConfiguration(new ConfigurationBuilder().Build());
+        var budget = ConnectorSyncBudget.FromConfiguration(
+            new ConfigurationBuilder().Build(), new ServiceCollection());
 
-        budget.MaxConcurrentTenantSyncs.Should().Be(ConnectorSyncBudget.DefaultMaxConcurrentTenantSyncs);
-        budget.StartupStagger.Should().Be(ConnectorSyncBudget.DefaultStartupStagger);
+        budget.Slots.Should().Be(ConnectorSyncBudget.DefaultSlots);
+        budget.PollerCount.Should().Be(1, "a host with no pollers still needs a valid budget");
     }
 
     [Theory]
-    [InlineData("Connectors:Settings:MaxConcurrentTenantSyncs")]
-    [InlineData("Parameters:Connectors:Settings:MaxConcurrentTenantSyncs")]
+    [InlineData("Connectors:Settings:SyncSlots")]
+    [InlineData("Parameters:Connectors:Settings:SyncSlots")]
     public void FromConfiguration_ReadsTheSharedConnectorSettings(string key)
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection([new KeyValuePair<string, string?>(key, "6")])
             .Build();
 
-        using var budget = ConnectorSyncBudget.FromConfiguration(configuration);
+        var budget = ConnectorSyncBudget.FromConfiguration(configuration, new ServiceCollection());
 
-        budget.MaxConcurrentTenantSyncs.Should().Be(6);
+        budget.Slots.Should().Be(6);
+    }
+
+    /// <summary>
+    /// The phase count has to be the pollers actually scheduled, so a connector that is added or
+    /// disabled changes the stagger without anyone editing a constant.
+    /// </summary>
+    [Fact]
+    public void FromConfiguration_CountsTheRegisteredPollers()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        services.AddConnectors(configuration, typeof(ConnectorBackgroundService<,>));
+        services.AddHostedService<UnrelatedHostedService>();
+
+        var budget = ConnectorSyncBudget.FromConfiguration(configuration, services);
+
+        var pollers = services.Count(d =>
+            d.ServiceType == typeof(IHostedService) && d.ImplementationType != typeof(UnrelatedHostedService));
+        pollers.Should().BeGreaterThan(1);
+        budget.PollerCount.Should().Be(pollers);
+    }
+
+    private sealed class UnrelatedHostedService : BackgroundService
+    {
+        protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorSyncBudgetTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorSyncBudgetTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Nocturne.API.Services.BackgroundServices;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.BackgroundServices;
+
+public class ConnectorSyncBudgetTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_RejectsABudgetNoSyncCouldFit(int size)
+    {
+        var construct = () => new ConnectorSyncBudget(size);
+
+        construct.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public async Task AcquireAsync_HoldsAtTheBudget_UntilALeaseIsReturned()
+    {
+        using var budget = new ConnectorSyncBudget(maxConcurrentTenantSyncs: 1);
+
+        var held = await budget.AcquireAsync(CancellationToken.None);
+        var waiting = budget.AcquireAsync(CancellationToken.None).AsTask();
+
+        (await Task.WhenAny(waiting, Task.Delay(TimeSpan.FromMilliseconds(200))))
+            .Should().NotBe(waiting, "the budget is exhausted while the first lease is held");
+        budget.InFlight.Should().Be(1);
+
+        held.Dispose();
+
+        (await Task.WhenAny(waiting, Task.Delay(TimeSpan.FromSeconds(5))))
+            .Should().Be(waiting, "returning the lease hands the slot to the waiter");
+        budget.InFlight.Should().Be(1);
+
+        (await waiting).Dispose();
+        budget.InFlight.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Lease_DisposedTwice_ReturnsTheSlotOnce()
+    {
+        using var budget = new ConnectorSyncBudget(maxConcurrentTenantSyncs: 1);
+
+        var lease = await budget.AcquireAsync(CancellationToken.None);
+        lease.Dispose();
+        lease.Dispose();
+
+        budget.InFlight.Should().Be(0, "a second dispose must not over-release the semaphore");
+    }
+
+    [Fact]
+    public async Task AcquireAsync_CancelledWhileWaiting_LeavesTheHeldSlotAlone()
+    {
+        using var budget = new ConnectorSyncBudget(maxConcurrentTenantSyncs: 1);
+        using var cts = new CancellationTokenSource();
+
+        using var held = await budget.AcquireAsync(CancellationToken.None);
+        var waiting = budget.AcquireAsync(cts.Token).AsTask();
+
+        cts.Cancel();
+
+        await waiting.Invoking(t => t).Should().ThrowAsync<OperationCanceledException>();
+        budget.InFlight.Should().Be(1);
+    }
+
+    [Fact]
+    public void NextStartupOffset_IsOneStaggerMoreForEachPollerAfterTheFirst()
+    {
+        using var budget = new ConnectorSyncBudget(startupStagger: TimeSpan.FromSeconds(4));
+
+        budget.NextStartupOffset().Should().Be(TimeSpan.Zero);
+        budget.NextStartupOffset().Should().Be(TimeSpan.FromSeconds(4));
+        budget.NextStartupOffset().Should().Be(TimeSpan.FromSeconds(8));
+    }
+
+    [Fact]
+    public void FromConfiguration_WithNothingSet_RunsOnTheDefault()
+    {
+        using var budget = ConnectorSyncBudget.FromConfiguration(new ConfigurationBuilder().Build());
+
+        budget.MaxConcurrentTenantSyncs.Should().Be(ConnectorSyncBudget.DefaultMaxConcurrentTenantSyncs);
+        budget.StartupStagger.Should().Be(ConnectorSyncBudget.DefaultStartupStagger);
+    }
+
+    [Theory]
+    [InlineData("Connectors:Settings:MaxConcurrentTenantSyncs")]
+    [InlineData("Parameters:Connectors:Settings:MaxConcurrentTenantSyncs")]
+    public void FromConfiguration_ReadsTheSharedConnectorSettings(string key)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection([new KeyValuePair<string, string?>(key, "6")])
+            .Build();
+
+        using var budget = ConnectorSyncBudget.FromConfiguration(configuration);
+
+        budget.MaxConcurrentTenantSyncs.Should().Be(6);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
@@ -36,6 +36,7 @@ public class NightscoutRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString);
         var sut = new NightscoutConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NightscoutConnectorBackgroundService>.Instance);
 
         // Act & Assert — should not throw
@@ -56,6 +57,7 @@ public class NightscoutRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString);
         var sut = new NightscoutConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NightscoutConnectorBackgroundService>.Instance);
 
         // Act & Assert — should not throw
@@ -75,6 +77,7 @@ public class NightscoutRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString);
         var sut = new NightscoutConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NightscoutConnectorBackgroundService>.Instance);
 
         // Act & Assert — should not throw on repeated calls
@@ -102,6 +105,7 @@ public class NightscoutRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString, config);
         var sut = new NightscoutConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NightscoutConnectorBackgroundService>.Instance);
 
         // Act & Assert — should skip the tenant without throwing
@@ -128,6 +132,7 @@ public class NightscoutRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString, config);
         var sut = new NightscoutConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NightscoutConnectorBackgroundService>.Instance);
 
         // Act & Assert — should skip the tenant without throwing
@@ -171,7 +176,7 @@ public class NightscoutRealtimeListenerTests
 
         var logger = new ListLogger<NightscoutConnectorBackgroundService>();
         var serviceProvider = BuildServiceProvider(connectionString, config);
-        var sut = new NightscoutConnectorBackgroundService(serviceProvider, logger);
+        var sut = new NightscoutConnectorBackgroundService(serviceProvider, new ConnectorSyncBudget(), logger);
 
         // Act
         await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
@@ -201,7 +206,7 @@ public class NightscoutRealtimeListenerTests
 
         var logger = new ListLogger<NightscoutConnectorBackgroundService>();
         var serviceProvider = BuildServiceProvider(connectionString, config);
-        var sut = new NightscoutConnectorBackgroundService(serviceProvider, logger);
+        var sut = new NightscoutConnectorBackgroundService(serviceProvider, new ConnectorSyncBudget(), logger);
 
         // Act
         await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
@@ -233,6 +238,7 @@ public class NightscoutRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString, config);
         var sut = new NightscoutConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NightscoutConnectorBackgroundService>.Instance);
 
         var dead = new SocketIO(new Uri("http://127.0.0.1:9"));
@@ -263,7 +269,7 @@ public class NightscoutRealtimeListenerTests
 
         var logger = new ListLogger<NightscoutConnectorBackgroundService>();
         var sut = new NightscoutConnectorBackgroundService(
-            BuildServiceProvider(connectionString, config), logger);
+            BuildServiceProvider(connectionString, config), new ConnectorSyncBudget(), logger);
 
         await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
 

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
@@ -30,6 +30,7 @@ public class NocturneRemoteRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString);
         var sut = new NocturneRemoteConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
 
         // Act & Assert — should not throw
@@ -50,6 +51,7 @@ public class NocturneRemoteRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString);
         var sut = new NocturneRemoteConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
 
         // Act & Assert — should not throw
@@ -69,6 +71,7 @@ public class NocturneRemoteRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString);
         var sut = new NocturneRemoteConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
 
         // Act & Assert — should not throw on repeated calls
@@ -97,6 +100,7 @@ public class NocturneRemoteRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString, config);
         var sut = new NocturneRemoteConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
 
         // Act & Assert — should skip the tenant without throwing
@@ -124,6 +128,7 @@ public class NocturneRemoteRealtimeListenerTests
         var serviceProvider = BuildServiceProvider(connectionString, config);
         var sut = new NocturneRemoteConnectorBackgroundService(
             serviceProvider,
+            new ConnectorSyncBudget(),
             NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
 
         // Act & Assert — should skip the tenant without throwing
@@ -150,7 +155,7 @@ public class NocturneRemoteRealtimeListenerTests
 
         var logger = new ListLogger<NocturneRemoteConnectorBackgroundService>();
         var sut = new NocturneRemoteConnectorBackgroundService(
-            BuildServiceProvider(connectionString, config), logger);
+            BuildServiceProvider(connectionString, config), new ConnectorSyncBudget(), logger);
 
         await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
 
@@ -178,7 +183,7 @@ public class NocturneRemoteRealtimeListenerTests
 
         var logger = new ListLogger<NocturneRemoteConnectorBackgroundService>();
         var sut = new NocturneRemoteConnectorBackgroundService(
-            BuildServiceProvider(connectionString, config), logger);
+            BuildServiceProvider(connectionString, config), new ConnectorSyncBudget(), logger);
 
         await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
 


### PR DESCRIPTION
## Problem

Every connector poller (`ConnectorBackgroundService<TConfig>`) fans out over all active tenants with `Parallel.ForEachAsync` under its own `MaxConcurrentTenantSyncs = 8`, and each tenant sync opens its own DI scope and at least one database connection (the config load included). There is one poller per installed connector — 13 scheduled at runtime — and they all share `StartupDelay = 5s` and `PollInterval = 1 minute`, so they tick on the same second. Peak demand at a tick is therefore roughly `13 × 8 + 13 lookup scopes ≈ 117` connections inside ~150 ms. Tenant count does not enter it: the peak is `connectors × per-service cap`.

Against a Postgres `max_connections` of 100 that is a refusal. In production it refused ~120 connections an hour for 28 hours (`FATAL: sorry, too many clients already`) from the moment a second application database joined the same server, and the app side reported it only as a bare `Microsoft.EntityFrameworkCore.Database.Connection` error with no body. Observed burst: 71 connections opening between 10:24:06.960 and 10:24:07.106.

The doc comment on `MaxConcurrentTenantSyncs` said it "caps resource use (DB connections)". That was true per service and misleading in total.

## Change

- **`ConnectorSyncBudget`** (new, singleton): a `SemaphoreSlim` every poller takes a lease from around the whole of a tenant's sync, config load included. Default 24 slots; overridable with `Connectors:Settings:SyncSlots` (also read from the `Parameters:`-prefixed copy Aspire writes). Rejects a size below 1.
- **Per-service cap kept** as one connector's *share* of the budget, so a connector whose tenants are all stuck (auth-retry storm) cannot take every slot from the others. The comment on it now says that.
- **Phase offsets**: the budget counts the pollers registered in DI and divides the poll interval among them, handed out in start order, so 13 pollers on a one-minute interval tick ~4.6 s apart instead of together. Adding a connector re-spaces them; nothing hardcodes the count. The per-tenant interval check means no tenant's sync is delayed by more than its poller's offset, and only after a restart.
- **Slot starvation is logged**: a tenant that waits more than 30 s for a slot is reported with the budget's occupancy, so a saturated budget does not present only as late syncs.
- Lease acquisition waits on the stopping token, and the per-tenant timeout starts only once a slot is held, so queueing for a slot is not charged to the tenant.
- `appsettings.example.json` documents the new key next to `MaxPoolSize`.

## What this does and does not fix

Peak *concurrent tenant syncs* at a tick goes from up to 104 to at most 24, plus 13 lookup scopes that the phasing now spreads out. A lease is a sync, not a connection: a sync may hold more than one connection while its repositories write, so the connection ceiling is 24 × (connections per sync) + 13, still well under the 100-connection pool where before it exceeded it. Unleased and unchanged: `NightscoutConnectorBackgroundService.StartRealtimeListenersAsync` (up to 8 scopes every 5 minutes, held across a 10 s socket connect, so leasing it would starve syncs on network time) and the one scope a user-triggered `ConnectorSyncService` sync opens.

Per-tick database *work* is unchanged: the same ~858 config loads a minute run (66 tenants × 13 pollers), just through 24 slots instead of 104. That is nightscout/nocturne#1144, the same loop from the wasted-round-trips angle, blocked on RLS. This PR is a connection-residency fix, not a query-load fix.

Fairness trade, stated plainly: three connectors with 8 stuck tenants each (3-minute `PerTenantSyncTimeout`) now hold the whole budget and stall every poller for 3 minutes, where before each connector's outage was its own. The starvation log is what makes that diagnosable.

## Verification

- `Nocturne.API.Tests`: 6698 passed, 0 failed.
- New tests: `ConnectorSyncBudgetTests` (lease blocks at the budget, double-dispose releases once, cancellation while waiting leaves held slots alone, offsets divide the interval by poller count and wrap, both configuration keys resolve, the poller count comes from the registered hosted services), plus three poller tests: a second poller's tenant sync waits while the first holds the only slot and its config loader is not reached until the slot is released; a tenant queued past its per-tenant timeout still runs; a poller after the first waits its phase offset before its first tick.
- Mutation checks, each failing exactly the test written for it: delete the lease; drop the phase offset; move the lease to cover only `PerformSyncAsync` (the config load then runs unleased); start the per-tenant timeout before acquiring the slot.
- Hostile review (fresh-context subagent) verified deadlock paths, shutdown behaviour with the delay outside the try, DI resolution across all test projects, and that the commented `Connectors:Settings` block in `appsettings.example.json` binds to a null section and changes nothing.

Post-deploy: `SELECT application_name, count(*), min(backend_start)::time, max(backend_start)::time FROM pg_stat_activity WHERE usename = 'nocturne_app' GROUP BY 1` should show the open window widening well past 150 ms and the count staying under the budget, and the Postgres log should stop recording `remaining connection slots` refusals.

https://claude.ai/code/session_01XXKK1F6PUBy4c82jV57mMa
