### PR TITLE
perf(data): detect changes once per save instead of three times

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -2484,8 +2484,16 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     /// <returns>The number of state entries written to the database</returns>
     public override int SaveChanges()
     {
-        UpdateTimestamps();
-        return base.SaveChanges();
+        var autoDetectChanges = DetectChangesOnceForSave();
+        try
+        {
+            UpdateTimestamps();
+            return base.SaveChanges();
+        }
+        finally
+        {
+            ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+        }
     }
 
     /// <summary>
@@ -2495,8 +2503,40 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     /// <returns>A task that represents the asynchronous save operation. The task result contains the number of state entries written to the database</returns>
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {
-        UpdateTimestamps();
-        return await base.SaveChangesAsync(cancellationToken);
+        var autoDetectChanges = DetectChangesOnceForSave();
+        try
+        {
+            UpdateTimestamps();
+            return await base.SaveChangesAsync(cancellationToken);
+        }
+        finally
+        {
+            ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+        }
+    }
+
+    /// <summary>
+    /// Runs the single change-detection pass a save needs, then disables auto-detection for the
+    /// rest of it. Left enabled, detection repeats for every <c>ChangeTracker.Entries()</c> call in
+    /// the pipeline — <see cref="UpdateTimestamps"/>, then
+    /// <see cref="Interceptors.MutationAuditInterceptor"/>, then EF's own pass — and each pass
+    /// re-parses two <c>JsonDocument</c>s per jsonb column of every tracked entity through
+    /// <see cref="JsonbStringComparer"/>. Everything downstream must therefore record its writes
+    /// through the change tracker rather than by assigning CLR properties.
+    /// A caller that has already disabled detection is left alone: nothing is detected on its
+    /// behalf, exactly as before.
+    /// </summary>
+    /// <returns>The value <c>AutoDetectChangesEnabled</c> must be restored to once the save ends.</returns>
+    private bool DetectChangesOnceForSave()
+    {
+        var wasEnabled = ChangeTracker.AutoDetectChangesEnabled;
+        if (wasEnabled)
+        {
+            ChangeTracker.DetectChanges();
+            ChangeTracker.AutoDetectChangesEnabled = false;
+        }
+
+        return wasEnabled;
     }
 
     /// <summary>
@@ -2522,28 +2562,36 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             var stampUpdated = isAdded || HasNonTimestampModification(entry);
 
             // System tracking columns (sys_created_at / sys_updated_at) on tenant data.
-            if (isAdded && entry.Entity is ISystemCreated systemCreated)
+            if (isAdded && entry.Entity is ISystemCreated)
             {
-                systemCreated.SysCreatedAt = utcNow;
+                Stamp(entry, nameof(ISystemCreated.SysCreatedAt), utcNow);
             }
-            if (stampUpdated && entry.Entity is ISystemTimestamped systemTimestamped)
+            if (stampUpdated && entry.Entity is ISystemTimestamped)
             {
-                systemTimestamped.SysUpdatedAt = utcNow;
+                Stamp(entry, nameof(ISystemTimestamped.SysUpdatedAt), utcNow);
             }
 
             // Auth/identity tables use the created_at / updated_at convention instead.
-            if (isAdded && entry.Entity is IEntityCreated entityCreated)
+            if (isAdded && entry.Entity is IEntityCreated)
             {
-                entityCreated.CreatedAt = utcNow;
+                Stamp(entry, nameof(IEntityCreated.CreatedAt), utcNow);
             }
-            if (stampUpdated && entry.Entity is IEntityTimestamped entityTimestamped)
+            if (stampUpdated && entry.Entity is IEntityTimestamped)
             {
-                entityTimestamped.UpdatedAt = utcNow;
+                Stamp(entry, nameof(IEntityTimestamped.UpdatedAt), utcNow);
             }
 
-            ApplyEntitySpecificTimestamps(entry.Entity, isAdded, stampUpdated, utcNow);
+            ApplyEntitySpecificTimestamps(entry, isAdded, stampUpdated, utcNow);
         }
     }
+
+    /// <summary>
+    /// Writes a timestamp through the change tracker. <see cref="DetectChangesOnceForSave"/> has
+    /// already turned auto-detection off by the time this runs, so a plain CLR assignment would
+    /// never be flagged modified and would never reach the UPDATE.
+    /// </summary>
+    private static void Stamp(EntityEntry entry, string propertyName, object value)
+        => entry.Property(propertyName).CurrentValue = value;
 
     /// <summary>
     /// True if the entry has a modified property other than the update-timestamp bookkeeping
