### PR TITLE
perf(glooko): reach back a fixed lookback per sync and walk the full history once a day

### DIFF
--- a/docs/api-descriptions/nocturne/Syncing.md
+++ b/docs/api-descriptions/nocturne/Syncing.md
@@ -14,7 +14,7 @@ A connection carries several independent streams — glucose, treatments (boluse
 - On a normal background sync each enabled type fetches from `latest_stored_record − 5min` (a small overlap absorbs clock drift).
 - When a type has **no** data yet, it performs an initial backfill over a bounded window (currently 6 months) so a new connection fills in recent history.
 - Profiles and food are small and fetched in full on every sync rather than windowed.
-- Glooko has no per-type resume point, because Glooko itself receives pump data in batches days after the fact. Each background sync re-reads a fixed lookback (`lookbackDays`, default 12), and once a day it walks the full 6-month window so anything that arrived late still lands. A manual sync with an explicit range is answered as asked.
+- Glooko has no per-type resume point, because Glooko itself receives pump data in batches days after the fact. Each scheduled sync re-reads a fixed lookback (`lookbackDays`, default 10), and once a day it walks the full 6-month window so anything that arrived late still lands; a walk that fails is retried after an hour, not on the next cycle. A manual sync (range or no range) and the SSV2 cursor mode are unaffected.
 
 ## Resilient ingestion
 

--- a/docs/api-descriptions/nocturne/Syncing.md
+++ b/docs/api-descriptions/nocturne/Syncing.md
@@ -14,6 +14,7 @@ A connection carries several independent streams — glucose, treatments (boluse
 - On a normal background sync each enabled type fetches from `latest_stored_record − 5min` (a small overlap absorbs clock drift).
 - When a type has **no** data yet, it performs an initial backfill over a bounded window (currently 6 months) so a new connection fills in recent history.
 - Profiles and food are small and fetched in full on every sync rather than windowed.
+- Glooko has no per-type resume point, because Glooko itself receives pump data in batches days after the fact. Each background sync re-reads a fixed lookback (`lookbackDays`, default 12), and once a day it walks the full 6-month window so anything that arrived late still lands. A manual sync with an explicit range is answered as asked.
 
 ## Resilient ingestion
 

--- a/src/Connectors/Nocturne.Connectors.Core/Utilities/FullWalkSchedule.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Utilities/FullWalkSchedule.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+
+namespace Nocturne.Connectors.Core.Utilities;
+
+/// <summary>
+///     When a connector should set its incremental window aside and read the source's whole history
+///     again. The last completion is carried as a round-trip timestamp string because the places a
+///     connector can keep runtime state — its secrets document, a sync cursor — hold strings.
+/// </summary>
+public static class FullWalkSchedule
+{
+    /// <summary>
+    ///     Whether a full walk is due: none has ever completed, the stored stamp is unreadable, the
+    ///     interval has elapsed, or the stamp lies in the future (a clock moved, and treating that as
+    ///     recent would suppress the walk until the clock caught up).
+    /// </summary>
+    public static bool IsDue(string? lastCompletedAt, TimeSpan interval, DateTimeOffset now)
+    {
+        if (!DateTimeOffset.TryParse(
+                lastCompletedAt,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out var last))
+            return true;
+
+        return now - last >= interval || last > now;
+    }
+
+    /// <summary>The stamp <see cref="IsDue"/> reads back, for a walk that completed at <paramref name="completedAt"/>.</summary>
+    public static string Stamp(DateTimeOffset completedAt) =>
+        completedAt.ToString("O", CultureInfo.InvariantCulture);
+}

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
@@ -82,11 +82,13 @@ public class GlookoConnectorConfiguration : BaseConnectorConfiguration
     ///     How many days back a background sync reaches. Glooko receives pump data in batches, days
     ///     after the fact, so the window is a fixed lookback rather than a resume point at the newest
     ///     stored record; anything that arrives later than this is picked up by the daily full walk
-    ///     over <see cref="GlookoConstants.FullWalkMonths"/>. Twelve days plus the one-day padding on
-    ///     each side of the request is exactly one <see cref="GlookoConstants.SyncChunkSize"/> fetch.
+    ///     over <see cref="GlookoConstants.FullWalkMonths"/>. Ten days plus the one-day padding on
+    ///     each side of the request fits one <see cref="GlookoConstants.SyncChunkSize"/> chunk (two
+    ///     requests) with room for the clock and a timezone offset change inside the window. The
+    ///     ceiling keeps a scheduled run to a handful of chunks — the full history is the walk's job.
     /// </summary>
-    [ConnectorProperty(ConnectorPropertyKey.LookbackDays, DefaultValue = "12", MinValue = 1, MaxValue = 180)]
-    public int LookbackDays { get; set; } = 12;
+    [ConnectorProperty(ConnectorPropertyKey.LookbackDays, DefaultValue = "10", MinValue = 1, MaxValue = 60)]
+    public int LookbackDays { get; set; } = 10;
 
     /// <summary>
     ///     Sync via Glooko's granular SSV2 cursor protocol — the per-resource <c>/api/v2/{resource}</c>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
@@ -84,7 +84,7 @@ public class GlookoConnectorConfiguration : BaseConnectorConfiguration
     ///     stored record; anything that arrives later than this is picked up by the daily full walk
     ///     over <see cref="GlookoConstants.FullWalkMonths"/>. Ten days plus the one-day padding on
     ///     each side of the request fits one <see cref="GlookoConstants.SyncChunkSize"/> chunk (two
-    ///     requests) with room for the clock and a timezone offset change inside the window. The
+    ///     requests on the V3 path, seven on V2) with room for the clock and a timezone offset change inside the window. The
     ///     ceiling keeps a scheduled run to a handful of chunks — the full history is the walk's job.
     /// </summary>
     [ConnectorProperty(ConnectorPropertyKey.LookbackDays, DefaultValue = "10", MinValue = 1, MaxValue = 60)]

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
@@ -79,6 +79,16 @@ public class GlookoConnectorConfiguration : BaseConnectorConfiguration
     public bool V3IncludeCgmBackfill { get; set; } = false;
 
     /// <summary>
+    ///     How many days back a background sync reaches. Glooko receives pump data in batches, days
+    ///     after the fact, so the window is a fixed lookback rather than a resume point at the newest
+    ///     stored record; anything that arrives later than this is picked up by the daily full walk
+    ///     over <see cref="GlookoConstants.FullWalkMonths"/>. Twelve days plus the one-day padding on
+    ///     each side of the request is exactly one <see cref="GlookoConstants.SyncChunkSize"/> fetch.
+    /// </summary>
+    [ConnectorProperty(ConnectorPropertyKey.LookbackDays, DefaultValue = "12", MinValue = 1, MaxValue = 180)]
+    public int LookbackDays { get; set; } = 12;
+
+    /// <summary>
     ///     Sync via Glooko's granular SSV2 cursor protocol — the per-resource <c>/api/v2/{resource}</c>
     ///     endpoints the mobile app uses — instead of the date-windowed web graph/batch flow. When enabled
     ///     this path sources <em>every</em> data type incrementally by persisted per-resource cursor:

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
@@ -288,9 +288,20 @@ public static class GlookoConstants
     public static readonly TimeSpan FullWalkInterval = TimeSpan.FromDays(1);
 
     /// <summary>
-    ///     The sync-cursor resource under which the last completed full walk is recorded.
+    ///     How long after a failed full walk the next one is tried. Shorter than
+    ///     <see cref="FullWalkInterval"/> so a new connection whose first walk failed is not left on
+    ///     the lookback for a day; longer than a poll interval so a persistently failing window is
+    ///     not walked every cycle.
+    /// </summary>
+    public static readonly TimeSpan FullWalkRetryInterval = TimeSpan.FromHours(1);
+
+    /// <summary>
+    ///     The sync-cursor resources under which the last completed and the last attempted full walk
+    ///     are recorded.
     /// </summary>
     public const string FullWalkCursorResource = "full-walk";
+
+    public const string FullWalkAttemptCursorResource = "full-walk-attempt";
 
     // -- Device information (sent during sign-in) -----------------------------
 

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
@@ -296,11 +296,14 @@ public static class GlookoConstants
     public static readonly TimeSpan FullWalkRetryInterval = TimeSpan.FromHours(1);
 
     /// <summary>
-    ///     The sync-cursor resources under which the last completed and the last attempted full walk
-    ///     are recorded.
+    ///     The sync-cursor resource under which the last completed full walk is recorded.
     /// </summary>
     public const string FullWalkCursorResource = "full-walk";
 
+    /// <summary>
+    ///     The sync-cursor resource under which the last attempted full walk is recorded, written
+    ///     before the walk runs so a walk that never finishes still counts against the retry interval.
+    /// </summary>
     public const string FullWalkAttemptCursorResource = "full-walk-attempt";
 
     // -- Device information (sent during sign-in) -----------------------------

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
@@ -274,6 +274,24 @@ public static class GlookoConstants
     /// </summary>
     public static readonly TimeSpan SyncChunkSize = TimeSpan.FromDays(14);
 
+    /// <summary>
+    ///     How far back a full walk reads. Glooko posts pump data in batches, often days after the
+    ///     fact, so a background sync cannot resume from the newest stored record; it re-reads a
+    ///     short lookback every run and this whole span once per <see cref="FullWalkInterval"/>.
+    /// </summary>
+    public const int FullWalkMonths = 6;
+
+    /// <summary>
+    ///     How often a background sync sets its lookback aside and walks <see cref="FullWalkMonths"/>
+    ///     of history. Late arrivals older than the lookback land within this long of reaching Glooko.
+    /// </summary>
+    public static readonly TimeSpan FullWalkInterval = TimeSpan.FromDays(1);
+
+    /// <summary>
+    ///     The sync-cursor resource under which the last completed full walk is recorded.
+    /// </summary>
+    public const string FullWalkCursorResource = "full-walk";
+
     // -- Device information (sent during sign-in) -----------------------------
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -488,7 +488,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
     /// <summary>
     ///     Stamps <paramref name="resource"/> with <paramref name="at"/>. A store that cannot be
-    ///     written costs a repeated walk later, not the sync that just succeeded.
+    ///     written does not fail the sync; while it stays unwritable the schedule cannot remember a
+    ///     walk and every scheduled run walks, which is what the warning is for.
     /// </summary>
     private async Task RecordFullWalkAsync(string resource, DateTime at, CancellationToken cancellationToken)
     {

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -333,19 +333,19 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             // static offset when the timeline is empty (e.g. V2-only accounts, or profile tz unknown).
             await ConfigureTimezoneTimelineAsync(context, cancellationToken);
 
+            var window = await ResolveSyncWindowAsync(request, config, cancellationToken);
+
             // The request window is real-UTC; Glooko queries expect fake-UTC (local wall-clock). Pad by
             // a day each side so a non-zero offset between the two never clips edge data (dedup absorbs
             // the overlap).
-            var from = request.From.HasValue
-                ? context.TimeMapper.ToGlookoTime(request.From.Value).AddDays(-1)
-                : context.TimeMapper.ToGlookoTime(DateTime.UtcNow.AddMonths(-6)).AddDays(-1);
-            var to = context.TimeMapper.ToGlookoTime(request.To ?? DateTime.UtcNow).AddDays(1);
+            var from = context.TimeMapper.ToGlookoTime(window.From).AddDays(-1);
+            var to = context.TimeMapper.ToGlookoTime(window.To).AddDays(1);
 
             var chunks = DateChunker.Chunk(from, to, GlookoConstants.SyncChunkSize).ToList();
 
             _logger.LogInformation(
-                "[{ConnectorSource}] Syncing {From:yyyy-MM-dd} to {To:yyyy-MM-dd} in {ChunkCount} chunk(s)",
-                ConnectorSource, from, to, chunks.Count);
+                "[{ConnectorSource}] Syncing {From:yyyy-MM-dd} to {To:yyyy-MM-dd} in {ChunkCount} chunk(s) ({Mode})",
+                ConnectorSource, from, to, chunks.Count, window.FullWalk ? "full walk" : "incremental");
 
             // Run the sync; if Glooko rejects the patient code (403 data_cant_view) the cached
             // glookoCode has gone stale (e.g. the account was re-linked), so re-authenticate once
@@ -394,6 +394,11 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 }
             }
 
