### PR TITLE
fix(dedup): page reconcile links by a persisted (sys_created_at, id) cursor

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -881,7 +881,7 @@ public static class ServiceRegistrationExtensions
         // Background sweep
         services.AddHostedService<AlertSweepService>();
 
-        // Periodic watermark-driven deduplication reconciliation across active tenants
+        // Periodic cursor-driven deduplication reconciliation across active tenants
         services.AddHostedService<Nocturne.API.Services.BackgroundServices.DeduplicationReconciliationBackgroundService>();
 
         return services;

--- a/src/API/Nocturne.API/Services/BackgroundServices/DeduplicationReconciliationBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/DeduplicationReconciliationBackgroundService.cs
@@ -8,10 +8,10 @@ using Nocturne.Infrastructure.Data;
 namespace Nocturne.API.Services.BackgroundServices;
 
 /// <summary>
-/// Periodically drives watermark-based deduplication reconciliation for every active tenant.
+/// Periodically drives cursor-based deduplication reconciliation for every active tenant.
 /// On each tick it enumerates active tenants and calls
 /// <see cref="IDeduplicationService.ReconcileNewLinksAsync(int, int, CancellationToken)"/> for each,
-/// merging duplicate canonical groups created since the tenant's last watermark.
+/// merging duplicate canonical groups created since the tenant's persisted cursor.
 /// </summary>
 /// <remarks>
 /// Single-instance deployment only. If the API is ever scaled out, gate per-tenant reconcile with a

--- a/src/Core/Nocturne.Core.Contracts/Infrastructure/IDeduplicationService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Infrastructure/IDeduplicationService.cs
@@ -90,9 +90,9 @@ public interface IDeduplicationService
 
     /// <summary>
     /// Reconcile newly-created linked_records for the current tenant in bounded chunks,
-    /// merging duplicate canonical groups. Processes links with SysCreatedAt at or after
-    /// the tenant's watermark (minus a small overlap), advancing the watermark per batch.
-    /// Stops when caught up or after maxBatches. Returns groups merged and whether caught up.
+    /// merging duplicate canonical groups. Pages links in (SysCreatedAt, Id) order from the
+    /// tenant's persisted cursor up to a short lag behind the present, advancing the cursor per
+    /// batch. Stops when caught up or after maxBatches. Returns groups merged and whether caught up.
     /// </summary>
     Task<ReconcileResult> ReconcileNewLinksAsync(int batchSize, int maxBatches, CancellationToken cancellationToken = default);
 }