@@ -2651,21 +2699,21 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     /// Applies timestamps for the few entities whose columns do not follow either the
     /// sys_* or created_at/updated_at conventions covered by the marker interfaces.
     /// </summary>
-    private static void ApplyEntitySpecificTimestamps(object entity, bool isAdded, bool stampUpdated, DateTime utcNow)
+    private static void ApplyEntitySpecificTimestamps(EntityEntry entry, bool isAdded, bool stampUpdated, DateTime utcNow)
     {
-        switch (entity)
+        switch (entry.Entity)
         {
             // Nullable updated_at, set alongside its ISystemTimestamped stamps.
-            case ClockFaceEntity clockFace when stampUpdated:
-                clockFace.UpdatedAt = utcNow;
+            case ClockFaceEntity when stampUpdated:
+                Stamp(entry, nameof(ClockFaceEntity.UpdatedAt), utcNow);
                 break;
             // Mirror of sys_created_at on a DateTimeOffset column, set on insert only.
-            case ConnectorConfigurationEntity connectorConfig when isAdded:
-                connectorConfig.LastModified = utcNow;
+            case ConnectorConfigurationEntity when isAdded:
+                Stamp(entry, nameof(ConnectorConfigurationEntity.LastModified), new DateTimeOffset(utcNow));
                 break;
             // Creation timestamp stored as issued_at, set on insert only.
-            case OAuthRefreshTokenEntity oauthRefreshToken when isAdded:
-                oauthRefreshToken.IssuedAt = utcNow;
+            case OAuthRefreshTokenEntity when isAdded:
+                Stamp(entry, nameof(OAuthRefreshTokenEntity.IssuedAt), utcNow);
                 break;
         }
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -2517,14 +2517,15 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
     /// <summary>
     /// Runs the single change-detection pass a save needs, then disables auto-detection for the
-    /// rest of it. Left enabled, detection repeats for every <c>ChangeTracker.Entries()</c> call in
-    /// the pipeline — <see cref="UpdateTimestamps"/>, then
-    /// <see cref="Interceptors.MutationAuditInterceptor"/>, then EF's own pass — and each pass
-    /// re-parses two <c>JsonDocument</c>s per jsonb column of every tracked entity through
-    /// <see cref="JsonbStringComparer"/>. Everything downstream must therefore record its writes
-    /// through the change tracker rather than by assigning CLR properties.
-    /// A caller that has already disabled detection is left alone: nothing is detected on its
-    /// behalf, exactly as before.
+    /// rest of it. Enabled, detection repeats for every <c>ChangeTracker.Entries()</c> call in the
+    /// pipeline — <see cref="UpdateTimestamps"/>, then
+    /// <see cref="Interceptors.MutationAuditInterceptor"/>, then EF's own pass — and every pass
+    /// re-parses two <c>JsonDocument</c>s per jsonb column of every entity whose value keeps
+    /// comparing equal, through <see cref="JsonbStringComparer"/>. The cost of detecting once is
+    /// that a modification made after this point must be recorded through the change tracker;
+    /// see <see cref="Stamp"/>.
+    /// A caller that has already disabled detection keeps its own contract: nothing is detected on
+    /// its behalf and its value is what gets restored.
     /// </summary>
     /// <returns>The value <c>AutoDetectChangesEnabled</c> must be restored to once the save ends.</returns>
     private bool DetectChangesOnceForSave()
@@ -2562,9 +2563,9 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             var stampUpdated = isAdded || HasNonTimestampModification(entry);
 
             // System tracking columns (sys_created_at / sys_updated_at) on tenant data.
-            if (isAdded && entry.Entity is ISystemCreated)
+            if (isAdded && entry.Entity is ISystemCreated systemCreated)
             {
-                Stamp(entry, nameof(ISystemCreated.SysCreatedAt), utcNow);
+                systemCreated.SysCreatedAt = utcNow;
             }
             if (stampUpdated && entry.Entity is ISystemTimestamped)
             {
@@ -2572,9 +2573,9 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             }
 
             // Auth/identity tables use the created_at / updated_at convention instead.
-            if (isAdded && entry.Entity is IEntityCreated)
+            if (isAdded && entry.Entity is IEntityCreated entityCreated)
             {
-                Stamp(entry, nameof(IEntityCreated.CreatedAt), utcNow);
+                entityCreated.CreatedAt = utcNow;
             }
             if (stampUpdated && entry.Entity is IEntityTimestamped)
             {
@@ -2586,9 +2587,10 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     }
 
     /// <summary>
-    /// Writes a timestamp through the change tracker. <see cref="DetectChangesOnceForSave"/> has
-    /// already turned auto-detection off by the time this runs, so a plain CLR assignment would
-    /// never be flagged modified and would never reach the UPDATE.
+    /// Writes a timestamp through the change tracker, which is how a modified row's stamp reaches
+    /// the UPDATE now that <see cref="DetectChangesOnceForSave"/> has turned auto-detection off.
+    /// Only the modify path needs it: an added row is inserted from its CLR values whatever the
+    /// modified flags say, so those stamps are plain assignments.
     /// </summary>
     private static void Stamp(EntityEntry entry, string propertyName, object value)
         => entry.Property(propertyName).CurrentValue = value;
@@ -2708,12 +2710,12 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
                 Stamp(entry, nameof(ClockFaceEntity.UpdatedAt), utcNow);
                 break;
             // Mirror of sys_created_at on a DateTimeOffset column, set on insert only.
-            case ConnectorConfigurationEntity when isAdded:
-                Stamp(entry, nameof(ConnectorConfigurationEntity.LastModified), new DateTimeOffset(utcNow));
+            case ConnectorConfigurationEntity connectorConfig when isAdded:
+                connectorConfig.LastModified = utcNow;
                 break;
             // Creation timestamp stored as issued_at, set on insert only.
-            case OAuthRefreshTokenEntity when isAdded:
-                Stamp(entry, nameof(OAuthRefreshTokenEntity.IssuedAt), utcNow);
+            case OAuthRefreshTokenEntity oauthRefreshToken when isAdded:
+                oauthRefreshToken.IssuedAt = utcNow;
                 break;
         }
     }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/SaveChangesChangeDetectionTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/SaveChangesChangeDetectionTests.cs