+            // Recorded only once the walk has succeeded, so a run that stopped at a failed chunk is
+            // walked again next time rather than counting against the schedule.
+            if (window.FullWalk && result.Success)
+                await RecordFullWalkAsync(cancellationToken);
+
             result.EndTime = DateTime.UtcNow;
             return result;
         }
@@ -406,6 +411,58 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             result.EndTime = DateTime.UtcNow;
             return result;
         }
+    }
+
+    /// <summary>
+    ///     This run's lower bound, in real UTC, and whether the run is a full walk.
+    ///     <para>
+    ///     An explicit range is answered as asked: it is the shape a manual re-import of one window
+    ///     sends. An open-ended run has no resume point of its own — Glooko posts pump data in
+    ///     batches, days after the fact, so the newest stored record says nothing about what is still
+    ///     to come — and reaches back <see cref="GlookoConnectorConfiguration.LookbackDays"/>, or the
+    ///     full <see cref="GlookoConstants.FullWalkMonths"/> when a walk is due. A caller's own lower
+    ///     bound can widen either but never narrow it, as
+    ///     <see cref="BaseConnectorService{TConfig}.ResumeFrom(DateTime?, DateTime)"/> reads it.
+    ///     </para>
+    ///     SSV2 resumes every resource from its stored cursor and ignores the bound on an open-ended
+    ///     run, so it keeps the history floor and no walk is scheduled for it; so does a service
+    ///     without a cursor store (detached tooling), which has nowhere to remember a walk.
+    ///     Both bounds come from one reading of the clock so the lookback plus its padding measures
+    ///     exactly the chunk it was sized to.
+    /// </summary>
+    private async Task<(DateTime From, DateTime To, bool FullWalk)> ResolveSyncWindowAsync(
+        SyncRequest request, GlookoConnectorConfiguration config, CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var historyFloor = now.AddMonths(-GlookoConstants.FullWalkMonths);
+        var to = request.To ?? now;
+
+        if (request.To.HasValue || config.UseSsv2Sync || _cursorStore is null)
+            return (request.From ?? historyFloor, to, false);
+
+        var fullWalk = await IsFullWalkDueAsync(cancellationToken);
+        var resumePoint = fullWalk ? historyFloor : now.AddDays(-config.LookbackDays);
+        return (ResumeFrom(request.From, resumePoint), to, fullWalk);
+    }
+
+    private async Task<bool> IsFullWalkDueAsync(CancellationToken cancellationToken)
+    {
+        var cursor = await _cursorStore!.GetAsync(
+            ServiceName, GlookoConstants.FullWalkCursorResource, cancellationToken);
+        return FullWalkSchedule.IsDue(
+            cursor?.LastUpdatedAt, GlookoConstants.FullWalkInterval, DateTimeOffset.UtcNow);
+    }
+
+    private async Task RecordFullWalkAsync(CancellationToken cancellationToken)
+    {
+        if (_cursorStore is null)
+            return;
+
+        await _cursorStore.SetAsync(
+            ServiceName,
+            GlookoConstants.FullWalkCursorResource,
+            new ConnectorSyncCursor(FullWalkSchedule.Stamp(DateTimeOffset.UtcNow), null),
+            cancellationToken);
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -333,19 +333,19 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             // static offset when the timeline is empty (e.g. V2-only accounts, or profile tz unknown).
             await ConfigureTimezoneTimelineAsync(context, cancellationToken);
 
-            var window = await ResolveSyncWindowAsync(request, config, cancellationToken);
-
             // The request window is real-UTC; Glooko queries expect fake-UTC (local wall-clock). Pad by
             // a day each side so a non-zero offset between the two never clips edge data (dedup absorbs
-            // the overlap).
-            var from = context.TimeMapper.ToGlookoTime(window.From).AddDays(-1);
-            var to = context.TimeMapper.ToGlookoTime(window.To).AddDays(1);
+            // the overlap). A range naming no lower bound reaches back the full history floor.
+            var now = DateTime.UtcNow;
+            var from = context.TimeMapper.ToGlookoTime(
+                request.From ?? now.AddMonths(-GlookoConstants.FullWalkMonths)).AddDays(-1);
+            var to = context.TimeMapper.ToGlookoTime(request.To ?? now).AddDays(1);
 
             var chunks = DateChunker.Chunk(from, to, GlookoConstants.SyncChunkSize).ToList();
 
             _logger.LogInformation(
-                "[{ConnectorSource}] Syncing {From:yyyy-MM-dd} to {To:yyyy-MM-dd} in {ChunkCount} chunk(s) ({Mode})",
-                ConnectorSource, from, to, chunks.Count, window.FullWalk ? "full walk" : "incremental");
+                "[{ConnectorSource}] Syncing {From:yyyy-MM-dd} to {To:yyyy-MM-dd} in {ChunkCount} chunk(s)",
+                ConnectorSource, from, to, chunks.Count);
 
             // Run the sync; if Glooko rejects the patient code (403 data_cant_view) the cached
             // glookoCode has gone stale (e.g. the account was re-linked), so re-authenticate once
@@ -394,11 +394,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 }
             }
 
-            // Recorded only once the walk has succeeded, so a run that stopped at a failed chunk is
-            // walked again next time rather than counting against the schedule.
-            if (window.FullWalk && result.Success)
-                await RecordFullWalkAsync(cancellationToken);
-
             result.EndTime = DateTime.UtcNow;
             return result;
         }
@@ -414,55 +409,102 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     }
 
     /// <summary>
