### PR TITLE
perf(data): drop the RESET batch from the connection close path

### DIFF
--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -559,7 +559,7 @@ if (!isNSwagGeneration && !app.Environment.IsEnvironment("Testing"))
         await DatabaseInitializationExtensions.MarkInterruptedJobsAsync(migratorConnectionString, logger);
     }
 
-    // Validate RLS, ownership, default privileges, and NoResetOnClose under the app role.
+    // Validate RLS, ownership, default privileges, and pool reset-on-close under the app role.
     await app.Services.ValidateDatabaseConfigurationAsync();
 
     // Sync config-managed OIDC providers to the database (satisfies FK constraints)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -625,6 +625,11 @@ public static class DatabaseInitializationExtensions
     /// Verifies that the runtime connection string does not have NoResetOnClose
     /// enabled. With NoResetOnClose = true, pooled connections skip DISCARD ALL,
     /// allowing stale app.current_tenant_id values to leak across requests.
+    ///
+    /// This is the sole guarantee that a pooled connection carries none of the RLS
+    /// GUCs between lessees: <c>TenantConnectionInterceptor</c> sets them on open and
+    /// clears nothing on close, because DISCARD ALL (which includes RESET ALL) already
+    /// does. Nothing may weaken this check without restoring a reset there.
     /// </summary>
     private static void VerifyNoResetOnClose(NocturneDbContext context, ILogger logger)
     {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -370,9 +370,9 @@ public static class DatabaseInitializationExtensions
     /// <summary>
     /// Validates runtime database configuration after migrations have run and
     /// the app DbContext is registered. Runs the RLS self-check under the app
-    /// role and asserts the runtime NpgsqlDataSource is configured with
-    /// NoResetOnClose = false (required so pooled connections DISCARD ALL
-    /// between uses, wiping app.current_tenant_id).
+    /// role and asserts the runtime connection string leaves Npgsql's reset on
+    /// pool return in place, so app.current_tenant_id cannot outlive a lessee
+    /// (<see cref="VerifyPoolResetOnClose(string?)"/>).
     /// </summary>
     public static async Task ValidateDatabaseConfigurationAsync(
         this IServiceProvider serviceProvider,
@@ -388,7 +388,7 @@ public static class DatabaseInitializationExtensions
             logger,
             cancellationToken);
 
-        VerifyNoResetOnClose(context, logger);
+        VerifyPoolResetOnClose(context, logger);
     }
 
     /// <summary>
@@ -622,24 +622,26 @@ public static class DatabaseInitializationExtensions
     }
 
     /// <summary>
-    /// Verifies that the runtime connection string does not have NoResetOnClose
-    /// enabled. With NoResetOnClose = true, pooled connections skip DISCARD ALL,
-    /// allowing stale app.current_tenant_id values to leak across requests.
+    /// Verifies that the runtime connection string leaves Npgsql's reset-on-pool-return in
+    /// place. <c>NpgsqlConnector</c> sends it only when pooling is on, multiplexing is off and
+    /// NoResetOnClose is off; with the reset skipped, a stale app.current_tenant_id leaks to the
+    /// next lessee of the physical connection.
     ///
-    /// This is the sole guarantee that a pooled connection carries none of the RLS
-    /// GUCs between lessees: <c>TenantConnectionInterceptor</c> sets them on open and
-    /// clears nothing on close, because DISCARD ALL (which includes RESET ALL) already
-    /// does. Nothing may weaken this check without restoring a reset there.
+    /// <c>TenantConnectionInterceptor</c> sets the RLS GUCs on open and clears nothing on close,
+    /// so this check is what keeps that safe. It guards the two settings a connection string can
+    /// turn on; it does not observe the reset happening, which
+    /// <c>PoolReturnDiscardsRlsGucsIntegrationTests</c> does against a real backend.
     /// </summary>