@@ -1,0 +1,248 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Interceptors;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// Pins the single change-detection pass per save. <c>UpdateTimestamps</c>, the
+/// <see cref="MutationAuditInterceptor"/> and EF's own pre-save check each used to trigger a full
+/// <c>DetectChanges</c>, so every jsonb column of every tracked entity was parsed three times per
+/// save. The store is in-memory SQLite so the persisted row, not just the tracker, is observable.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SaveChangesChangeDetectionTests : IDisposable
+{
+    private const string CompactJson = """[{"Time":"00:00","Value":1.5,"TimeAsSeconds":0}]""";
+    private const string JsonbNormalizedJson = """[{"Time": "00:00", "Value": 1.5, "TimeAsSeconds": 0}]""";
+
+    private readonly List<SqliteTestDatabase> _databases = [];
+
+    [Fact]
+    public async Task Save_DetectsChangesExactlyOnce()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = NewStore(tenantId);
+        var id = await SeedScheduleAsync(db, tenantId);
+
+        await using var ctx = NewAuditedContext(db);
+        var schedule = await ctx.BasalSchedules.SingleAsync(s => s.Id == id);
+        schedule.ProfileName = "Renamed";
+
+        var detections = 0;
+        ctx.ChangeTracker.DetectedAllChanges += (_, _) => detections++;
+
+        await ctx.SaveChangesAsync();
+
+        detections.Should().Be(1,
+            "the save detects once up front and runs with auto-detection off from then on");
+    }
+
+    [Fact]
+    public async Task Save_RestoresAutoDetectChanges()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = NewStore(tenantId);
+
+        await using var ctx = db.CreateContext();
+        ctx.Foods.Add(new FoodEntity { Id = Guid.CreateVersion7() });
+
+        await ctx.SaveChangesAsync();
+
+        ctx.ChangeTracker.AutoDetectChangesEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FailedSave_RestoresAutoDetectChanges()
+    {
+        var db = NewStore();
+
+        await using var ctx = db.CreateContext(); // no tenant resolved
+        ctx.Foods.Add(new FoodEntity { Id = Guid.CreateVersion7() });
+
+        var act = () => ctx.SaveChangesAsync();
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        ctx.ChangeTracker.AutoDetectChangesEnabled.Should().BeTrue(
+            "the save restores the flag even when it throws part-way through");
+    }
+
+    [Fact]
+    public async Task Save_WithDetectionAlreadyDisabled_DetectsNothingAndLeavesItDisabled()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = NewStore(tenantId);
+        var id = Guid.CreateVersion7();
+        var before = DateTime.UtcNow;
+
+        await using var ctx = db.CreateContext();
+        ctx.ChangeTracker.AutoDetectChangesEnabled = false;
+
+        var detections = 0;
+        ctx.ChangeTracker.DetectedAllChanges += (_, _) => detections++;
+
+        ctx.Foods.Add(new FoodEntity { Id = id });
+        await ctx.SaveChangesAsync();
+
+        detections.Should().Be(0, "a caller that disabled detection is not detected for");
+        ctx.ChangeTracker.AutoDetectChangesEnabled.Should().BeFalse();
+
+        await using var verify = db.CreateContext();
+        var food = await verify.Foods.SingleAsync(f => f.Id == id);
+        food.SysCreatedAt.Should().BeOnOrAfter(before,
+            "an explicitly added row is still stamped and inserted without detection");
+    }
+
+    [Fact]
+    public async Task JsonbNormalizedRoundTrip_IssuesNoUpdateAndNoAuditRow()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = NewStore(tenantId);
+        var id = await SeedScheduleAsync(db, tenantId);
+
+        DateTime stampedOnInsert;
+        await using (var ctx = NewAuditedContext(db))
+        {
+            var schedule = await ctx.BasalSchedules.SingleAsync(s => s.Id == id);
+            stampedOnInsert = schedule.SysUpdatedAt;
+
+            // What an upsert does: re-assign the compact serialization over the value Postgres
+            // normalized on write.
+            schedule.EntriesJson = JsonbNormalizedJson;
+            await Task.Delay(5);
+            await ctx.SaveChangesAsync();
+
+            ctx.Entry(schedule).State.Should().Be(EntityState.Unchanged);
+        }
+
+        await using (var verify = db.CreateContext())
+        {
+            var schedule = await verify.BasalSchedules.SingleAsync(s => s.Id == id);
+            schedule.SysUpdatedAt.Should().Be(stampedOnInsert, "no UPDATE was issued");
+            (await verify.MutationAuditLog.CountAsync()).Should().Be(0, "no audit row was written");
+        }
+    }
+
+    [Fact]
+    public async Task SemanticJsonChange_StillUpdatesAndAudits()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = NewStore(tenantId);
+        var id = await SeedScheduleAsync(db, tenantId);
+
+        DateTime stampedOnInsert;
+        await using (var ctx = NewAuditedContext(db))
+        {
+            var schedule = await ctx.BasalSchedules.SingleAsync(s => s.Id == id);
+            stampedOnInsert = schedule.SysUpdatedAt;
+
+            schedule.EntriesJson = """[{"Time":"00:00","Value":2.0,"TimeAsSeconds":0}]""";
+            await Task.Delay(5);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = db.CreateContext())
+        {
+            var schedule = await verify.BasalSchedules.SingleAsync(s => s.Id == id);
+            schedule.SysUpdatedAt.Should().BeAfter(stampedOnInsert,
+                "the single detection pass still flags a real modification, and the stamp written "
+                + "through the tracker still reaches the UPDATE");
+            (await verify.MutationAuditLog.CountAsync()).Should().Be(1);
+        }
+    }
+
+    [Fact]
+    public void EveryTimestampMarkerProperty_IsMapped()
+    {
+        using var ctx = OfflineDbContext.Create();
+
+        var markers = new (Type Marker, string Property)[]
+        {
+            (typeof(ISystemCreated), nameof(ISystemCreated.SysCreatedAt)),
+            (typeof(ISystemTimestamped), nameof(ISystemTimestamped.SysUpdatedAt)),
+            (typeof(IEntityCreated), nameof(IEntityCreated.CreatedAt)),
+            (typeof(IEntityTimestamped), nameof(IEntityTimestamped.UpdatedAt)),
+        };
+
+        // UpdateTimestamps stamps these through the change tracker, which throws on a property the
+        // model does not map.
+        foreach (var (marker, property) in markers)
+        {
+            var unmapped = ctx.Model.GetEntityTypes()
+                .Where(t => marker.IsAssignableFrom(t.ClrType) && t.FindProperty(property) is null)
+                .Select(t => t.ClrType.Name)
+                .ToList();
+
+            unmapped.Should().BeEmpty($"{property} must be mapped on every {marker.Name}");
+        }
+    }
+
+    private async Task<Guid> SeedScheduleAsync(SqliteTestDatabase db, Guid tenantId)
+    {
+        var id = Guid.CreateVersion7();
+        await using var ctx = db.CreateContext();
+        ctx.BasalSchedules.Add(new BasalScheduleEntity
+        {
+            Id = id,
+            TenantId = tenantId,
+            Timestamp = DateTime.UtcNow,
+            ProfileName = "Default",
+            EntriesJson = CompactJson,
+        });
+        await ctx.SaveChangesAsync();
+        return id;
+    }
+
+    /// <summary>
+    /// An isolated SQLite store carrying the audit interceptor, so a save runs the same three
+    /// <c>Entries()</c> walks production does.
+    /// </summary>
+    private SqliteTestDatabase NewStore(Guid? tenantId = null)
+    {
+        var interceptor = new MutationAuditInterceptor(Mock.Of<IHttpContextAccessor>());
+        var db = tenantId is null
+            ? TestDbContextFactory.CreateSqlite()
+            : TestDbContextFactory.CreateSqliteWithTenant(tenantId.Value, "test", interceptor);
+        _databases.Add(db);
+        return db;
+    }
+
+    /// <summary>
+    /// A context with a human actor attached: a save with no audit context is an unattributed
+    /// background save and is never audited, which would make an audit-row assertion vacuous.
+    /// </summary>
+    private static NocturneDbContext NewAuditedContext(SqliteTestDatabase db)
+    {
+        var ctx = db.CreateContext();
+        ctx.AuditContext = new StubAuditContext();
+        return ctx;
+    }
+
+    private sealed class StubAuditContext : IAuditContext
+    {
+        public Guid? SubjectId { get; } = Guid.CreateVersion7();
+        public string? SubjectName => "tester";
+        public string? AuthType => "SessionCookie";
+        public string? IpAddress => null;
+        public Guid? TokenId => null;
+        public string? TraceId => null;
+        public string? Endpoint => "PUT /api/v4/basal-schedules";
+        public bool IsSystem => false;
+    }
+
+    public void Dispose()
+    {
+        foreach (var db in _databases)
+        {
+            db.Dispose();
+        }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/SaveChangesChangeDetectionTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/SaveChangesChangeDetectionTests.cs
@@ -12,10 +12,12 @@ using Xunit;
 namespace Nocturne.Infrastructure.Data.Tests;
 
 /// <summary>
-/// Pins the single change-detection pass per save. <c>UpdateTimestamps</c>, the
-/// <see cref="MutationAuditInterceptor"/> and EF's own pre-save check each used to trigger a full
-/// <c>DetectChanges</c>, so every jsonb column of every tracked entity was parsed three times per
-/// save. The store is in-memory SQLite so the persisted row, not just the tracker, is observable.
+/// Covers the single change-detection pass a save runs, and the stamps that depend on it.
+/// <c>UpdateTimestamps</c>, the <see cref="MutationAuditInterceptor"/> and EF's own pre-save check
+/// each enumerate the change tracker, so detection has to happen once up front and be off for the
+/// rest of the save; a stamp applied to a modified row after that point only reaches the UPDATE
+/// because it is written through the tracker. Every store here carries the audit interceptor and
+/// is in-memory SQLite, so the persisted row is observable, not just the tracker.
 /// </summary>
 [Trait("Category", "Unit")]
 public class SaveChangesChangeDetectionTests : IDisposable
@@ -48,8 +50,7 @@ public class SaveChangesChangeDetectionTests : IDisposable
     [Fact]
     public async Task Save_RestoresAutoDetectChanges()
     {
-        var tenantId = Guid.NewGuid();
-        var db = NewStore(tenantId);
+        var db = NewStore(Guid.NewGuid());
 
         await using var ctx = db.CreateContext();
         ctx.Foods.Add(new FoodEntity { Id = Guid.CreateVersion7() });
@@ -62,9 +63,9 @@ public class SaveChangesChangeDetectionTests : IDisposable
     [Fact]
     public async Task FailedSave_RestoresAutoDetectChanges()
     {
-        var db = NewStore();
+        var db = NewStore(Guid.NewGuid());
 
-        await using var ctx = db.CreateContext(); // no tenant resolved
+        await using var ctx = db.CreateContext(Guid.Empty); // no tenant resolved
         ctx.Foods.Add(new FoodEntity { Id = Guid.CreateVersion7() });
 
         var act = () => ctx.SaveChangesAsync();
@@ -152,35 +153,96 @@ public class SaveChangesChangeDetectionTests : IDisposable
         {
             var schedule = await verify.BasalSchedules.SingleAsync(s => s.Id == id);
             schedule.SysUpdatedAt.Should().BeAfter(stampedOnInsert,
-                "the single detection pass still flags a real modification, and the stamp written "
-                + "through the tracker still reaches the UPDATE");
+                "sys_updated_at written through the tracker still reaches the UPDATE");
             (await verify.MutationAuditLog.CountAsync()).Should().Be(1);
         }
     }
 
     [Fact]
-    public void EveryTimestampMarkerProperty_IsMapped()
+    public async Task EntityTimestamped_ModifyStillBumpsUpdatedAt()
+    {
+        var db = NewStore(Guid.NewGuid());
+        var id = Guid.CreateVersion7();
+
+        await using (var ctx = db.CreateContext())
+        {
+            ctx.Subjects.Add(new SubjectEntity { Id = id, Name = "original" });
+            await ctx.SaveChangesAsync();
+        }
+
+        DateTime stampedOnInsert;
+        await using (var ctx = db.CreateContext())
+        {
+            var subject = await ctx.Subjects.SingleAsync(s => s.Id == id);
+            stampedOnInsert = subject.UpdatedAt;
+
+            subject.Name = "renamed";
+            await Task.Delay(5);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = db.CreateContext())
+        {
+            var subject = await verify.Subjects.SingleAsync(s => s.Id == id);
+            subject.UpdatedAt.Should().BeAfter(stampedOnInsert,
+                "updated_at written through the tracker still reaches the UPDATE");
+        }
+    }
+
+    [Fact]
+    public async Task ClockFace_ModifyStillBumpsItsNullableUpdatedAt()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = NewStore(tenantId);
+        var id = Guid.CreateVersion7();
+
+        await using (var ctx = db.CreateContext())
+        {
+            ctx.ClockFaces.Add(new ClockFaceEntity { Id = id, Name = "original" });
+            await ctx.SaveChangesAsync();
+        }
+
+        DateTime stampedOnInsert;
+        await using (var ctx = db.CreateContext())
+        {
+            var clockFace = await ctx.ClockFaces.SingleAsync(c => c.Id == id);
+            stampedOnInsert = clockFace.UpdatedAt!.Value;
+
+            clockFace.Name = "renamed";
+            await Task.Delay(5);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = db.CreateContext())
+        {
+            var clockFace = await verify.ClockFaces.SingleAsync(c => c.Id == id);
+            clockFace.UpdatedAt!.Value.Should().BeAfter(stampedOnInsert,
+                "the entity-specific updated_at written through the tracker still reaches the UPDATE");
+        }
+    }
+
+    [Fact]
+    public void EveryTrackerWrittenStamp_IsMapped()
     {
         using var ctx = OfflineDbContext.Create();
 
-        var markers = new (Type Marker, string Property)[]
+        // UpdateTimestamps looks these up by name on the change tracker, which throws on a
+        // property the model does not map.
+        var markers = new (Type Owner, string Property)[]
         {
-            (typeof(ISystemCreated), nameof(ISystemCreated.SysCreatedAt)),
             (typeof(ISystemTimestamped), nameof(ISystemTimestamped.SysUpdatedAt)),
-            (typeof(IEntityCreated), nameof(IEntityCreated.CreatedAt)),
             (typeof(IEntityTimestamped), nameof(IEntityTimestamped.UpdatedAt)),
+            (typeof(ClockFaceEntity), nameof(ClockFaceEntity.UpdatedAt)),
         };
 
-        // UpdateTimestamps stamps these through the change tracker, which throws on a property the
-        // model does not map.
-        foreach (var (marker, property) in markers)
+        foreach (var (owner, property) in markers)
         {
             var unmapped = ctx.Model.GetEntityTypes()
-                .Where(t => marker.IsAssignableFrom(t.ClrType) && t.FindProperty(property) is null)
+                .Where(t => owner.IsAssignableFrom(t.ClrType) && t.FindProperty(property) is null)
                 .Select(t => t.ClrType.Name)
                 .ToList();
 
-            unmapped.Should().BeEmpty($"{property} must be mapped on every {marker.Name}");
+            unmapped.Should().BeEmpty($"{property} must be mapped on every {owner.Name}");
         }
     }
 