-    ///     This run's lower bound, in real UTC, and whether the run is a full walk.
-    ///     <para>
-    ///     An explicit range is answered as asked: it is the shape a manual re-import of one window
-    ///     sends. An open-ended run has no resume point of its own — Glooko posts pump data in
-    ///     batches, days after the fact, so the newest stored record says nothing about what is still
-    ///     to come — and reaches back <see cref="GlookoConnectorConfiguration.LookbackDays"/>, or the
-    ///     full <see cref="GlookoConstants.FullWalkMonths"/> when a walk is due. A caller's own lower
-    ///     bound can widen either but never narrow it, as
-    ///     <see cref="BaseConnectorService{TConfig}.ResumeFrom(DateTime?, DateTime)"/> reads it.
-    ///     </para>
-    ///     SSV2 resumes every resource from its stored cursor and ignores the bound on an open-ended
-    ///     run, so it keeps the history floor and no walk is scheduled for it; so does a service
-    ///     without a cursor store (detached tooling), which has nowhere to remember a walk.
-    ///     Both bounds come from one reading of the clock so the lookback plus its padding measures
-    ///     exactly the chunk it was sized to.
+    ///     Entry point for the scheduled sync.
     /// </summary>
-    private async Task<(DateTime From, DateTime To, bool FullWalk)> ResolveSyncWindowAsync(
-        SyncRequest request, GlookoConnectorConfiguration config, CancellationToken cancellationToken)
+    /// <remarks>
+    ///     The base derives the window from the tenant's newest glucose reading. Most Glooko accounts
+    ///     never store one (CGM backfill is off by default), so that resolves to the six-month
+    ///     <see cref="BaseConnectorService{TConfig}.InitialSyncFloor"/> on every run; and where one
+    ///     exists it says nothing about what is still to come, because Glooko posts pump data in
+    ///     batches days after the fact. The connector therefore reads a fixed
+    ///     <see cref="GlookoConnectorConfiguration.LookbackDays"/> each run, and the floor once per
+    ///     <see cref="GlookoConstants.FullWalkInterval"/>. The walk is recorded only once it has
+    ///     succeeded, so a run that stopped at a failed chunk is walked again — after
+    ///     <see cref="GlookoConstants.FullWalkRetryInterval"/>, not on every cycle, so a persistently
+    ///     failing window cannot reinstate the per-cycle cost the schedule exists to remove.
+    ///     <para>
+    ///     SSV2 resumes every resource from its own cursor and ignores the bound on a scheduled run;
+    ///     a service without a cursor store has nowhere to remember a walk; a caller naming its own
+    ///     <paramref name="since"/> has already chosen. All three take the base window.
+    ///     </para>
+    /// </remarks>
+    public override async Task<SyncResult> SyncDataAsync(
+        GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken = default,
+        DateTime? since = null,
+        ISyncProgressReporter? progressReporter = null)
     {
+        if (since.HasValue || config.UseSsv2Sync || _cursorStore is null)
+            return await base.SyncDataAsync(config, cancellationToken, since, progressReporter);
+
         var now = DateTime.UtcNow;
-        var historyFloor = now.AddMonths(-GlookoConstants.FullWalkMonths);
-        var to = request.To ?? now;
+        var fullWalk = await IsFullWalkDueAsync(now, cancellationToken);
+        var from = fullWalk
+            ? now.AddMonths(-GlookoConstants.FullWalkMonths)
+            : now.AddDays(-config.LookbackDays);
 
-        if (request.To.HasValue || config.UseSsv2Sync || _cursorStore is null)
-            return (request.From ?? historyFloor, to, false);
+        _logger.LogInformation(
+            "[{ConnectorSource}] Scheduled sync reaches back to {From:yyyy-MM-dd} ({Mode})",
+            ConnectorSource, from, fullWalk ? "full walk" : "incremental");
 
-        var fullWalk = await IsFullWalkDueAsync(cancellationToken);
-        var resumePoint = fullWalk ? historyFloor : now.AddDays(-config.LookbackDays);
-        return (ResumeFrom(request.From, resumePoint), to, fullWalk);
+        if (fullWalk)
+            await RecordFullWalkAsync(GlookoConstants.FullWalkAttemptCursorResource, now, cancellationToken);
+
+        var result = await base.SyncDataAsync(config, cancellationToken, from, progressReporter);
+
+        if (fullWalk && result.Success)
+            await RecordFullWalkAsync(GlookoConstants.FullWalkCursorResource, now, cancellationToken);
+
+        return result;
     }
 
-    private async Task<bool> IsFullWalkDueAsync(CancellationToken cancellationToken)
+    /// <summary>
+    ///     Whether the scheduled run should walk the full history: the last completed walk is older
+    ///     than the interval and the last attempt older than the retry interval. A store that cannot
+    ///     be read walks, so a transient fault costs one extra walk rather than a missed one.
+    /// </summary>
+    private async Task<bool> IsFullWalkDueAsync(DateTime now, CancellationToken cancellationToken)
     {
-        var cursor = await _cursorStore!.GetAsync(
-            ServiceName, GlookoConstants.FullWalkCursorResource, cancellationToken);
-        return FullWalkSchedule.IsDue(
-            cursor?.LastUpdatedAt, GlookoConstants.FullWalkInterval, DateTimeOffset.UtcNow);
+        try
+        {
+            var completed = await _cursorStore!.GetAsync(
+                ServiceName, GlookoConstants.FullWalkCursorResource, cancellationToken);
+            if (!FullWalkSchedule.IsDue(completed?.LastUpdatedAt, GlookoConstants.FullWalkInterval, now))
+                return false;
+
+            var attempted = await _cursorStore.GetAsync(
+                ServiceName, GlookoConstants.FullWalkAttemptCursorResource, cancellationToken);
+            return FullWalkSchedule.IsDue(
+                attempted?.LastUpdatedAt, GlookoConstants.FullWalkRetryInterval, now);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "[{ConnectorSource}] Could not read the full-walk schedule; walking", ConnectorSource);
+            return true;
+        }
     }
 
-    private async Task RecordFullWalkAsync(CancellationToken cancellationToken)
+    /// <summary>
+    ///     Stamps <paramref name="resource"/> with <paramref name="at"/>. A store that cannot be
+    ///     written costs a repeated walk later, not the sync that just succeeded.
+    /// </summary>
+    private async Task RecordFullWalkAsync(string resource, DateTime at, CancellationToken cancellationToken)
     {
-        if (_cursorStore is null)
-            return;
-
-        await _cursorStore.SetAsync(
-            ServiceName,
-            GlookoConstants.FullWalkCursorResource,
-            new ConnectorSyncCursor(FullWalkSchedule.Stamp(DateTimeOffset.UtcNow), null),
-            cancellationToken);
+        try
+        {
+            await _cursorStore!.SetAsync(
+                ServiceName, resource,
+                new ConnectorSyncCursor(FullWalkSchedule.Stamp(new DateTimeOffset(at, TimeSpan.Zero)), null),
+                cancellationToken);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "[{ConnectorSource}] Could not record the full walk ({Resource})", ConnectorSource, resource);
+        }
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
@@ -8,6 +8,7 @@ using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Connectors.MyFitnessPal.Configurations;
 using Nocturne.Connectors.MyFitnessPal.Mappers;
 using Nocturne.Connectors.MyFitnessPal.Models;
@@ -136,7 +137,7 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
             // reconciling is retried rather than counting against the schedule.
             if (read.WalkedEntireDiary)
             {
-                config.LastFullWalkAt = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
+                config.LastFullWalkAt = FullWalkSchedule.Stamp(DateTimeOffset.UtcNow);
                 await PersistSecretsIfChangedAsync(config, cancellationToken);
             }
         }
@@ -185,20 +186,9 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
     /// provides it. An unset or unparseable timestamp walks — a connector that has never completed
     /// one has never reconciled.
     /// </remarks>
-    public static bool IsFullWalkDue(MyFitnessPalConnectorConfiguration config)
-    {
-        if (!DateTimeOffset.TryParse(
-                config.LastFullWalkAt,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.RoundtripKind,
-                out var last))
-            return true;
-
-        // A timestamp in the future means a clock moved, which would otherwise suppress the walk
-        // until it caught up.
-        return DateTimeOffset.UtcNow - last >= MyFitnessPalConstants.FullWalkInterval
-               || last > DateTimeOffset.UtcNow;
-    }
+    public static bool IsFullWalkDue(MyFitnessPalConnectorConfiguration config) =>
+        FullWalkSchedule.IsDue(
+            config.LastFullWalkAt, MyFitnessPalConstants.FullWalkInterval, DateTimeOffset.UtcNow);
 
     /// <summary>
     /// Obtains an access token and the MyFitnessPal user id required by the GraphQL API.

--- a/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
+++ b/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
@@ -234,10 +234,10 @@ export const connectorPropertyMeta = {
     category: 'Advanced',
   },
 