-    private static void VerifyNoResetOnClose(NocturneDbContext context, ILogger logger)
+    /// <param name="connectionString">The runtime connection string. A null or empty value is not checked.</param>
+    public static void VerifyPoolResetOnClose(string? connectionString)
     {
-        var connectionString = context.Database.GetConnectionString();
         if (string.IsNullOrEmpty(connectionString))
         {
             return;
         }
 
         var csb = new NpgsqlConnectionStringBuilder(connectionString);
+
         if (csb.NoResetOnClose)
         {
             throw new InvalidOperationException(
@@ -649,6 +651,19 @@ public static class DatabaseInitializationExtensions
                 "Remove 'No Reset On Close=true' from the connection string.");
         }
 
-        logger.LogDebug("NoResetOnClose check passed for runtime connection string");
+        if (csb.Multiplexing)
+        {
+            throw new InvalidOperationException(
+                "The runtime PostgreSQL connection string has Multiplexing = true. " +
+                "Npgsql sends no reset when a multiplexed connection is returned, " +
+                "which allows stale app.current_tenant_id values to leak across tenants. " +
+                "Remove 'Multiplexing=true' from the connection string.");
+        }
+    }
+
+    private static void VerifyPoolResetOnClose(NocturneDbContext context, ILogger logger)
+    {
+        VerifyPoolResetOnClose(context.Database.GetConnectionString());
+        logger.LogDebug("Pool reset-on-close check passed for runtime connection string");
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/RetentionPurgeExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/RetentionPurgeExtensions.cs
@@ -12,7 +12,7 @@ namespace Nocturne.Infrastructure.Data.Extensions;
 /// The tenant reach the DELETE needs comes from
 /// <see cref="RlsPinningExtensions.CreateTenantPinnedContextAsync"/> and cannot come from a
 /// <c>set_config</c> issued as its own command: EF opens and closes the connection around each
-/// command, and <c>TenantConnectionInterceptor</c>'s close resets the session variable. Every
+/// command, and the pool's DISCARD ALL clears the session variable on the way back. Every
 /// tenant-scoped table is <c>FORCE ROW LEVEL SECURITY</c>, so an unpinned DELETE evaluates
 /// <c>tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid</c> against
 /// NULL, matches nothing, and reports success having deleted no rows.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
@@ -6,13 +6,19 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 namespace Nocturne.Infrastructure.Data.Interceptors;
 
 /// <summary>
-/// EF Core connection interceptor that sets the PostgreSQL session variable
+/// EF Core connection interceptor that sets the PostgreSQL session variables
 /// for Row-Level Security tenant isolation.
 ///
 /// On connection open: SELECT set_config('app.current_tenant_id', $1, false)
-/// On connection close: RESET app.current_tenant_id
 ///
-/// The same open/reset pair carries app.current_subject_id, which gives the
+/// Nothing is reset on close. Npgsql runs DISCARD ALL — which includes RESET ALL —
+/// on every pool return, so each of these GUCs is already cleared before the next
+/// lessee sees the physical connection, and
+/// <c>DatabaseInitializationExtensions.VerifyNoResetOnClose</c> refuses to start the API
+/// unless that is on. Issuing the RESETs here as well cost one extra round trip per
+/// checkout and, at production checkout rates, five sixths of the statements Postgres saw.
+///
+/// The same open path carries app.current_subject_id, which gives the
 /// subject-scoped cross-tenant reads (tenant switcher, caregiver overview,
 /// membership enumeration) reach over one subject's own rows. Both are set only
 /// when non-empty, so an unpinned context leaves the GUC unset and matches nothing.
@@ -91,37 +97,6 @@ public class TenantConnectionInterceptor : DbConnectionInterceptor
         param.ParameterName = name;
         param.Value = value;
         cmd.Parameters.Add(param);
-    }
-
-    /// <summary>
-    /// Executes before a connection is closed.
-    /// Resets the PostgreSQL session variable.
-    /// </summary>
-    /// <param name="connection">The database connection.</param>
-    /// <param name="eventData">Information about the connection event.</param>
-    /// <param name="result">The interception result.</param>
-    /// <returns>The interception result.</returns>
-    public override async ValueTask<InterceptionResult> ConnectionClosingAsync(
-        DbConnection connection,
-        ConnectionEventData eventData,
-        InterceptionResult result)
-    {
-        // Reset the session variables before the connection returns to the pool.
-        // This prevents a stale tenant or subject ID from leaking to the next request.
-        try
-        {
-            await using var cmd = connection.CreateCommand();
-            cmd.CommandText =
-                "RESET app.current_tenant_id; RESET app.current_subject_id; RESET app.is_share; " +
-                "RESET app.visible_categories; RESET app.share_full_history";
-            await cmd.ExecuteNonQueryAsync();
-        }
-        catch
-        {
-            // Swallow errors during cleanup - the connection may already be broken
-        }
-
-        return result;
     }
 
     private async Task EnsureRoleIsSafeAsync(DbConnection connection, CancellationToken cancellationToken)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