@@ -201,15 +263,13 @@ public class SaveChangesChangeDetectionTests : IDisposable
     }
 
     /// <summary>
-    /// An isolated SQLite store carrying the audit interceptor, so a save runs the same three
-    /// <c>Entries()</c> walks production does.
+    /// An isolated SQLite store carrying the audit interceptor, so a save walks the change tracker
+    /// as many times as it does in production.
     /// </summary>
-    private SqliteTestDatabase NewStore(Guid? tenantId = null)
+    private SqliteTestDatabase NewStore(Guid tenantId)
     {
-        var interceptor = new MutationAuditInterceptor(Mock.Of<IHttpContextAccessor>());
-        var db = tenantId is null
-            ? TestDbContextFactory.CreateSqlite()
-            : TestDbContextFactory.CreateSqliteWithTenant(tenantId.Value, "test", interceptor);
+        var db = TestDbContextFactory.CreateSqliteWithTenant(
+            tenantId, "test", new MutationAuditInterceptor(Mock.Of<IHttpContextAccessor>()));
         _databases.Add(db);
         return db;
     }


### PR DESCRIPTION
Fixes #1272.

## What was wrong

Every `SaveChanges`/`SaveChangesAsync` ran a full `DetectChanges` three times:

1. `NocturneDbContext.UpdateTimestamps()` enumerates `ChangeTracker.Entries()`, and `Entries()` calls `TryDetectChanges()`.
2. EF invokes the save interceptors before its own detection, and `MutationAuditInterceptor.SavingChangesAsync` enumerates `ChangeTracker.Entries<IAuditable>()` — a second full pass.
3. EF's `SaveChanges` then calls `TryDetectChanges()` itself.