--- a/src/Core/Nocturne.Core.Models/DeduplicationModels.cs
+++ b/src/Core/Nocturne.Core.Models/DeduplicationModels.cs
@@ -114,7 +114,7 @@ public record DeduplicationInput(Guid RecordId, long Mills, string DataSource, M
 public record DeduplicationBatchResult(int Processed, int GroupsCreated, int RecordsLinked, int DuplicateGroups);
 
 /// <summary>
-/// Result of a watermark-bounded reconcile pass: the number of duplicate groups merged
+/// Result of a cursor-bounded reconcile pass: the number of duplicate groups merged
 /// and whether the pass caught up to the end of the newly-created links.
 /// </summary>
 public record ReconcileResult(int GroupsMerged, bool CaughtUp);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DedupReconcileStateEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DedupReconcileStateEntity.cs
@@ -5,8 +5,8 @@ namespace Nocturne.Infrastructure.Data.Entities;
 
 /// <summary>
 /// PostgreSQL entity recording how far dedup reconciliation has processed for a tenant.
-/// One row per tenant, keyed on the ingestion time (<c>linked_records.sys_created_at</c>)
-/// of the last reconciled link.
+/// One row per tenant, holding the last reconciled link as a
+/// (<c>sys_created_at</c>, <c>id</c>) keyset cursor.
 /// </summary>
 [Table("dedup_reconcile_state")]
 public class DedupReconcileStateEntity : ITenantScoped
@@ -20,8 +20,15 @@ public class DedupReconcileStateEntity : ITenantScoped
 
     /// <summary>
     /// Ingestion time (<c>linked_records.sys_created_at</c>) of the last reconciled link.
-    /// Reconciliation resumes from records created after this point.
     /// </summary>
     [Column("last_reconciled_link_created_at")]
     public DateTime LastReconciledLinkCreatedAt { get; set; }
+
+    /// <summary>
+    /// Id of the last reconciled link, ordering the links that share
+    /// <see cref="LastReconciledLinkCreatedAt"/>. Null on rows written before the column existed;
+    /// reconciliation then resumes at the first link of that instant.
+    /// </summary>
+    [Column("last_reconciled_link_id")]
+    public Guid? LastReconciledLinkId { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260908125351_AddDedupReconcileCursorLinkId.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260908125351_AddDedupReconcileCursorLinkId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260908125351_AddDedupReconcileCursorLinkId")]
+    partial class AddDedupReconcileCursorLinkId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260908125351_AddDedupReconcileCursorLinkId.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260908125351_AddDedupReconcileCursorLinkId.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDedupReconcileCursorLinkId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "last_reconciled_link_id",
+                table: "dedup_reconcile_state",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_reconciled_link_id",
+                table: "dedup_reconcile_state");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -96,11 +96,13 @@ public class DeduplicationService : IDeduplicationService
     private const int DedupChunkSize = 500;
 
     /// <summary>
-    /// How far before the watermark each reconcile chunk re-reads. Covers links whose
-    /// SysCreatedAt straddles a previous batch boundary; re-processing them is idempotent
-    /// because <see cref="MergeDuplicateGroupsAsync"/> is a no-op once a region is merged.
+    /// How far behind the present <see cref="ReconcileNewLinksAsync"/> reads. A link's
+    /// <c>sys_created_at</c> is its ingest transaction's start time, so a transaction still open
+    /// when a pass reads past that instant would commit a link the cursor has already passed.
+    /// Links younger than this are left for a later pass, by which time any transaction shorter
+    /// than the lag has committed.
     /// </summary>
-    private static readonly TimeSpan ReconcileOverlap = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan CommitVisibilityLag = TimeSpan.FromMinutes(2);
 
     /// <summary>
     /// A record's match criteria paired with its soft-deleted status, keyed by record id
@@ -1088,27 +1090,15 @@ public class DeduplicationService : IDeduplicationService
         int maxBatches,
         CancellationToken cancellationToken = default)
     {
-        var watermark = await GetWatermarkAsync(cancellationToken);
-
-        // Re-read from a little before the watermark so links whose SysCreatedAt straddled the
-        // previous batch's boundary aren't missed. Re-processing is idempotent: once a region is
-        // merged, MergeDuplicateGroupsAsync finds nothing more to collapse there.
-        // A fresh tenant (deploy-day backfill) has no watermark yet, so it defaults to
-        // DateTime.MinValue — subtracting the overlap would underflow, so skip it and start at MinValue.
-        var cutoff = watermark == DateTime.MinValue ? DateTime.MinValue : watermark - ReconcileOverlap;
+        var cursor = await GetCursorAsync(cancellationToken);
+        var horizon = DateTime.UtcNow - CommitVisibilityLag;
 
         var merged = 0;
         var caughtUp = false;
-        var previousMaxCreated = DateTime.MinValue;
 
         for (var batchNo = 0; batchNo < maxBatches; batchNo++)
         {
-            // Tenant-scoped automatically via the global query filter.
-            var batch = await _context.LinkedRecords
-                .Where(lr => lr.SysCreatedAt >= cutoff)
-                .OrderBy(lr => lr.SysCreatedAt)
-                .Take(batchSize)
-                .ToListAsync(cancellationToken);
+            var batch = await LinksAfter(cursor, horizon).Take(batchSize).ToListAsync(cancellationToken);
 
             if (batch.Count == 0)
             {
@@ -1130,21 +1120,11 @@ public class DeduplicationService : IDeduplicationService
                 merged += await MergeDuplicateGroupsAsync(type, candidateCanonicalIds, cancellationToken);
             }
 
-            var maxCreated = batch.Max(l => l.SysCreatedAt);
-            await SetWatermarkAsync(maxCreated, cancellationToken);
+            var last = batch[^1];
+            cursor = new ReconcileCursor(last.SysCreatedAt, last.Id);
+            await SetCursorAsync(cursor.Value, cancellationToken);
 
-            // Forward-progress guard: if the batch's max SysCreatedAt did not advance past the
-            // previous batch (e.g. many links share the same instant and a full batch sits on one
-            // boundary), re-reading from cutoff would loop forever — so stop here.
-            if (batchNo > 0 && maxCreated <= previousMaxCreated)
-            {
-                caughtUp = true;
-                break;
-            }
-            previousMaxCreated = maxCreated;
-            cutoff = maxCreated - ReconcileOverlap;
-
-            // A partial batch means we've drained everything at/after the cutoff.
+            // A partial batch means we've drained everything up to the horizon.
             if (batch.Count < batchSize)
             {
                 caughtUp = true;
@@ -1153,6 +1133,33 @@ public class DeduplicationService : IDeduplicationService
         }
 
         return new ReconcileResult(merged, caughtUp);
+    }
+
+    /// <summary>
+    /// The tenant's links in (SysCreatedAt, Id) order, strictly after <paramref name="after"/> and
+    /// created before <paramref name="horizon"/>. Ordering on the id as well lets a page end inside
+    /// a run of links sharing one <c>sys_created_at</c> (a bulk insert stamps every link in the
+    /// transaction with the same instant) and the next page continue from there; a cursor on the
+    /// timestamp alone would re-read or skip the rest of the run.
+    /// </summary>
+    internal IQueryable<LinkedRecordEntity> LinksAfter(ReconcileCursor? after, DateTime horizon)
+    {
+        // Tenant-scoped automatically via the global query filter.
+        var query = _context.LinkedRecords
+            .AsNoTracking()
+            .Where(lr => lr.SysCreatedAt < horizon);
+
+        if (after is { } c)
+        {
+            // The redundant lower bound is what the planner ranges the (tenant_id, sys_created_at)
+            // index on; the disjunction alone is not recognised as a range.
+            query = query.Where(lr => lr.SysCreatedAt >= c.CreatedAt
+                && (lr.SysCreatedAt > c.CreatedAt || lr.Id.CompareTo(c.Id) > 0));
+        }
+
+        return query
+            .OrderBy(lr => lr.SysCreatedAt)
+            .ThenBy(lr => lr.Id);
     }
 
     /// <summary>
@@ -1895,30 +1902,34 @@ public class DeduplicationService : IDeduplicationService
     }
 
     /// <summary>