@@ -11,12 +11,12 @@ namespace Nocturne.Infrastructure.Data.Interceptors;
 ///
 /// On connection open: SELECT set_config('app.current_tenant_id', $1, false)
 ///
-/// Nothing is reset on close. Npgsql runs DISCARD ALL — which includes RESET ALL —
-/// on every pool return, so each of these GUCs is already cleared before the next
-/// lessee sees the physical connection, and
-/// <c>DatabaseInitializationExtensions.VerifyNoResetOnClose</c> refuses to start the API
-/// unless that is on. Issuing the RESETs here as well cost one extra round trip per
-/// checkout and, at production checkout rates, well over half of the statements Postgres saw.
+/// Nothing is reset on close. Npgsql resets the session on every pool return —
+/// DISCARD ALL, or the DEALLOCATE-sparing equivalent that still carries RESET ALL when
+/// the connection holds prepared statements — so each of these GUCs is cleared before
+/// the next lessee's first command reaches the backend.
+/// <c>DatabaseInitializationExtensions.VerifyPoolResetOnClose</c> refuses to start the API
+/// on a connection string that would turn that reset off.
 ///
 /// The same open path carries app.current_subject_id, which gives the
 /// subject-scoped cross-tenant reads (tenant switcher, caregiver overview,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
@@ -16,7 +16,7 @@ namespace Nocturne.Infrastructure.Data.Interceptors;
 /// lessee sees the physical connection, and
 /// <c>DatabaseInitializationExtensions.VerifyNoResetOnClose</c> refuses to start the API
 /// unless that is on. Issuing the RESETs here as well cost one extra round trip per