Each pass compares every property of every tracked entity against its snapshot. `ChangeDetector` skips properties already flagged modified, so the properties that get compared three times are exactly the ones that keep coming back equal — including every jsonb-backed string that an upsert re-serialised without changing semantically. For those, `JsonbStringComparer` falls past its ordinal fast path and parses two `JsonDocument`s, three times per save.

The issue's production measurement: `SaveChangesAsync` 22.7 % of managed CPU inclusive, `ChangeDetector.DetectChanges` 21.8 %, `JsonbStringComparer.JsonEquals` 20.4 %, `JsonDocument.Parse` 27 % across both overloads, allocation rate averaging 427 MB/s.

## What changes

`src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs`

- Both `SaveChanges` overrides call a new `DetectChangesOnceForSave()`: it runs `ChangeTracker.DetectChanges()` once, sets `AutoDetectChangesEnabled = false`, and returns the previous value, which a `finally` restores. `Entries()` in `UpdateTimestamps` and in the audit interceptor now read state without re-detecting, and EF's `TryDetectChanges` is a no-op.
- With detection off, a plain CLR assignment on a **modified** row is never flagged and never reaches the UPDATE. The three modify-path stamps — `ISystemTimestamped.SysUpdatedAt`, `IEntityTimestamped.UpdatedAt` and `ClockFaceEntity.UpdatedAt` — therefore go through the tracker (`entry.Property(name).CurrentValue = value`, via a small `Stamp` helper), the way `MutationAuditInterceptor` already does for the `DeletedByUser` shadow property.
- The **added**-path stamps (`SysCreatedAt`, `CreatedAt`, `ConnectorConfigurationEntity.LastModified`, `OAuthRefreshTokenEntity.IssuedAt`) stay plain CLR assignments: EF inserts a new row from its live CLR values regardless of modified flags, so routing them through the tracker bought nothing. `ApplyEntitySpecificTimestamps` takes the `EntityEntry` for the one case that needs it.