-    /// Returns the current tenant's reconciliation watermark — the ingestion time of the last
-    /// reconciled link — or <see cref="DateTime.MinValue"/> if reconciliation has never run.
+    /// Returns the current tenant's reconciliation cursor — the last reconciled link — or null if
+    /// reconciliation has never run. A row written before the id column existed resumes at the
+    /// first link of its instant, so the rest of that instant is reconciled again; the merge is
+    /// idempotent.
     /// </summary>
-    internal async Task<DateTime> GetWatermarkAsync(CancellationToken ct)
+    internal async Task<ReconcileCursor?> GetCursorAsync(CancellationToken ct)
     {
         var state = await _context.DedupReconcileState
             .Where(s => s.TenantId == _context.TenantId)
             .FirstOrDefaultAsync(ct);
 
-        return state?.LastReconciledLinkCreatedAt ?? DateTime.MinValue;
+        return state is null
+            ? null
+            : new ReconcileCursor(state.LastReconciledLinkCreatedAt, state.LastReconciledLinkId ?? Guid.Empty);
     }
 
     /// <summary>
-    /// Upserts the current tenant's reconciliation watermark, inserting a row if none exists
+    /// Upserts the current tenant's reconciliation cursor, inserting a row if none exists
     /// or updating the existing one otherwise.
     /// </summary>