-/// checkout and, at production checkout rates, five sixths of the statements Postgres saw.
+/// checkout and, at production checkout rates, well over half of the statements Postgres saw.
 ///
 /// The same open path carries app.current_subject_id, which gives the
 /// subject-scoped cross-tenant reads (tenant switcher, caregiver overview,

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/PoolReturnDiscardsRlsGucsIntegrationTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/PoolReturnDiscardsRlsGucsIntegrationTests.cs
@@ -1,0 +1,147 @@
+using System.Data.Common;
+using Nocturne.Infrastructure.Data.Interceptors;
+using Npgsql;
+
+namespace Nocturne.Infrastructure.Data.Tests.Rls;
+
+/// <summary>
+/// Proves that Npgsql's DISCARD ALL on pool return is on its own enough to clear every RLS GUC
+/// <c>TenantConnectionInterceptor</c> sets, so the interceptor does not have to RESET them on
+/// close. The pool is capped at one physical connection, so every lease below is the same
+/// backend: a GUC that survived the return would be read back by the next lessee.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("RLS completeness")]
+public class PoolReturnDiscardsRlsGucsIntegrationTests
+{
+    private static readonly string[] RlsGucs =
+    [
+        "app.current_tenant_id",
+        "app.current_subject_id",
+        "app.is_share",
+        "app.visible_categories",
+        "app.share_full_history",
+    ];
+
+    private readonly RlsCompletenessFixture _fx;
+
+    public PoolReturnDiscardsRlsGucsIntegrationTests(RlsCompletenessFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task PoolReturn_ClearsEveryRlsGuc_WithoutAResetOnClose()
+    {
+        var connectionString = new NpgsqlConnectionStringBuilder(_fx.AppConnectionString)
+        {
+            MinPoolSize = 0,
+            MaxPoolSize = 1,
+        }.ConnectionString;
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(connectionString).Build();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseNpgsql(dataSource)
+            .AddInterceptors(new TenantConnectionInterceptor())
+            .Options;
+
+        var shareTenant = Guid.NewGuid();
+        var shareSubject = Guid.NewGuid();
+        int backendPid;
+
+        // Lease 1 - a share-flagged, category-restricted context. Every GUC is on the session.
+        await using (var share = new NocturneDbContext(options)
+        {
+            TenantId = shareTenant,
+            SubjectId = shareSubject,
+            IsShareContext = true,
+            VisibleCategories = "glucose.read,treatments.read",
+            ShareFullHistory = true,
+        })
+        {
+            var connection = await OpenAsync(share);
+            backendPid = Convert.ToInt32(await ScalarAsync(connection, "SELECT pg_backend_pid()"));
+
+            await AssertSettingAsync(connection, "app.current_tenant_id", shareTenant.ToString());
+            await AssertSettingAsync(connection, "app.current_subject_id", shareSubject.ToString());
+            await AssertSettingAsync(connection, "app.is_share", "true");
+            await AssertSettingAsync(connection, "app.visible_categories", "glucose.read,treatments.read");
+            await AssertSettingAsync(connection, "app.share_full_history", "true");
+
+            await share.Database.CloseConnectionAsync();
+        }
+
+        // Nothing but the pool's DISCARD ALL has run against this backend since. Read the GUCs
+        // off a raw lease, so no interceptor gets the chance to overwrite them first.
+        await using (var probe = await dataSource.OpenConnectionAsync())
+        {
+            Convert.ToInt32(await ScalarAsync(probe, "SELECT pg_backend_pid()")).Should().Be(backendPid,
+                "the pool must hand back the same physical connection for this to prove anything");
+
+            foreach (var guc in RlsGucs)
+            {
+                (await SettingAsync(probe, guc)).Should().BeNullOrEmpty(
+                    $"{guc} must not survive the pool return");
+            }
+        }
+
+        // Lease 2 - a plain tenant context. It sets no subject, so a surviving subject id from
+        // the share would still be readable here.
+        var plainTenant = Guid.NewGuid();
+        await using (var plain = new NocturneDbContext(options) { TenantId = plainTenant })
+        {
+            var connection = await OpenAsync(plain);
+            Convert.ToInt32(await ScalarAsync(connection, "SELECT pg_backend_pid()")).Should().Be(backendPid);
+
+            await AssertSettingAsync(connection, "app.current_tenant_id", plainTenant.ToString());
+            (await SettingAsync(connection, "app.current_subject_id")).Should().BeNullOrEmpty(
+                "the share's subject id must not reach a context that sets none");
+            await AssertSettingAsync(connection, "app.is_share", "false");
+            (await SettingAsync(connection, "app.visible_categories")).Should().BeEmpty();
+            await AssertSettingAsync(connection, "app.share_full_history", "false");
+
+            await plain.Database.CloseConnectionAsync();
+        }
+
+        // Lease 3 - an unpinned context. It sets neither tenant nor subject, so both must be
+        // clear on the physical connection the previous two lessees pinned.
+        await using (var unpinned = new NocturneDbContext(options))
+        {
+            var connection = await OpenAsync(unpinned);
+            Convert.ToInt32(await ScalarAsync(connection, "SELECT pg_backend_pid()")).Should().Be(backendPid);
+
+            (await SettingAsync(connection, "app.current_tenant_id")).Should().BeNullOrEmpty(
+                "an unpinned context must match nothing, not the previous lessee's tenant");
+            (await SettingAsync(connection, "app.current_subject_id")).Should().BeNullOrEmpty();
+            await AssertSettingAsync(connection, "app.is_share", "false");
+
+            await unpinned.Database.CloseConnectionAsync();
+        }
+    }
+
+    private static async Task<DbConnection> OpenAsync(NocturneDbContext context)
+    {
+        await context.Database.OpenConnectionAsync();
+        return context.Database.GetDbConnection();
+    }
+
+    private static async Task AssertSettingAsync(DbConnection connection, string name, string expected)
+        => (await SettingAsync(connection, name)).Should().Be(expected);
+
+    private static async Task<string?> SettingAsync(DbConnection connection, string name)
+        => (string?)await ScalarAsync(connection, "SELECT current_setting(@name, true)", name);
+
+    private static async Task<object?> ScalarAsync(DbConnection connection, string sql, string? name = null)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+
+        if (name is not null)
+        {
+            var parameter = cmd.CreateParameter();
+            parameter.ParameterName = "@name";
+            parameter.Value = name;
+            cmd.Parameters.Add(parameter);
+        }
+
+        var value = await cmd.ExecuteScalarAsync();
+        return value is DBNull ? null : value;
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/VerifyPoolResetOnCloseTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/VerifyPoolResetOnCloseTests.cs
@@ -1,0 +1,47 @@
+using Nocturne.Infrastructure.Data.Extensions;
+
+namespace Nocturne.Infrastructure.Data.Tests.Extensions;
+
+/// <summary>
+/// The startup check that keeps <c>TenantConnectionInterceptor</c>'s empty close path safe: it
+/// rejects the connection-string settings that stop Npgsql resetting a connection on pool return,
+/// which is what clears the RLS GUCs between lessees.
+/// </summary>
+[Trait("Category", "Unit")]
+public class VerifyPoolResetOnCloseTests
+{
+    private const string Base = "Host=localhost;Database=nocturne;Username=nocturne_app;Password=secret";
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(Base)]
+    [InlineData(Base + ";No Reset On Close=false")]
+    [InlineData(Base + ";Multiplexing=false")]
+    public void AcceptsAConnectionStringThatKeepsTheReset(string? connectionString)
+    {
+        var act = () => DatabaseInitializationExtensions.VerifyPoolResetOnClose(connectionString);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RejectsNoResetOnClose()
+    {
+        var act = () => DatabaseInitializationExtensions.VerifyPoolResetOnClose(
+            Base + ";No Reset On Close=true");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*NoResetOnClose*");
+    }
+
+    [Fact]
+    public void RejectsMultiplexing()
+    {
+        // Npgsql sends no reset for a multiplexed connection, so the GUCs would outlive the lessee
+        // exactly as they would under NoResetOnClose.
+        var act = () => DatabaseInitializationExtensions.VerifyPoolResetOnClose(
+            Base + ";Multiplexing=true");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Multiplexing*");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/TenantConnectionInterceptorTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/TenantConnectionInterceptorTests.cs
@@ -6,9 +6,10 @@ namespace Nocturne.Infrastructure.Data.Tests.Interceptors;
 
 /// <summary>
 /// Pins the close path of <see cref="TenantConnectionInterceptor"/> as free of round trips.
-/// Npgsql's DISCARD ALL on pool return clears every RLS GUC the interceptor sets, so a reset
-/// here is one wasted statement per checkout — 87 % of everything production Postgres saw.
-/// <c>PoolReturnDiscardsRlsGucsIntegrationTests</c> is the proof that DISCARD ALL suffices.
+/// Npgsql's reset on pool return clears every RLS GUC the interceptor sets, so a command issued
+/// here buys nothing: in the production profile the five RESET statements it sent were about
+/// 62 % of all statements reaching Postgres (5 x ~43,000 of 345,917 per 5 minutes).
+/// <c>PoolReturnDiscardsRlsGucsIntegrationTests</c> is the proof that the pool reset suffices.
 /// </summary>
 [Trait("Category", "Unit")]
 public class TenantConnectionInterceptorTests
@@ -17,11 +18,12 @@ public class TenantConnectionInterceptorTests
     public async Task ConnectionClosingAsync_IssuesNoCommand()
     {
         var interceptor = new TenantConnectionInterceptor();
-        await using var connection = new CommandRefusingConnection();
+        await using var connection = new CommandCountingConnection();
 
         // The event data goes unread by a close that touches nothing.
         var result = await interceptor.ConnectionClosingAsync(connection, null!, default);
 
+        connection.CommandsCreated.Should().Be(0);
         result.IsSuppressed.Should().BeFalse();
     }
 
@@ -29,15 +31,22 @@ public class TenantConnectionInterceptorTests
     public void ConnectionClosing_IssuesNoCommand()
     {
         var interceptor = new TenantConnectionInterceptor();
-        using var connection = new CommandRefusingConnection();
+        using var connection = new CommandCountingConnection();
 
         var result = interceptor.ConnectionClosing(connection, null!, default);
 
+        connection.CommandsCreated.Should().Be(0);
         result.IsSuppressed.Should().BeFalse();
     }
 
-    private sealed class CommandRefusingConnection : DbConnection
+    /// <summary>
+    /// Counts rather than throws: a close that creates a command and swallows the failure would
+    /// still look clean to an assertion that relies on the exception escaping.
+    /// </summary>
+    private sealed class CommandCountingConnection : DbConnection
     {
+        public int CommandsCreated { get; private set; }
+
         public override string ConnectionString { get; set; } = string.Empty;
 
         public override string Database => string.Empty;
@@ -60,7 +69,93 @@ public class TenantConnectionInterceptorTests
             => throw new NotSupportedException();
 
         protected override DbCommand CreateDbCommand()
-            => throw new InvalidOperationException(
-                "Closing a connection must issue no command: the pool's DISCARD ALL already clears the RLS GUCs.");
+        {
+            CommandsCreated++;
+            return new NoOpCommand();
+        }
+    }
+
+    private sealed class NoOpCommand : DbCommand
+    {
+        public override string CommandText { get; set; } = string.Empty;
+
+        public override int CommandTimeout { get; set; }
+
+        public override CommandType CommandType { get; set; }
+
+        public override bool DesignTimeVisible { get; set; }
+
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+
+        protected override DbConnection? DbConnection { get; set; }
+
+        protected override DbParameterCollection DbParameterCollection { get; } = new NoOpParameterCollection();
+
+        protected override DbTransaction? DbTransaction { get; set; }
+
+        public override void Cancel()
+        {
+        }
+
+        public override int ExecuteNonQuery() => 0;
+
+        public override object? ExecuteScalar() => null;
+
+        public override void Prepare()
+        {
+        }
+
+        protected override DbParameter CreateDbParameter() => throw new NotSupportedException();
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class NoOpParameterCollection : DbParameterCollection
+    {
+        private readonly List<object> _items = [];
+
+        public override int Count => _items.Count;
+
+        public override object SyncRoot => _items;
+
+        public override int Add(object value)
+        {
+            _items.Add(value);
+            return _items.Count - 1;
+        }
+
+        public override void AddRange(Array values) => throw new NotSupportedException();
+
+        public override void Clear() => _items.Clear();
+
+        public override bool Contains(object value) => _items.Contains(value);
+
+        public override bool Contains(string value) => false;
+
+        public override void CopyTo(Array array, int index) => throw new NotSupportedException();
+
+        public override System.Collections.IEnumerator GetEnumerator() => _items.GetEnumerator();
+
+        public override int IndexOf(object value) => _items.IndexOf(value);
+
+        public override int IndexOf(string parameterName) => -1;
+
+        public override void Insert(int index, object value) => _items.Insert(index, value);
+
+        public override void Remove(object value) => _items.Remove(value);
+
+        public override void RemoveAt(int index) => _items.RemoveAt(index);
+
+        public override void RemoveAt(string parameterName) => throw new NotSupportedException();
+
+        protected override DbParameter GetParameter(int index) => throw new NotSupportedException();
+
+        protected override DbParameter GetParameter(string parameterName) => throw new NotSupportedException();
+
+        protected override void SetParameter(int index, DbParameter value) => throw new NotSupportedException();
+
+        protected override void SetParameter(string parameterName, DbParameter value)
+            => throw new NotSupportedException();
     }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/TenantConnectionInterceptorTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/TenantConnectionInterceptorTests.cs
@@ -1,0 +1,66 @@
+using System.Data;
+using System.Data.Common;
+using Nocturne.Infrastructure.Data.Interceptors;
+
+namespace Nocturne.Infrastructure.Data.Tests.Interceptors;
+
+/// <summary>
+/// Pins the close path of <see cref="TenantConnectionInterceptor"/> as free of round trips.
+/// Npgsql's DISCARD ALL on pool return clears every RLS GUC the interceptor sets, so a reset
+/// here is one wasted statement per checkout — 87 % of everything production Postgres saw.
+/// <c>PoolReturnDiscardsRlsGucsIntegrationTests</c> is the proof that DISCARD ALL suffices.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TenantConnectionInterceptorTests
+{
+    [Fact]
+    public async Task ConnectionClosingAsync_IssuesNoCommand()
+    {
+        var interceptor = new TenantConnectionInterceptor();
+        await using var connection = new CommandRefusingConnection();
+
+        // The event data goes unread by a close that touches nothing.
+        var result = await interceptor.ConnectionClosingAsync(connection, null!, default);
+
+        result.IsSuppressed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ConnectionClosing_IssuesNoCommand()
+    {
+        var interceptor = new TenantConnectionInterceptor();
+        using var connection = new CommandRefusingConnection();
+
+        var result = interceptor.ConnectionClosing(connection, null!, default);
+
+        result.IsSuppressed.Should().BeFalse();
+    }
+
+    private sealed class CommandRefusingConnection : DbConnection
+    {
+        public override string ConnectionString { get; set; } = string.Empty;
+
+        public override string Database => string.Empty;
+
+        public override string DataSource => string.Empty;
+
+        public override string ServerVersion => string.Empty;
+
+        public override ConnectionState State => ConnectionState.Open;
+
+        public override void ChangeDatabase(string databaseName) => throw new NotSupportedException();
+
+        public override void Close()
+        {
+        }
+
+        public override void Open() => throw new NotSupportedException();
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+            => throw new NotSupportedException();
+
+        protected override DbCommand CreateDbCommand()
+            => throw new InvalidOperationException(
+                "Closing a connection must issue no command: the pool's DISCARD ALL already clears the RLS GUCs.");
+    }
+}


### PR DESCRIPTION
Implements the proposal in the latest comment on #1266 — the inverse of that issue's title. `DISCARD ALL` stays; the app-side `RESET` batch goes. Not marked `Fixes` because the issue is titled around the other direction; close it if this is the resolution you want.

## What was wrong

`TenantConnectionInterceptor.ConnectionClosingAsync` issued one command carrying five statements on every connection close:

```
RESET app.current_tenant_id; RESET app.current_subject_id; RESET app.is_share;
RESET app.visible_categories; RESET app.share_full_history
```

Npgsql resets the session on the same pool return — `DISCARD ALL`, or the `DEALLOCATE`-sparing equivalent that still carries `RESET ALL` when the connection holds prepared statements. `DatabaseInitializationExtensions` already refuses to start the API if the runtime connection string would turn that reset off, so it is not merely likely to run: it is a startup precondition. Every GUC the batch cleared was cleared again a moment later by the mechanism the app already depends on.

The measurement in the issue comment: over 5 minutes on the hosted instance, 345,917 statements reached Postgres — 43,035 `DISCARD ALL`, 42,762 `set_config` on open, and 5 × ~43,000 `RESET`. The RESET statements alone were about **62 %** of all statements; connection ceremony as a whole was **87 %**. In a 60 s API CPU sample `ConnectionClosingAsync` was the top application frame by inclusive managed CPU at 30.7 %, almost all of it Npgsql round-trip processing under `ExecuteNonQuery`, against 3.6 % for `ConnectionOpenedAsync`.

## What changes

- `src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs` — `ConnectionClosingAsync` is removed entirely; nothing else lived in it. The class doc no longer describes an open/reset pair and says why the close path is empty.
- `src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs` — `VerifyNoResetOnClose` becomes **`VerifyPoolResetOnClose`**, takes the connection string rather than the context, and now rejects **`Multiplexing=true`** as well as `NoResetOnClose=true`. `NpgsqlConnector` sends the reset only when `Pooling` is on, `Multiplexing` is off and `NoResetOnClose` is off, so multiplexing would have skipped the reset the interceptor now relies on. The doc says what the check guards (two connection-string settings) and points at the integration test for the part it cannot observe.
- `src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/RetentionPurgeExtensions.cs` — a remark that attributed the between-command clearing to the interceptor's close now attributes it to the pool reset. Same fact, correct owner.
- `src/API/Nocturne.API/Program.cs` — the startup comment names the renamed check.

## Behavioural deltas

- One fewer round trip per connection checkout, and ~215,000 fewer statements per 5 minutes on the Postgres side at current production rates.
- The GUCs are now cleared by the pool reset instead of by an explicit `RESET` immediately before it. Npgsql prepends the reset to the next lessee's first message, so it still lands before any statement that lessee issues, including the interceptor's own `set_config` on open. What a pooled connection carries between lessees does not change.
- A connection that leaves the pool entirely (broken, pruned, or a non-pooled connection string) previously got a best-effort `RESET` in a `try`/`catch` before being discarded. It no longer does, and does not need to: the session dies with it.
- **New startup failure:** a runtime connection string with `Multiplexing=true` now throws at startup. It previously started and would, after this change, have leaked GUCs across lessees. Nocturne does not set multiplexing anywhere, so no supported configuration is affected.

## Tests

New `tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/PoolReturnDiscardsRlsGucsIntegrationTests.cs` (`Category=Integration`, Testcontainers Postgres 17.6 via the existing `RlsCompletenessFixture`, real migrations, real `nocturne_app` role, real `TenantConnectionInterceptor`). The pool is capped at `MaxPoolSize=1` so all three leases are provably the same backend — every lease asserts `pg_backend_pid()` is unchanged:

1. Lease as a share-flagged, category-restricted context (`IsShareContext`, `VisibleCategories`, `ShareFullHistory`, tenant and subject). Assert all five GUCs are actually set, so the later assertions are not vacuous. Close.
2. Lease a **raw** `NpgsqlConnection` from the same data source, so no interceptor can overwrite anything first, and assert `app.current_tenant_id`, `app.current_subject_id`, `app.is_share`, `app.visible_categories` and `app.share_full_history` are all empty/unset. This is the pool-reset-alone proof.
3. Lease a plain tenant context: its tenant is set, `app.current_subject_id` is empty (the share's subject did not survive), `is_share='false'`, `visible_categories=''`, `share_full_history='false'`.
4. Lease an unpinned context: both `app.current_tenant_id` and `app.current_subject_id` are empty, so an unpinned read matches nothing rather than inheriting the previous lessee's tenant.

New `tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/TenantConnectionInterceptorTests.cs` — a `DbConnection` that **counts** `CreateDbCommand` calls and never throws, passed to both `ConnectionClosing` and `ConnectionClosingAsync`; each asserts zero commands. Counting rather than throwing is the point: the removed `ConnectionClosingAsync` wrapped its command in `try`/`catch`, so a throwing fake would have been swallowed and the test would have passed against the old code too. Restoring `origin/main`'s interceptor file makes `ConnectionClosingAsync_IssuesNoCommand` fail with `Expected connection.CommandsCreated to be 0, but found 1`. (The sync overload was never overridden, so its test is a forward guard, not a regression detector.)

New `tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/VerifyPoolResetOnCloseTests.cs` — first coverage of the startup check at all: accepts a default connection string and the explicit `false` forms, rejects `No Reset On Close=true`, rejects `Multiplexing=true`.

Runs (Docker Desktop available locally, so the integration test really ran):

- `dotnet test tests/Integration/Nocturne.Infrastructure.Data.Tests -p:GenerateNSwagClient=false` — 122 passed, 0 failed. This includes `RlsCarrierResetIntegrationTests`, which covers the share-lockout case across two acquisitions.
- `dotnet test tests/Unit/Nocturne.Infrastructure.Data.Tests -p:GenerateNSwagClient=false` — 987 passed, 0 failed.
- Mutation check on the new integration test: flipping the probe assertion to `NotBeNullOrEmpty` fails with `Expected ... not to be <null> or empty ..., but found ""`, confirming it reads a real post-reset session rather than passing vacuously.

## Verifying in production

After deploy, on the Postgres side:

```sql
SELECT query, calls FROM pg_stat_statements
WHERE query ILIKE 'RESET app.%' OR query = 'DISCARD ALL'
ORDER BY calls DESC;
```

`RESET app.*` should stop accumulating calls while `DISCARD ALL` keeps pace with checkouts; total statements per interval should drop by roughly the 62 % the RESETs accounted for. On the app side, a 60 s `dotnet-trace` CPU sample should no longer show `TenantConnectionInterceptor.ConnectionClosingAsync` at all.

Isolation smoke: open a public share link, then load an owner dashboard for the same tenant on a warm pool, and confirm the owner still sees share-hidden data (this is the `RlsCarrierResetIntegrationTests` scenario, live). Any leak would show as an owner suddenly seeing nothing, or an unpinned background sweep suddenly matching rows.

https://claude.ai/code/session_016FPjRhrCBT3HmSRh213HXs