-  // MyFitnessPal-specific
+  // MyFitnessPal and Glooko
   LookbackDays: {
     label: 'Lookback Days',
-    description: 'Number of days of historical data to retrieve',
+    description: 'How many days back each sync reaches',
     category: 'Sync',
   },
   LastFullWalkAt: {

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Utilities/FullWalkScheduleTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Utilities/FullWalkScheduleTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Nocturne.Connectors.Core.Utilities;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Utilities;
+
+public class FullWalkScheduleTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 9, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Interval = TimeSpan.FromDays(1);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not a timestamp")]
+    public void IsDue_WalksWhenNoWalkHasEverCompleted(string? stamp)
+    {
+        FullWalkSchedule.IsDue(stamp, Interval, Now).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDue_SkipsTheWalkUntilTheIntervalHasElapsed()
+    {
+        var justNow = FullWalkSchedule.Stamp(Now.AddMinutes(-30));
+        var onTheInterval = FullWalkSchedule.Stamp(Now - Interval);
+        var oneMinuteShort = FullWalkSchedule.Stamp(Now - Interval + TimeSpan.FromMinutes(1));
+
+        FullWalkSchedule.IsDue(justNow, Interval, Now).Should().BeFalse();
+        FullWalkSchedule.IsDue(oneMinuteShort, Interval, Now).Should().BeFalse();
+        FullWalkSchedule.IsDue(onTheInterval, Interval, Now).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDue_WalksWhenTheStoredTimeIsInTheFuture()
+    {
+        var ahead = FullWalkSchedule.Stamp(Now.AddDays(3));
+
+        FullWalkSchedule.IsDue(ahead, Interval, Now).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Stamp_RoundTripsThroughIsDueWithTheInstantIntact()
+    {
+        // A stamp in another zone still compares as the instant it names.
+        var completedAt = new DateTimeOffset(2026, 9, 9, 22, 0, 0, TimeSpan.FromHours(10));
+        var stamp = FullWalkSchedule.Stamp(completedAt);
+
+        stamp.Should().Be("2026-09-09T22:00:00.0000000+10:00");
+        FullWalkSchedule.IsDue(stamp, Interval, Now).Should().BeFalse("12:00Z is the same instant, not a day later");
+        FullWalkSchedule.IsDue(stamp, Interval, Now.AddDays(1)).Should().BeTrue();
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceBackgroundWindowTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceBackgroundWindowTests.cs
@@ -132,13 +132,23 @@ public class GlookoConnectorServiceBackgroundWindowTests
     [Fact]
     public async Task ScheduledRun_WhenTheWalkFails_RecordsTheAttemptAndBacksOff()
     {
-        var store = new FakeCursorStore();
         var failing = new GlookoEndpointHandler(failingPaths: [GlookoConstants.V3GraphDataPath]);
+        var requestsWhenAttemptLanded = -1;
+        var store = new FakeCursorStore
+        {
+            OnSet = resource =>
+            {
+                if (resource == Attempted)
+                    requestsWhenAttemptLanded = failing.RequestsFor(GlookoConstants.V3GraphDataPath);
+            },
+        };
 
         var result = await Scheduled(GlookoSyncHarness.Service(failing, cursorStore: store), ScheduledConfig());
 
         result.Success.Should().BeFalse();
         store.Saved.Keys.Should().BeEquivalentTo([Attempted]);
+        requestsWhenAttemptLanded.Should().Be(0,
+            "the attempt is stamped before the walk starts, so a walk that never finishes still counts");
 
         var next = new GlookoEndpointHandler();
         await Scheduled(GlookoSyncHarness.Service(next, cursorStore: store), ScheduledConfig());

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceBackgroundWindowTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceBackgroundWindowTests.cs
@@ -9,194 +9,206 @@ using Xunit;
 namespace Nocturne.Connectors.Glooko.Tests.Services;
 
 /// <summary>
-/// A background run has no upper bound and, for most Glooko accounts, no glucose watermark to hand
-/// it a lower one, so the connector used to answer every such run with the whole history floor:
-/// fourteen chunks and twenty-eight requests, every five minutes, for ever. The window now reaches
-/// back a fixed lookback, and the whole floor only once per <see cref="GlookoConstants.FullWalkInterval"/>.
+/// The scheduled run is the connector's own to bound: the base hands it the glucose watermark, which
+/// most Glooko accounts never have, and then the six-month floor — fourteen chunks and twenty-eight
+/// requests, every five minutes, for ever. Every test here drives the scheduled entry point, the
+/// shape <c>ConnectorBackgroundService</c> actually sends, and asserts the date windows Glooko is
+/// asked for.
 /// </summary>
 public class GlookoConnectorServiceBackgroundWindowTests
 {
-    private static readonly SyncDataType[] Types =
-    [
-        SyncDataType.StateSpans, SyncDataType.TempBasals, SyncDataType.DeviceEvents, SyncDataType.Profiles,
-    ];
+    private static readonly string Completed = GlookoConstants.FullWalkCursorResource;
+    private static readonly string Attempted = GlookoConstants.FullWalkAttemptCursorResource;
 
     /// <summary>
-    /// A stamp that keeps the schedule quiet: half an hour into the interval.
+    /// The harness serves the state-span, temp-basal, device-event and profile feeds; the rest of
+    /// the connector's types are switched off so the scheduled run reports on what it fetched.
     /// </summary>
-    private static ConnectorSyncCursor RecentWalk() =>
-        new(FullWalkSchedule.Stamp(DateTimeOffset.UtcNow.AddMinutes(-30)), null);
+    private static GlookoConnectorConfiguration ScheduledConfig(bool useV3Api = true)
+    {
+        var config = GlookoSyncHarness.Config(useV3Api);
+        config.SyncGlucose = false;
+        config.SyncManualBG = false;
+        config.SyncBoluses = false;
+        config.SyncBasalInjections = false;
+        config.SyncCarbIntake = false;
+        config.SyncBolusCalculations = false;
+        config.SyncNotes = false;
+        config.SyncFood = false;
+        config.SyncActivity = false;
+        return config;
+    }
+
+    private static ConnectorSyncCursor StampAgo(TimeSpan ago) =>
+        new(FullWalkSchedule.Stamp(DateTimeOffset.UtcNow - ago), null);
+
+    private static FakeCursorStore StoreWith(params (string Resource, ConnectorSyncCursor Cursor)[] stamps)
+    {
+        var store = new FakeCursorStore();
+        foreach (var (resource, cursor) in stamps)
+            store.Saved[resource] = cursor;
+        return store;
+    }
+
+    private static Task<SyncResult> Scheduled(
+        RecordingGlookoConnectorService service, GlookoConnectorConfiguration config) =>
+        service.SyncDataAsync(config, CancellationToken.None);
 
     [Fact]
-    public async Task SyncDataAsync_OnTheFirstRun_WalksTheFullHistoryAndRecordsIt()
+    public async Task ScheduledRun_OnTheFirstRun_WalksTheFullHistoryAndRecordsIt()
     {
         var handler = new GlookoEndpointHandler();
         var store = new FakeCursorStore();
-        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
 
-        var result = await service.SyncDataAsync(
-            OpenEnded(), GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+        var result = await Scheduled(GlookoSyncHarness.Service(handler, cursorStore: store), ScheduledConfig());
 
         result.Success.Should().BeTrue();
         handler.WindowCount.Should().Be(FullWalkChunks());
         Parse(handler.Windows[0].Start).Should().BeCloseTo(
             DateTime.UtcNow.AddMonths(-GlookoConstants.FullWalkMonths).AddDays(-1), TimeSpan.FromHours(1));
 
-        var stamp = store.Saved.Should().ContainKey(GlookoConstants.FullWalkCursorResource).WhoseValue;
-        FullWalkSchedule.IsDue(stamp.LastUpdatedAt, GlookoConstants.FullWalkInterval, DateTimeOffset.UtcNow)
+        store.Saved.Keys.Should().BeEquivalentTo([Completed, Attempted]);
+        FullWalkSchedule.IsDue(store.Saved[Completed].LastUpdatedAt, GlookoConstants.FullWalkInterval, DateTimeOffset.UtcNow)
             .Should().BeFalse("the walk that just completed is what the next run stands on");
     }
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task SyncDataAsync_InsideTheInterval_ReachesBackOnlyTheLookback(bool useV3Api)
+    public async Task ScheduledRun_InsideTheInterval_ReachesBackOnlyTheLookback(bool useV3Api)
     {
         var handler = new GlookoEndpointHandler();
-        var seeded = RecentWalk();
-        var store = new FakeCursorStore { Saved = { [GlookoConstants.FullWalkCursorResource] = seeded } };
+        var seeded = StampAgo(TimeSpan.FromMinutes(30));
+        var store = StoreWith((Completed, seeded));
+        var config = ScheduledConfig(useV3Api);
         var service = GlookoSyncHarness.Service(handler, cursorStore: store);
-        var config = GlookoSyncHarness.Config(useV3Api);
 
-        var result = await service.SyncDataAsync(OpenEnded(), config, CancellationToken.None);
+        var result = await Scheduled(service, config);
 
         result.Success.Should().BeTrue();
-        // The lookback plus the day of padding on each side is exactly one chunk.
+        // The lookback plus the day of padding on each side is one chunk.
         handler.WindowCount.Should().Be(1);
         Parse(handler.Windows[0].Start).Should().BeCloseTo(
             DateTime.UtcNow.AddDays(-config.LookbackDays - 1), TimeSpan.FromHours(1));
-        store.Saved[GlookoConstants.FullWalkCursorResource].Should().BeSameAs(seeded,
-            "an incremental run leaves the walk stamp alone");
+        store.Saved.Should().HaveCount(1);
+        store.Saved[Completed].Should().BeSameAs(seeded, "an incremental run leaves the stamps alone");
         service.Published.Should().Contain(PublishKind.StateSpans);
     }
 
     [Fact]
-    public async Task SyncDataAsync_InsideTheInterval_HonoursAWiderLookback()
+    public async Task ScheduledRun_InsideTheInterval_HonoursAWiderLookback()
     {
         var handler = new GlookoEndpointHandler();
-        var store = new FakeCursorStore { Saved = { [GlookoConstants.FullWalkCursorResource] = RecentWalk() } };
-        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
-        var config = GlookoSyncHarness.Config(useV3Api: true);
+        var config = ScheduledConfig();
         config.LookbackDays = 30;
 
-        await service.SyncDataAsync(OpenEnded(), config, CancellationToken.None);
+        await Scheduled(
+            GlookoSyncHarness.Service(handler, cursorStore: StoreWith((Completed, StampAgo(TimeSpan.FromMinutes(30))))),
+            config);
 
         handler.WindowCount.Should().Be(3, "30 days plus two of padding is three fortnightly chunks");
-        Parse(handler.Windows[0].Start).Should().BeCloseTo(
-            DateTime.UtcNow.AddDays(-31), TimeSpan.FromHours(1));
+        Parse(handler.Windows[0].Start).Should().BeCloseTo(DateTime.UtcNow.AddDays(-31), TimeSpan.FromHours(1));
     }
 
     [Fact]
-    public async Task SyncDataAsync_OnceTheIntervalHasElapsed_WalksAgain()
+    public async Task ScheduledRun_OnceTheIntervalHasElapsed_WalksAgain()
     {
         var handler = new GlookoEndpointHandler();
-        var overdue = DateTimeOffset.UtcNow - GlookoConstants.FullWalkInterval - TimeSpan.FromMinutes(1);
-        var store = new FakeCursorStore
-        {
-            Saved = { [GlookoConstants.FullWalkCursorResource] = new(FullWalkSchedule.Stamp(overdue), null) },
-        };
-        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
+        var overdue = GlookoConstants.FullWalkInterval + TimeSpan.FromMinutes(1);
+        var store = StoreWith((Completed, StampAgo(overdue)), (Attempted, StampAgo(overdue)));
 
-        await service.SyncDataAsync(OpenEnded(), GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+        await Scheduled(GlookoSyncHarness.Service(handler, cursorStore: store), ScheduledConfig());
 
         handler.WindowCount.Should().Be(FullWalkChunks());
-        Parse(store.Saved[GlookoConstants.FullWalkCursorResource].LastUpdatedAt!)
-            .Should().BeAfter(overdue.UtcDateTime, "the new walk replaces the stale stamp");
+        Parse(store.Saved[Completed].LastUpdatedAt!).Should().BeAfter(
+            DateTime.UtcNow - overdue, "the new walk replaces the stale stamp");
     }
 
     /// <summary>
-    /// A chunk that fails stops the pass, so the walk has not covered its history and must not be
-    /// counted; the next run walks again instead of settling into the lookback.
+    /// A chunk that fails stops the pass, so the walk has not covered its history and is not counted
+    /// as completed — but it was attempted, and the next runs stay on the lookback until the retry
+    /// interval has passed rather than walking every cycle.
     /// </summary>
     [Fact]
-    public async Task SyncDataAsync_WhenTheWalkFails_DoesNotRecordIt()
+    public async Task ScheduledRun_WhenTheWalkFails_RecordsTheAttemptAndBacksOff()
     {
-        var handler = new GlookoEndpointHandler(failingPaths: [GlookoConstants.V3GraphDataPath]);
         var store = new FakeCursorStore();
-        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
+        var failing = new GlookoEndpointHandler(failingPaths: [GlookoConstants.V3GraphDataPath]);
 
-        var result = await service.SyncDataAsync(
-            OpenEnded(), GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+        var result = await Scheduled(GlookoSyncHarness.Service(failing, cursorStore: store), ScheduledConfig());
 
         result.Success.Should().BeFalse();
-        store.Saved.Should().NotContainKey(GlookoConstants.FullWalkCursorResource);
+        store.Saved.Keys.Should().BeEquivalentTo([Attempted]);
+
+        var next = new GlookoEndpointHandler();
+        await Scheduled(GlookoSyncHarness.Service(next, cursorStore: store), ScheduledConfig());
+
+        next.WindowCount.Should().Be(1, "the retry interval has not elapsed");
+        store.Saved.Should().NotContainKey(Completed);
     }
 
-    /// <summary>
-    /// The caller's lower bound and the schedule's each reach as far back as the other allows: a
-    /// repair from six weeks ago is not clipped to the lookback, and a bound inside the lookback
-    /// does not narrow it.
-    /// </summary>
     [Fact]
-    public async Task SyncDataAsync_WithACallerLowerBound_WidensButNeverNarrowsTheLookback()
+    public async Task ScheduledRun_OnceTheRetryIntervalHasElapsed_WalksAgainAfterAFailure()
     {
-        var store = new FakeCursorStore { Saved = { [GlookoConstants.FullWalkCursorResource] = RecentWalk() } };
-        var config = GlookoSyncHarness.Config(useV3Api: true);
+        var handler = new GlookoEndpointHandler();
+        var store = StoreWith((Attempted, StampAgo(GlookoConstants.FullWalkRetryInterval + TimeSpan.FromMinutes(1))));
 
-        var wider = new GlookoEndpointHandler();
-        await GlookoSyncHarness.Service(wider, cursorStore: store).SyncDataAsync(
-            OpenEnded(from: DateTime.UtcNow.AddDays(-42)), config, CancellationToken.None);
+        await Scheduled(GlookoSyncHarness.Service(handler, cursorStore: store), ScheduledConfig());
 
-        wider.WindowCount.Should().Be(4, "six weeks plus padding is four chunks");
-        Parse(wider.Windows[0].Start).Should().BeCloseTo(DateTime.UtcNow.AddDays(-43), TimeSpan.FromHours(1));
-
-        var narrower = new GlookoEndpointHandler();
-        await GlookoSyncHarness.Service(narrower, cursorStore: store).SyncDataAsync(
-            OpenEnded(from: DateTime.UtcNow.AddDays(-2)), config, CancellationToken.None);
-
-        narrower.WindowCount.Should().Be(1);
-        Parse(narrower.Windows[0].Start).Should().BeCloseTo(
-            DateTime.UtcNow.AddDays(-config.LookbackDays - 1), TimeSpan.FromHours(1));
+        handler.WindowCount.Should().Be(FullWalkChunks());
+        store.Saved.Should().ContainKey(Completed);
     }
 
     /// <summary>
-    /// An explicit range is a manual re-import of one window: it is answered as asked whatever the
-    /// schedule says, and it is not a walk, so it neither records one nor consumes one.
+    /// A caller that names its own lower bound has already chosen; the schedule neither widens nor
+    /// records.
     /// </summary>
     [Fact]
-    public async Task SyncDataAsync_WithAnExplicitRange_IgnoresTheSchedule()
+    public async Task ScheduledRun_WithACallerSince_HonoursItAndLeavesTheScheduleAlone()
     {
         var handler = new GlookoEndpointHandler();
         var store = new FakeCursorStore();
-        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
 
-        var result = await service.SyncDataAsync(
-            new SyncRequest
-            {
-                From = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-                To = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc),
-                DataTypes = [.. Types],
-            },
-            GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+        await GlookoSyncHarness.Service(handler, cursorStore: store).SyncDataAsync(
+            ScheduledConfig(), CancellationToken.None, since: DateTime.UtcNow.AddDays(-3));
 
-        result.Success.Should().BeTrue();
-        handler.WindowCount.Should().Be(3);
+        handler.WindowCount.Should().Be(1);
+        Parse(handler.Windows[0].Start).Should().BeCloseTo(DateTime.UtcNow.AddDays(-4), TimeSpan.FromHours(1));
         store.Saved.Should().BeEmpty();
     }
 
     /// <summary>
-    /// Nothing can remember a walk without a store, so a detached service (dry-run tooling) has no
-    /// schedule: it answers the caller's bound, or the floor when there is none, as it always did.
+    /// The tenant's own sync button sends a request with neither bound. It is not a scheduled run,
+    /// so it re-pulls the floor as it always did and never touches the schedule — clicking it does
+    /// not spend the day's walk.
     /// </summary>
     [Fact]
-    public async Task SyncDataAsync_WithoutACursorStore_AnswersTheCallerOrTheFloor()
+    public async Task RequestedRun_WithNoBounds_ReadsTheFloorAndLeavesTheScheduleAlone()
     {
-        var floor = new GlookoEndpointHandler();
-        await GlookoSyncHarness.Service(floor).SyncDataAsync(
-            OpenEnded(), GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+        var handler = new GlookoEndpointHandler();
+        var store = new FakeCursorStore();
 
-        floor.WindowCount.Should().Be(FullWalkChunks());
+        var result = await GlookoSyncHarness.Service(handler, cursorStore: store).SyncDataAsync(
+            new SyncRequest(), ScheduledConfig(), CancellationToken.None);
 
-        var bounded = new GlookoEndpointHandler();
-        await GlookoSyncHarness.Service(bounded).SyncDataAsync(
-            OpenEnded(from: DateTime.UtcNow.AddDays(-3)), GlookoSyncHarness.Config(useV3Api: true),
-            CancellationToken.None);
-
-        bounded.WindowCount.Should().Be(1, "the caller's three days are not widened to any lookback");
-        Parse(bounded.Windows[0].Start).Should().BeCloseTo(DateTime.UtcNow.AddDays(-4), TimeSpan.FromHours(1));
+        result.Success.Should().BeTrue();
+        handler.WindowCount.Should().Be(FullWalkChunks());
+        store.Saved.Should().BeEmpty();
     }
 
-    private static SyncRequest OpenEnded(DateTime? from = null) => new() { From = from, DataTypes = [.. Types] };
+    /// <summary>
+    /// Nothing can remember a walk without a store, so a detached service (dry-run tooling) takes the
+    /// base window, which for an account without Glooko glucose is the floor.
+    /// </summary>
+    [Fact]
+    public async Task ScheduledRun_WithoutACursorStore_TakesTheBaseWindow()
+    {
+        var handler = new GlookoEndpointHandler();
+
+        await Scheduled(GlookoSyncHarness.Service(handler), ScheduledConfig());
+
+        handler.WindowCount.Should().Be(FullWalkChunks());
+    }
 
     /// <summary>
     /// The chunk count the floor spans, computed the way the sync computes it so a month's length

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceBackgroundWindowTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceBackgroundWindowTests.cs
@@ -1,0 +1,217 @@
+using System.Globalization;
+using FluentAssertions;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Connectors.Glooko.Configurations;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+/// A background run has no upper bound and, for most Glooko accounts, no glucose watermark to hand
+/// it a lower one, so the connector used to answer every such run with the whole history floor:
+/// fourteen chunks and twenty-eight requests, every five minutes, for ever. The window now reaches
+/// back a fixed lookback, and the whole floor only once per <see cref="GlookoConstants.FullWalkInterval"/>.
+/// </summary>
+public class GlookoConnectorServiceBackgroundWindowTests
+{
+    private static readonly SyncDataType[] Types =
+    [
+        SyncDataType.StateSpans, SyncDataType.TempBasals, SyncDataType.DeviceEvents, SyncDataType.Profiles,
+    ];
+
+    /// <summary>
+    /// A stamp that keeps the schedule quiet: half an hour into the interval.
+    /// </summary>
+    private static ConnectorSyncCursor RecentWalk() =>
+        new(FullWalkSchedule.Stamp(DateTimeOffset.UtcNow.AddMinutes(-30)), null);
+
+    [Fact]
+    public async Task SyncDataAsync_OnTheFirstRun_WalksTheFullHistoryAndRecordsIt()
+    {
+        var handler = new GlookoEndpointHandler();
+        var store = new FakeCursorStore();
+        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
+
+        var result = await service.SyncDataAsync(
+            OpenEnded(), GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        handler.WindowCount.Should().Be(FullWalkChunks());
+        Parse(handler.Windows[0].Start).Should().BeCloseTo(
+            DateTime.UtcNow.AddMonths(-GlookoConstants.FullWalkMonths).AddDays(-1), TimeSpan.FromHours(1));
+
+        var stamp = store.Saved.Should().ContainKey(GlookoConstants.FullWalkCursorResource).WhoseValue;
+        FullWalkSchedule.IsDue(stamp.LastUpdatedAt, GlookoConstants.FullWalkInterval, DateTimeOffset.UtcNow)
+            .Should().BeFalse("the walk that just completed is what the next run stands on");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SyncDataAsync_InsideTheInterval_ReachesBackOnlyTheLookback(bool useV3Api)
+    {
+        var handler = new GlookoEndpointHandler();
+        var seeded = RecentWalk();
+        var store = new FakeCursorStore { Saved = { [GlookoConstants.FullWalkCursorResource] = seeded } };
+        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
+        var config = GlookoSyncHarness.Config(useV3Api);
+
+        var result = await service.SyncDataAsync(OpenEnded(), config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        // The lookback plus the day of padding on each side is exactly one chunk.
+        handler.WindowCount.Should().Be(1);
+        Parse(handler.Windows[0].Start).Should().BeCloseTo(
+            DateTime.UtcNow.AddDays(-config.LookbackDays - 1), TimeSpan.FromHours(1));
+        store.Saved[GlookoConstants.FullWalkCursorResource].Should().BeSameAs(seeded,
+            "an incremental run leaves the walk stamp alone");
+        service.Published.Should().Contain(PublishKind.StateSpans);
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_InsideTheInterval_HonoursAWiderLookback()
+    {
+        var handler = new GlookoEndpointHandler();
+        var store = new FakeCursorStore { Saved = { [GlookoConstants.FullWalkCursorResource] = RecentWalk() } };
+        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
+        var config = GlookoSyncHarness.Config(useV3Api: true);
+        config.LookbackDays = 30;
+
+        await service.SyncDataAsync(OpenEnded(), config, CancellationToken.None);
+
+        handler.WindowCount.Should().Be(3, "30 days plus two of padding is three fortnightly chunks");
+        Parse(handler.Windows[0].Start).Should().BeCloseTo(
+            DateTime.UtcNow.AddDays(-31), TimeSpan.FromHours(1));
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_OnceTheIntervalHasElapsed_WalksAgain()
+    {
+        var handler = new GlookoEndpointHandler();
+        var overdue = DateTimeOffset.UtcNow - GlookoConstants.FullWalkInterval - TimeSpan.FromMinutes(1);
+        var store = new FakeCursorStore
+        {
+            Saved = { [GlookoConstants.FullWalkCursorResource] = new(FullWalkSchedule.Stamp(overdue), null) },
+        };
+        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
+
+        await service.SyncDataAsync(OpenEnded(), GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+
+        handler.WindowCount.Should().Be(FullWalkChunks());
+        Parse(store.Saved[GlookoConstants.FullWalkCursorResource].LastUpdatedAt!)
+            .Should().BeAfter(overdue.UtcDateTime, "the new walk replaces the stale stamp");
+    }
+
+    /// <summary>
+    /// A chunk that fails stops the pass, so the walk has not covered its history and must not be
+    /// counted; the next run walks again instead of settling into the lookback.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheWalkFails_DoesNotRecordIt()
+    {
+        var handler = new GlookoEndpointHandler(failingPaths: [GlookoConstants.V3GraphDataPath]);
+        var store = new FakeCursorStore();
+        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
+
+        var result = await service.SyncDataAsync(
+            OpenEnded(), GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        store.Saved.Should().NotContainKey(GlookoConstants.FullWalkCursorResource);
+    }
+
+    /// <summary>
+    /// The caller's lower bound and the schedule's each reach as far back as the other allows: a
+    /// repair from six weeks ago is not clipped to the lookback, and a bound inside the lookback
+    /// does not narrow it.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WithACallerLowerBound_WidensButNeverNarrowsTheLookback()
+    {
+        var store = new FakeCursorStore { Saved = { [GlookoConstants.FullWalkCursorResource] = RecentWalk() } };
+        var config = GlookoSyncHarness.Config(useV3Api: true);
+
+        var wider = new GlookoEndpointHandler();
+        await GlookoSyncHarness.Service(wider, cursorStore: store).SyncDataAsync(
+            OpenEnded(from: DateTime.UtcNow.AddDays(-42)), config, CancellationToken.None);
+
+        wider.WindowCount.Should().Be(4, "six weeks plus padding is four chunks");
+        Parse(wider.Windows[0].Start).Should().BeCloseTo(DateTime.UtcNow.AddDays(-43), TimeSpan.FromHours(1));
+
+        var narrower = new GlookoEndpointHandler();
+        await GlookoSyncHarness.Service(narrower, cursorStore: store).SyncDataAsync(
+            OpenEnded(from: DateTime.UtcNow.AddDays(-2)), config, CancellationToken.None);
+
+        narrower.WindowCount.Should().Be(1);
+        Parse(narrower.Windows[0].Start).Should().BeCloseTo(
+            DateTime.UtcNow.AddDays(-config.LookbackDays - 1), TimeSpan.FromHours(1));
+    }
+
+    /// <summary>
+    /// An explicit range is a manual re-import of one window: it is answered as asked whatever the
+    /// schedule says, and it is not a walk, so it neither records one nor consumes one.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WithAnExplicitRange_IgnoresTheSchedule()
+    {
+        var handler = new GlookoEndpointHandler();
+        var store = new FakeCursorStore();
+        var service = GlookoSyncHarness.Service(handler, cursorStore: store);
+
+        var result = await service.SyncDataAsync(
+            new SyncRequest
+            {
+                From = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                To = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+                DataTypes = [.. Types],
+            },
+            GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        handler.WindowCount.Should().Be(3);
+        store.Saved.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Nothing can remember a walk without a store, so a detached service (dry-run tooling) has no
+    /// schedule: it answers the caller's bound, or the floor when there is none, as it always did.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WithoutACursorStore_AnswersTheCallerOrTheFloor()
+    {
+        var floor = new GlookoEndpointHandler();
+        await GlookoSyncHarness.Service(floor).SyncDataAsync(
+            OpenEnded(), GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+
+        floor.WindowCount.Should().Be(FullWalkChunks());
+
+        var bounded = new GlookoEndpointHandler();
+        await GlookoSyncHarness.Service(bounded).SyncDataAsync(
+            OpenEnded(from: DateTime.UtcNow.AddDays(-3)), GlookoSyncHarness.Config(useV3Api: true),
+            CancellationToken.None);
+
+        bounded.WindowCount.Should().Be(1, "the caller's three days are not widened to any lookback");
+        Parse(bounded.Windows[0].Start).Should().BeCloseTo(DateTime.UtcNow.AddDays(-4), TimeSpan.FromHours(1));
+    }
+
+    private static SyncRequest OpenEnded(DateTime? from = null) => new() { From = from, DataTypes = [.. Types] };
+
+    /// <summary>
+    /// The chunk count the floor spans, computed the way the sync computes it so a month's length
+    /// never decides the test.
+    /// </summary>
+    private static int FullWalkChunks()
+    {
+        var now = DateTime.UtcNow;
+        return DateChunker.Chunk(
+                now.AddMonths(-GlookoConstants.FullWalkMonths).AddDays(-1), now.AddDays(1),
+                GlookoConstants.SyncChunkSize)
+            .Count();
+    }
+
+    private static DateTime Parse(string timestamp) =>
+        DateTime.Parse(timestamp, CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSsv2SyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSsv2SyncTests.cs
@@ -211,20 +211,6 @@ public class GlookoSsv2SyncTests
         }
     }
 
-    private sealed class FakeCursorStore : IConnectorSyncCursorStore
-    {
-        public Dictionary<string, ConnectorSyncCursor> Saved { get; } = new(StringComparer.Ordinal);
-
-        public Task<ConnectorSyncCursor?> GetAsync(string connectorName, string resource, CancellationToken ct = default)
-            => Task.FromResult(Saved.TryGetValue(resource, out var c) ? c : null);
-
-        public Task SetAsync(string connectorName, string resource, ConnectorSyncCursor cursor, CancellationToken ct = default)
-        {
-            Saved[resource] = cursor;
-            return Task.CompletedTask;
-        }
-    }
-
     private sealed class FixedGlookoTokenProvider : GlookoAuthTokenProvider
     {
         public FixedGlookoTokenProvider()

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSsv2SyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSsv2SyncTests.cs
@@ -134,6 +134,25 @@ public class GlookoSsv2SyncTests
         DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses, SyncDataType.CarbIntake],
     };
 
+    /// <summary>
+    /// SSV2 resumes every resource from its own cursor, so the scheduled run is not put on the
+    /// windowed path's walk schedule: the cursor store holds only the resource cursors afterwards.
+    /// </summary>
+    [Fact]
+    public async Task Ssv2_ScheduledRun_IsNotPutOnTheFullWalkSchedule()
+    {
+        var store = new FakeCursorStore();
+        var handler = new RoutingHandler(path =>
+            path.Contains("/api/v2/cgm/egvs") ? EgvPage(["g1"], "2026-06-02T00:00:00Z", "g1", lastPage: true)
+            : Json("{\"lastPage\":true}"));
+        var service = BuildService(handler, store, CapturePublisher([]));
+
+        await service.SyncDataAsync(Config(), CancellationToken.None);
+
+        store.Saved.Keys.Should().NotContain(GlookoConstants.FullWalkCursorResource);
+        store.Saved.Keys.Should().NotContain(GlookoConstants.FullWalkAttemptCursorResource);
+    }
+
     private static GlookoConnectorConfiguration Config() => new()
     {
         ConnectSource = ConnectSource.Glooko,

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
@@ -49,6 +49,9 @@ internal sealed class FakeCursorStore : IConnectorSyncCursorStore
 {
     public Dictionary<string, ConnectorSyncCursor> Saved { get; } = new(StringComparer.Ordinal);
 
+    /// <summary>Observes each write as it happens, for tests that care when a stamp lands.</summary>
+    public Action<string>? OnSet { get; init; }
+
     public Task<ConnectorSyncCursor?> GetAsync(
         string connectorName, string resource, CancellationToken ct = default) =>
         Task.FromResult(Saved.TryGetValue(resource, out var cursor) ? cursor : null);
@@ -57,6 +60,7 @@ internal sealed class FakeCursorStore : IConnectorSyncCursorStore
         string connectorName, string resource, ConnectorSyncCursor cursor, CancellationToken ct = default)
     {
         Saved[resource] = cursor;
+        OnSet?.Invoke(resource);
         return Task.CompletedTask;
     }
 }

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
@@ -36,8 +36,29 @@ internal static class GlookoSyncHarness
         GlookoEndpointHandler handler,
         PublishKind? rejected = null,
         IConnectorPublisher? publisher = null,
-        StaticGlookoTokenProvider? tokenProvider = null) =>
-        new(new HttpClient(handler), tokenProvider ?? new StaticGlookoTokenProvider(), rejected, publisher);
+        StaticGlookoTokenProvider? tokenProvider = null,
+        IConnectorSyncCursorStore? cursorStore = null) =>
+        new(new HttpClient(handler), tokenProvider ?? new StaticGlookoTokenProvider(), rejected, publisher,
+            cursorStore);
+}
+
+/// <summary>
+/// Remembers what the sync persists between runs, standing in for the tenant's stored cursors.
+/// </summary>
+internal sealed class FakeCursorStore : IConnectorSyncCursorStore
+{
+    public Dictionary<string, ConnectorSyncCursor> Saved { get; } = new(StringComparer.Ordinal);
+
+    public Task<ConnectorSyncCursor?> GetAsync(
+        string connectorName, string resource, CancellationToken ct = default) =>
+        Task.FromResult(Saved.TryGetValue(resource, out var cursor) ? cursor : null);
+
+    public Task SetAsync(
+        string connectorName, string resource, ConnectorSyncCursor cursor, CancellationToken ct = default)
+    {
+        Saved[resource] = cursor;
+        return Task.CompletedTask;
+    }
 }
 
 /// <summary>
@@ -63,7 +84,7 @@ internal sealed class RecordingGlookoConnectorService : GlookoConnectorService
 
     public RecordingGlookoConnectorService(
         HttpClient httpClient, GlookoAuthTokenProvider tokenProvider, PublishKind? rejected,
-        IConnectorPublisher? publisher = null)
+        IConnectorPublisher? publisher = null, IConnectorSyncCursorStore? cursorStore = null)
         : base(
             httpClient,
             new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
@@ -71,7 +92,8 @@ internal sealed class RecordingGlookoConnectorService : GlookoConnectorService
             Mock.Of<IRetryDelayStrategy>(),
             Mock.Of<IRateLimitingStrategy>(),
             tokenProvider,
-            publisher)
+            publisher,
+            cursorStore: cursorStore)
     {
         _rejected = rejected;
     }

--- a/tests/Unit/Nocturne.Connectors.MyFitnessPal.Tests/MyFitnessPalSyncRequestTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyFitnessPal.Tests/MyFitnessPalSyncRequestTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json;
 using FluentAssertions;
 using Nocturne.Connectors.MyFitnessPal.Configurations;
@@ -47,45 +46,6 @@ public class MyFitnessPalSyncRequestTests
 
         resource.GetProperty("paginationInput").GetProperty("before").GetString().Should().Be("page-2");
         resource.GetProperty("syncCursors").EnumerateObject().Should().BeEmpty();
-    }
-
-    [Fact]
-    public void IsFullWalkDue_WalksWhenNoFullWalkHasEverCompleted()
-    {
-        // Until one completes, the connector has never been able to withdraw anything.
-        MyFitnessPalConnectorService.IsFullWalkDue(new MyFitnessPalConnectorConfiguration())
-            .Should().BeTrue();
-
-        MyFitnessPalConnectorService.IsFullWalkDue(
-            new MyFitnessPalConnectorConfiguration { LastFullWalkAt = "not a timestamp" })
-            .Should().BeTrue();
-    }
-
-    [Fact]
-    public void IsFullWalkDue_SkipsTheWalkUntilTheIntervalHasElapsed()
-    {
-        var justNow = DateTimeOffset.UtcNow.AddMinutes(-30);
-        var overdue = DateTimeOffset.UtcNow - MyFitnessPalConstants.FullWalkInterval - TimeSpan.FromMinutes(1);
-
-        MyFitnessPalConnectorService.IsFullWalkDue(new MyFitnessPalConnectorConfiguration
-        {
-            LastFullWalkAt = justNow.ToString("O", CultureInfo.InvariantCulture),
-        }).Should().BeFalse();
-
-        MyFitnessPalConnectorService.IsFullWalkDue(new MyFitnessPalConnectorConfiguration
-        {
-            LastFullWalkAt = overdue.ToString("O", CultureInfo.InvariantCulture),
-        }).Should().BeTrue();
-    }
-
-    [Fact]
-    public void IsFullWalkDue_WalksWhenTheStoredTimeIsInTheFuture()
-    {
-        // A clock moved; treating it as recent would suppress reconciliation indefinitely.
-        MyFitnessPalConnectorService.IsFullWalkDue(new MyFitnessPalConnectorConfiguration
-        {
-            LastFullWalkAt = DateTimeOffset.UtcNow.AddDays(3).ToString("O", CultureInfo.InvariantCulture),
-        }).Should().BeTrue();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Connectors.MyFitnessPal.Tests/MyFitnessPalSyncRequestTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyFitnessPal.Tests/MyFitnessPalSyncRequestTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using FluentAssertions;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Connectors.MyFitnessPal.Configurations;
 using Nocturne.Connectors.MyFitnessPal.Models;
 using Nocturne.Connectors.MyFitnessPal.Services;
@@ -46,6 +47,29 @@ public class MyFitnessPalSyncRequestTests
 
         resource.GetProperty("paginationInput").GetProperty("before").GetString().Should().Be("page-2");
         resource.GetProperty("syncCursors").EnumerateObject().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The rule lives in <c>FullWalkSchedule</c>; this pins the binding: the stamp read is
+    /// <c>LastFullWalkAt</c> and the interval is <c>FullWalkInterval</c>.
+    /// </summary>
+    [Fact]
+    public void IsFullWalkDue_ReadsLastFullWalkAtAgainstTheFullWalkInterval()
+    {
+        MyFitnessPalConnectorService.IsFullWalkDue(new MyFitnessPalConnectorConfiguration())
+            .Should().BeTrue();
+
+        var oneMinuteShort = DateTimeOffset.UtcNow - MyFitnessPalConstants.FullWalkInterval + TimeSpan.FromMinutes(1);
+        MyFitnessPalConnectorService.IsFullWalkDue(new MyFitnessPalConnectorConfiguration
+        {
+            LastFullWalkAt = FullWalkSchedule.Stamp(oneMinuteShort),
+        }).Should().BeFalse();
+
+        var oneMinuteOver = DateTimeOffset.UtcNow - MyFitnessPalConstants.FullWalkInterval - TimeSpan.FromMinutes(1);
+        MyFitnessPalConnectorService.IsFullWalkDue(new MyFitnessPalConnectorConfiguration
+        {
+            LastFullWalkAt = FullWalkSchedule.Stamp(oneMinuteOver),
+        }).Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1277. Addresses the Glooko half of #1054.

## What changed

A scheduled Glooko run took its lower bound from `BaseConnectorService.RunBackgroundSyncAsync`, which derives it from the tenant's newest *glucose* reading. Glooko stores glucose only when `v3IncludeCgmBackfill` is on (default off), so for a normal Glooko account there is none and the base substitutes its six-month `InitialSyncFloor`: 14 fortnightly chunks, 28 Glooko requests and a re-publish of six months of records, every five minutes, for every such tenant. On the hosted instance that was 480 Glooko calls per 10 minutes across 12 tenants and the largest identifiable share of both API and Postgres CPU (numbers in #1277).

The connector now bounds its own scheduled run, at the same seam MyFitnessPal uses (`SyncDataAsync(config, ct, since, reporter)` override, before the base computes anything):

- **Incremental run:** `since = now - LookbackDays`. `LookbackDays` is a new Glooko property on the existing `ConnectorPropertyKey.LookbackDays` key, default 10 (one 14-day chunk with the fake-UTC padding, with room for the clock and a timezone offset change; two requests on V3, seven on V2), ceiling 60. Glooko receives pump data in batches days after the fact, so the window is a fixed lookback rather than a resume point at the newest stored record.
- **Full walk** once per `GlookoConstants.FullWalkInterval` (24 h): the six-month floor. Completion is recorded through the `IConnectorSyncCursorStore` the service already holds for SSV2, under `full-walk`; the *attempt* is recorded under `full-walk-attempt` before the run, and a walk is due only when the completion is older than the interval and the attempt older than `FullWalkRetryInterval` (1 h). So a walk that stops at a failed chunk is retried after an hour, not on every cycle, and a new connection whose first walk failed is not left on the lookback for a day. Store reads that fail walk (one extra walk, never a missed one); store writes that fail log a warning and do not fail the sync.
- **Unchanged paths:** a caller that passes its own `since`; the requested-range overload, which is what the tenant's own "Sync now" button (a request with no bounds), the dev-admin sweep, the timezone-timeline re-sync and the cursor reset all use — they keep the floor-or-range behaviour and never touch the schedule; SSV2 (resumes from its per-resource cursors); a service without a cursor store (detached tooling).

Declared behavioural deltas beyond the target case:

- The two tenants **with** CGM backfill previously synced from their glucose watermark (about two days). They now sync the same 10-day lookback as everyone else: one chunk either way, more re-published records per cycle, and no longer the #1054 stranding shape where a treatment older than the glucose watermark is never fetched again.
- The first scheduled run after deploy is a full walk for every Glooko tenant (no stamp yet), then daily.

`FullWalkSchedule` (Connectors.Core) is MyFitnessPal's `IsFullWalkDue` rule lifted out so both connectors share it; MyFitnessPal delegates to it. `Syncing.md`'s resume-point section gains a Glooko paragraph, and the web label for `LookbackDays` no longer reads as MyFitnessPal-only.

Expected on the hosted instance: a V3 scheduled run is 4 requests (the two windowed calls plus the once-per-run session and device-settings calls) and a walk is 30, so per tenant per day ~288 × 4 + 30 ≈ 1,200 Glooko calls instead of ~8,000 (about -85 %); V2-mode tenants pay 8 per run. The Glooko-driven publish stream (state spans, system events, profiles, temp-basal tombstone scans) falls by the same factor. The API log line `Scheduled sync reaches back to … (incremental|full walk)` shows which mode each run took. #1277 carries the before-numbers to compare against after deploy.

## Tests

`GlookoConnectorServiceBackgroundWindowTests` drives the **scheduled entry point** (`SyncDataAsync(config, ct)`, the call `ConnectorBackgroundService` makes) against the fake endpoints and asserts the date windows Glooko is asked for:

- first run, no stamps: full-walk chunk count, window starts at the floor, completion and attempt recorded, completion not due;
- inside the interval (v2 and v3 paths): one chunk starting at `now - LookbackDays - 1d`, seeded stamp left as the same instance, state spans published;
- a 30-day lookback: three chunks;
- interval elapsed: full walk again, completion stamp replaced;
- failed walk (graph endpoint 500): attempt stamped before the first request, no completion, and the next run stays on the lookback;
- attempt older than the retry interval with no completion: walks and records;
- caller `since`: honoured, no stamps;
- requested run with no bounds (the sync button): floor, no stamps;
- no cursor store: base window.

`GlookoSsv2SyncTests` gains a scheduled-run test asserting no walk stamps are written on SSV2. `FullWalkScheduleTests` (Core) covers never-walked / unparseable / interval edge / future stamp / offset round-trip; `MyFitnessPalSyncRequestTests` keeps one test pinning that connector's binding (`LastFullWalkAt` against `FullWalkInterval`). 256 Glooko, 203 Core and 52 MyFitnessPal tests pass. The SSV2 suite now uses the shared `FakeCursorStore` from the harness.

A first version of this PR resolved the window inside `PerformSyncInternalAsync` and widened it with `ResumeFrom`; the hostile review showed that `From` arrives as the non-null six-month floor there, so the widening undid the lookback on every real run, and the tests could not see it because they hand-built requests. Both are fixed above.