-    internal async Task SetWatermarkAsync(DateTime value, CancellationToken ct)
+    internal async Task SetCursorAsync(ReconcileCursor cursor, CancellationToken ct)
     {
         // Npgsql requires Kind=Utc to persist a timestamptz; SQLite tests won't catch a bad caller.
-        value = value.Kind switch
+        var createdAt = cursor.CreatedAt.Kind switch
         {
-            DateTimeKind.Utc => value,
-            DateTimeKind.Local => value.ToUniversalTime(),
-            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            DateTimeKind.Utc => cursor.CreatedAt,
+            DateTimeKind.Local => cursor.CreatedAt.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(cursor.CreatedAt, DateTimeKind.Utc)
         };
 
         var state = await _context.DedupReconcileState
@@ -1928,17 +1939,19 @@ public class DeduplicationService : IDeduplicationService
         if (state is null)
         {
             // single-threaded per tenant; PK guards accidental concurrent insert
-            _context.DedupReconcileState.Add(new DedupReconcileStateEntity
-            {
-                TenantId = _context.TenantId,
-                LastReconciledLinkCreatedAt = value
-            });
+            state = new DedupReconcileStateEntity { TenantId = _context.TenantId };
+            _context.DedupReconcileState.Add(state);
         }
-        else
-        {
-            state.LastReconciledLinkCreatedAt = value;
-        }
+
+        state.LastReconciledLinkCreatedAt = createdAt;
+        state.LastReconciledLinkId = cursor.Id;
 
         await _context.SaveChangesAsync(ct);
     }
 }
+
+/// <summary>
+/// Keyset position of <see cref="DeduplicationService.ReconcileNewLinksAsync"/> in the tenant's
+/// links: the <c>sys_created_at</c> and id of the last link reconciled.
+/// </summary>
+internal readonly record struct ReconcileCursor(DateTime CreatedAt, Guid Id);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -97,10 +97,11 @@ public class DeduplicationService : IDeduplicationService
 
     /// <summary>
     /// How far behind the present <see cref="ReconcileNewLinksAsync"/> reads. A link's
-    /// <c>sys_created_at</c> is its ingest transaction's start time, so a transaction still open
-    /// when a pass reads past that instant would commit a link the cursor has already passed.
-    /// Links younger than this are left for a later pass, by which time any transaction shorter
-    /// than the lag has committed.
+    /// <c>sys_created_at</c> is the API clock when its insert's <c>SaveChanges</c> began
+    /// (<see cref="NocturneDbContext"/> stamps it before opening the transaction), so an insert
+    /// still committing when a pass reads past that instant would land a link the cursor has
+    /// already passed. Links younger than this are left for a later pass, by which time any
+    /// insert shorter than the lag has committed. The horizon is taken from the same clock.
     /// </summary>
     private static readonly TimeSpan CommitVisibilityLag = TimeSpan.FromMinutes(2);
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -13,8 +13,8 @@ namespace Nocturne.Infrastructure.Data.Tests.Services;
 /// Tests for dedup reconciliation in <see cref="DeduplicationService"/>: the reusable
 /// per-record criteria + deleted-status loader (<see cref="MatchCriteria"/> plus soft-deleted
 /// status keyed by record id), merging duplicate canonical groups (full and candidate-bounded,
-/// including transitive chains), the per-tenant reconciliation watermark round-trip, and the
-/// watermark-bounded chunked reconcile pass over newly-created links.
+/// including transitive chains), the per-tenant reconciliation cursor round-trip, and the
+/// cursor-bounded chunked reconcile pass over newly-created links.
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("Category", "Deduplication")]
@@ -682,7 +682,7 @@ public class DeduplicationReconcileTests : IDisposable
     public async Task ReconcileNewLinksAsync_MergesGroupsWithRecentLinks()
     {
         var now = DateTime.UtcNow;
-        await _service.SetWatermarkAsync(now.AddHours(-1), CancellationToken.None);
+        await _service.SetCursorAsync(new ReconcileCursor(now.AddHours(-1), Guid.Empty), CancellationToken.None);
 
         var t = now.AddMinutes(-5);
         var mylife = await AddCarb(t, "mylife-connector", 50);
@@ -690,7 +690,8 @@ public class DeduplicationReconcileTests : IDisposable
         AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
         AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
         await _context.SaveChangesAsync();
-        await SetAllLinkSysCreatedAt(now);
+        var created = now.AddMinutes(-5);
+        await SetAllLinkSysCreatedAt(created);
 
         var result = await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
 
@@ -699,17 +700,18 @@ public class DeduplicationReconcileTests : IDisposable
         var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
         links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
 
-        var watermark = await _service.GetWatermarkAsync(CancellationToken.None);
-        watermark.Should().BeCloseTo(now, TimeSpan.FromSeconds(1));
+        var cursor = await _service.GetCursorAsync(CancellationToken.None);
+        cursor.Should().NotBeNull();
+        cursor!.Value.CreatedAt.Should().BeCloseTo(created, TimeSpan.FromSeconds(1));
     }
 
     [Fact]