Everything else in the save pipeline was checked and needs no change:

- `MutationAuditInterceptor` is the only `SaveChangesInterceptor` registered (`ServiceCollectionExtensions`); `TenantConnectionInterceptor` is a connection interceptor and is unaffected. It reads `IsModified`, `OriginalValue` and `CurrentValue`, all of which the single pass populates, and its `Set<MutationAuditLogEntity>().AddRange` does not need detection to take effect.
- `EnforceTenantOwnership` only assigns `TenantId` on `Added` entries — same live-CLR-values argument as above.
- `HasNonTimestampModification` reads `IsModified`, populated by the single pass.
- `StripNulCharacters` already wrote through `property.CurrentValue`.
- Nothing in the repository sets `AutoDetectChangesEnabled` itself (`grep` over the whole tree returns no hits outside this change), but the guard is there anyway: if a caller has already disabled detection, nothing is detected on its behalf and its flag is restored to `false`, which is byte-for-byte the old behaviour.

## Behavioural deltas

- The async save goes from three detection passes to one. The **sync** `SaveChanges()` goes from two to one: `MutationAuditInterceptor` only overrides `SavingChangesAsync`, so the sync path never had the interceptor's pass (and writes no audit rows — pre-existing, unchanged here). Nothing in `src/` calls the sync overload; the only occurrence is `base.SaveChanges()` inside the override itself.
- `UpdateTimestamps` now throws if one of the three tracker-written properties is not mapped, where before the assignment was a silent no-op. No entity type in the model is in that state; a guard test pins it.
- Detection now happens strictly before `UpdateTimestamps` rather than lazily inside it. Same observable ordering, since `Entries()` detected first anyway.
- A caller that mutates a tracked entity from inside a `SavingChanges` interceptor and expects a later automatic pass to notice would no longer be noticed. There is no such caller today; the audit interceptor already writes through the tracker.