-    public async Task ReconcileNewLinksAsync_IgnoresLinksBeforeWatermark()
+    public async Task ReconcileNewLinksAsync_IgnoresLinksBeforeCursor()
     {
         var now = DateTime.UtcNow;
-        await _service.SetWatermarkAsync(now, CancellationToken.None);
+        await _service.SetCursorAsync(new ReconcileCursor(now, Guid.Empty), CancellationToken.None);
 
-        // Links created an hour ago — well before (watermark - overlap), so out of scope.
+        // Links created an hour ago — before the cursor, so already reconciled.
         var t = now.AddHours(-1);
         var mylife = await AddCarb(t, "mylife-connector", 50);
         var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
@@ -729,7 +731,7 @@ public class DeduplicationReconcileTests : IDisposable
     public async Task ReconcileNewLinksAsync_SkipsUnknownRecordType()
     {
         var now = DateTime.UtcNow;
-        await _service.SetWatermarkAsync(now.AddHours(-1), CancellationToken.None);
+        await _service.SetCursorAsync(new ReconcileCursor(now.AddHours(-1), Guid.Empty), CancellationToken.None);
 
         // A valid mergeable pair that should still collapse despite a bogus row in the batch.
         var t = now.AddMinutes(-5);
@@ -753,7 +755,7 @@ public class DeduplicationReconcileTests : IDisposable
             SysCreatedAt = DateTime.UtcNow
         });
         await _context.SaveChangesAsync();
-        await SetAllLinkSysCreatedAt(now);
+        await SetAllLinkSysCreatedAt(now.AddMinutes(-5));
 
         var act = async () => await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
 
@@ -765,11 +767,9 @@ public class DeduplicationReconcileTests : IDisposable
     }
 
     [Fact]
-    public async Task ReconcileNewLinksAsync_FreshTenant_DefaultWatermark_ReconcilesWithoutThrowing()
+    public async Task ReconcileNewLinksAsync_FreshTenant_NoCursor_ReconcilesFromTheStart()
     {
-        // Fresh tenant: no watermark seeded, so GetWatermarkAsync returns DateTime.MinValue.
-        // cutoff = watermark - ReconcileOverlap would underflow (ArgumentOutOfRangeException).
-        (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(DateTime.MinValue);
+        (await _service.GetCursorAsync(CancellationToken.None)).Should().BeNull();
 
         var now = DateTime.UtcNow;
         var t = now.AddMinutes(-5);
@@ -778,46 +778,176 @@ public class DeduplicationReconcileTests : IDisposable
         AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
         AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
         await _context.SaveChangesAsync();
-        await SetAllLinkSysCreatedAt(now);
+        var created = now.AddMinutes(-5);
+        await SetAllLinkSysCreatedAt(created);
 
-        var act = async () => await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
+        var result = await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
 
-        var result = await act.Should().NotThrowAsync();
-        result.Subject.GroupsMerged.Should().Be(1);
+        result.GroupsMerged.Should().Be(1);
         var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
         links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
 
-        // The watermark advances past MinValue.
-        var watermark = await _service.GetWatermarkAsync(CancellationToken.None);
-        watermark.Should().BeCloseTo(now, TimeSpan.FromSeconds(1));
+        var cursor = await _service.GetCursorAsync(CancellationToken.None);
+        cursor.Should().NotBeNull();
+        cursor!.Value.CreatedAt.Should().BeCloseTo(created, TimeSpan.FromSeconds(1));
     }
 
     [Fact]
-    public async Task Watermark_RoundTrips_DefaultsToMinValue()
+    public async Task ReconcileNewLinksAsync_PagesThroughLinksSharingOneCreationInstant()
     {
-        (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(DateTime.MinValue);
+        // One bulk insert stamps every link with the same sys_created_at. Three mergeable pairs,
+        // an hour apart with distinct values so no pair can match another, all created in one
+        // instant; a batch of three cuts through the instant twice. Every pair must still merge,
+        // and the pass must report itself caught up.
+        var now = DateTime.UtcNow;
+        var created = now.AddMinutes(-5);
+        await AddThreePairsCreatedAt(now.AddHours(-6), created);
 
+        var result = await _service.ReconcileNewLinksAsync(batchSize: 3, maxBatches: 10, CancellationToken.None);
+
+        result.GroupsMerged.Should().Be(3);
+        result.CaughtUp.Should().BeTrue();
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(3);
+
+        var cursor = await _service.GetCursorAsync(CancellationToken.None);
+        cursor.Should().NotBeNull();
+        cursor!.Value.CreatedAt.Should().BeCloseTo(created, TimeSpan.FromSeconds(1));
+        cursor.Value.Id.Should().Be(links.Select(l => l.Id).Max(), "the cursor rests on the last link in (sys_created_at, id) order");
+    }
+
+    [Fact]
+    public async Task ReconcileNewLinksAsync_ResumesInsideAnInstantAcrossPasses()
+    {
+        // The persisted cursor carries the id, so a pass that ends part-way through a run of links
+        // sharing one sys_created_at is continued by the next pass rather than restarted. With a
+        // timestamp-only cursor the second pass would re-read the first batch and never move on.
+        var now = DateTime.UtcNow;
+        await AddThreePairsCreatedAt(now.AddHours(-6), now.AddMinutes(-5));
+
+        var merged = 0;
+        var passes = 0;
+        ReconcileResult result;
+        do
+        {
+            result = await _service.ReconcileNewLinksAsync(batchSize: 2, maxBatches: 1, CancellationToken.None);
+            merged += result.GroupsMerged;
+            passes++;
+        } while (!result.CaughtUp && passes < 10);
+
+        result.CaughtUp.Should().BeTrue("six links in batches of two need three full passes and one empty one");
+        passes.Should().Be(4);
+        merged.Should().Be(3);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task ReconcileNewLinksAsync_LeavesLinksYoungerThanTheLagForALaterPass()
+    {
+        // A link's sys_created_at is its ingest transaction's start; a sibling from the same
+        // transaction may not have committed yet. Links created just now stay for a later pass.
+        var now = DateTime.UtcNow;
+        var t = now.AddHours(-1);
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
+        await _context.SaveChangesAsync();
+        await SetAllLinkSysCreatedAt(now);
+
+        var young = await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
+
+        young.GroupsMerged.Should().Be(0);
+        young.CaughtUp.Should().BeTrue();
+        (await _service.GetCursorAsync(CancellationToken.None)).Should().BeNull();
+
+        await SetAllLinkSysCreatedAt(now.AddMinutes(-3));
+
+        var aged = await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
+
+        aged.GroupsMerged.Should().Be(1);
+    }
+
+    [Fact]
+    public void LinksAfter_OnPostgres_RangesOnTheCreationIndexAndPagesByKeyset()
+    {
+        // The page query must range the (tenant_id, sys_created_at) index and break ties on id,
+        // so a run of links sharing one instant is paged rather than re-read. The SQL is checked
+        // against the Npgsql provider because the SQLite tests above cannot see the shape.
+        using var context = OfflineDbContext.Create();
+        var service = new DeduplicationService(
+            context, new Mock<IServiceScopeFactory>().Object, NullLogger<DeduplicationService>.Instance);
+        var cursor = new ReconcileCursor(new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), Guid.CreateVersion7());
+
+        var sql = service.LinksAfter(cursor, cursor.CreatedAt.AddHours(1)).Take(5000).ToQueryString();
+
+        sql.Should().MatchRegex(@"l\.sys_created_at >= @\w+ AND \(l\.sys_created_at > @\w+ OR l\.id > @\w+\)",
+            "the lower bound ranges the creation index and the keyset continues inside an instant");
+        sql.Should().MatchRegex(@"l\.sys_created_at < @\w+", "the horizon is the upper bound");
+        sql.Should().MatchRegex(@"ORDER BY l\.sys_created_at, l\.id\s+LIMIT", "the order matches the cursor");
+    }
+
+    [Fact]
+    public async Task Cursor_RoundTrips_DefaultsToNull()
+    {
+        (await _service.GetCursorAsync(CancellationToken.None)).Should().BeNull();
+
+        var cursor = new ReconcileCursor(new DateTime(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc), Guid.CreateVersion7());
+        await _service.SetCursorAsync(cursor, CancellationToken.None);
+
+        (await _service.GetCursorAsync(CancellationToken.None)).Should().Be(cursor);
+    }
+
+    [Fact]
+    public async Task Cursor_WrittenBeforeTheIdColumn_ResumesAtTheStartOfItsInstant()
+    {
         var t = new DateTime(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc);
-        await _service.SetWatermarkAsync(t, CancellationToken.None);
+        _context.DedupReconcileState.Add(new DedupReconcileStateEntity
+        {
+            TenantId = TestTenantId,
+            LastReconciledLinkCreatedAt = t,
+            LastReconciledLinkId = null
+        });
+        await _context.SaveChangesAsync();
 
-        (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(t);
+        (await _service.GetCursorAsync(CancellationToken.None)).Should().Be(new ReconcileCursor(t, Guid.Empty));
     }
 
     [Fact]
-    public async Task Watermark_SetTwice_Updates()
+    public async Task Cursor_SetTwice_Updates()
     {
-        var t1 = new DateTime(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc);
-        var t2 = new DateTime(2026, 5, 31, 9, 30, 0, DateTimeKind.Utc);
+        var first = new ReconcileCursor(new DateTime(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc), Guid.CreateVersion7());
+        var second = new ReconcileCursor(new DateTime(2026, 5, 31, 9, 30, 0, DateTimeKind.Utc), Guid.CreateVersion7());
 
-        await _service.SetWatermarkAsync(t1, CancellationToken.None);
-        await _service.SetWatermarkAsync(t2, CancellationToken.None);
+        await _service.SetCursorAsync(first, CancellationToken.None);
+        await _service.SetCursorAsync(second, CancellationToken.None);
 
-        (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(t2);
+        (await _service.GetCursorAsync(CancellationToken.None)).Should().Be(second);
 
         // Upsert must update the single row, not create a duplicate.
         var rows = await _context.DedupReconcileState.IgnoreQueryFilters()
             .Where(s => s.TenantId == TestTenantId).CountAsync();
         rows.Should().Be(1);
+    }
+
+    /// <summary>
+    /// Three cross-source carb pairs an hour apart with distinct values, so each pair merges with
+    /// itself and nothing else, all six links stamped with the same <paramref name="createdAt"/>.
+    /// </summary>
+    private async Task AddThreePairsCreatedAt(DateTime firstEvent, DateTime createdAt)
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            var t = firstEvent.AddHours(i);
+            var carbs = 50 + i * 10;
+            var mylife = await AddCarb(t, "mylife-connector", carbs);
+            var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", carbs);
+            AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+            AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
+        }
+        await _context.SaveChangesAsync();
+        await SetAllLinkSysCreatedAt(createdAt);
     }
 
     [Fact]
@@ -1133,7 +1263,7 @@ public class DeduplicationReconcileTests : IDisposable
     /// Overrides <see cref="LinkedRecordEntity.SysCreatedAt"/> on all of the tenant's links.
     /// The SaveChanges interceptor stamps SysCreatedAt = now only on <c>Added</c> rows, so the
     /// initializer value is ignored on insert; updating already-persisted rows lets tests pin a
-    /// deterministic ingestion time for the watermark-bounded reconcile pass.
+    /// deterministic ingestion time for the cursor-bounded reconcile pass.
     /// </summary>
     private async Task SetAllLinkSysCreatedAt(DateTime sysCreatedAt)
     {


### PR DESCRIPTION
Fixes #1268.

## What was wrong

`ReconcileNewLinksAsync` paged `linked_records` by `sys_created_at` with a 2-minute re-read overlap, and re-applied that overlap between batches of the same tick. Any 2-minute window holding more than one batch (5,000 links — every connector backfill) made the second batch re-read the first, the forward-progress guard fired, and the watermark stayed at the end of the first batch. On the hosted instance every one of the 20 largest tenants was stuck this way, some for four months: the pass re-read the same 5,000 links and re-ran `MergeDuplicateGroupsAsync` over them every 2 minutes, and no link created after the stuck point was ever reconciled. Those statements were 46 % of all Postgres query time since July and about a fifth of the API's managed CPU.

## What changes

- The reconcile position is a **(sys_created_at, id) keyset cursor**, persisted in `dedup_reconcile_state` (new nullable `last_reconciled_link_id`, migration `AddDedupReconcileCursorLinkId`). Pages are read strictly after the cursor and ordered `(sys_created_at, id)`, so a run of links sharing one instant (a bulk insert stamps every link in the transaction with the same `sys_created_at`; one tenant has 128,501 such links) is paged through rather than re-read or skipped, within a tick and across ticks.
- The re-read overlap is replaced by a **2-minute visibility lag**: links younger than `CommitVisibilityLag` are left for a later pass. `sys_created_at` is stamped from the API clock in `UpdateTimestamps` before the insert's transaction opens, and the horizon is read from that same clock, so an insert still committing when a pass reads past its instant is covered as long as it commits within the lag. Same constant, same protection, no re-reading, no cross-clock skew.
- The forward-progress guard is gone; the cursor makes progress unconditional. The batch read is `AsNoTracking`, so `SetCursorAsync`'s `SaveChanges` no longer runs change detection over 5,000 tracked links.
- Rows written before the id column existed resume at the first link of their instant (`Guid.Empty`); that instant is reconciled again, which is idempotent.

## Behavioural deltas to know about

- A duplicate is now merged by the reconcile pass at least 2 minutes after ingest instead of on the next tick; worst case is about 4 minutes rather than 2. Ingest-time dedup is unchanged.
- Every tenant with a stuck watermark will do real catch-up after deploy: up to `MaxBatchesPerTick × BatchSize` = 20,000 links per 2-minute tick until the cursor reaches the present (the largest tenant has ~780k links, so roughly 80 minutes). CPU stays at today's level during catch-up and then drops.

## Tests

`DeduplicationReconcileTests`: the existing reconcile tests moved to the cursor API and to link timestamps older than the lag; new tests cover paging through six links that share one `sys_created_at` in batches of three, resuming inside that instant across passes with `maxBatches: 1` (the exact scenario that used to stall), leaving links younger than the lag for a later pass, the pre-column null-id resume, cursor round-trips, and the Postgres SQL shape of the page query (index range on `sys_created_at`, `id` tie-break, `ORDER BY sys_created_at, id LIMIT`) against the Npgsql provider via `ToQueryString`.

## Verifying in production

`pg_stat_statements`: the `linked_records … sys_created_at >= $1 … ORDER BY … LIMIT` statement is replaced by one with `"sys_created_at" >= $1 AND ("sys_created_at" > $1 OR "id" > $2) … ORDER BY "sys_created_at", "id" LIMIT`; once tenants are caught up its rows-per-call should fall from ~3,300 to single digits and the `MergeDuplicateGroupsAsync` neighbour queries with it. `dedup_reconcile_state.last_reconciled_link_created_at` should sit within a few minutes of `now()` for every active tenant.


## Hostile review

Ran as a fresh-context review of the branch: three mutations (`CompareTo > 0` to `>= 0`, dropping the id tie-break, restoring the timestamp-only cursor) are each caught by the new tests; boundary, `DateTime.Kind`, tenant-filter, tracker-state and migration claims verified. Two wording findings (the lag comment described `sys_created_at` as a DB-side transaction time; three leftover "watermark" comments) are fixed in the second commit. One caveat it could not verify from a dev box: the Incremental Sort plan for the 128k-links-in-one-instant tenant, which is one-off catch-up work.