## Tests

New `tests/Unit/Nocturne.Infrastructure.Data.Tests/SaveChangesChangeDetectionTests.cs` (in-memory SQLite, audit interceptor registered on every store, so a save walks the change tracker as many times as it does in production):

- `Save_DetectsChangesExactlyOnce` — counts `ChangeTracker.DetectedAllChanges`. **Reverting `NocturneDbContext.cs` to `main` makes this fail with "found 3"**; it passes with 1 here.
- `Save_RestoresAutoDetectChanges` and `FailedSave_RestoresAutoDetectChanges` — the flag is restored on both paths.
- `Save_WithDetectionAlreadyDisabled_DetectsNothingAndLeavesItDisabled` — a caller-disabled flag is honoured, and an explicitly added row is still stamped and inserted, which is also what makes the added-path CLR assignments safe.
- `JsonbNormalizedRoundTrip_IssuesNoUpdateAndNoAuditRow` — the existing jsonb round-trip coverage re-run at the save level: no UPDATE (`sys_updated_at` unchanged) and no audit row.
- `SemanticJsonChange_StillUpdatesAndAudits`, `EntityTimestamped_ModifyStillBumpsUpdatedAt`, `ClockFace_ModifyStillBumpsItsNullableUpdatedAt` — one per tracker-written stamp. Each reverts to reading the row from a second context. Mutation-checked: replacing any one of the three `Stamp` calls with the old CLR assignment fails its test (`SysUpdatedAt` also reddens the pre-existing `UpdateTimestampsTests.SystemTimestamped_StampsBothOnInsert_AndBumpsUpdatedOnModify`).
- `EveryTrackerWrittenStamp_IsMapped` — model guard for the three `entry.Property(name)` lookups.

The pre-existing `UpdateTimestampsTests` (insert stamps, touch-preservation, clock face, connector configuration, OAuth refresh token, tenant ownership) all persist to SQLite and verify from a second context, so the added-path stamps stay covered; they pass unchanged.

Runs:

- `dotnet test tests/Unit/Nocturne.Infrastructure.Data.Tests -p:GenerateNSwagClient=false` — 987 passed, 0 failed.
- `dotnet test tests/Unit/Nocturne.API.Tests -p:GenerateNSwagClient=false --filter "FullyQualifiedName~SaveChanges|FullyQualifiedName~Audit|FullyQualifiedName~Timestamp"` — 193 passed, 0 failed.

## Verifying in production

Re-run the measurement from the issue after deploy: a 60 s `dotnet-trace` CPU sample should show `ChangeDetector.DetectChanges`, `JsonbStringComparer.JsonEquals` and `JsonDocument.Parse` at roughly a third of their current inclusive share, and `dotnet-counters` `dotnet.gc.heap.total_allocated` well below the 427 MB/s average. Correctness signal: `sys_updated_at` and `updated_at` on rows touched by a real edit must keep advancing, and `mutation_audit_log` must keep receiving exactly one row per user-attributed change and none for a no-op connector re-sync.

https://claude.ai/code/session_016FPjRhrCBT3HmSRh213HXs
