### PR TITLE
perf(profiles): decompose a profile batch with one create-or-update round per table

### DIFF
--- a/src/API/Nocturne.API/Services/Profiles/ProfileWriteService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/ProfileWriteService.cs
@@ -48,9 +48,9 @@ public class ProfileWriteService : IProfileWriteService
             {
                 profile.Id = Guid.CreateVersion7().ToString();
             }
-
-            await _decomposer.DecomposeAsync(profile, WriteOrigin.Live, cancellationToken);
         }
+
+        await _decomposer.DecomposeBatchAsync(profileList, WriteOrigin.Live, cancellationToken);
 
         await _sideEffects.OnCreatedAsync(
             CollectionName,

--- a/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
+++ b/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
@@ -141,8 +141,9 @@ public abstract class DecomposerBase
     /// attribution: it is reached from a genuine per-record edit, and since a legacy record
     /// persists only as its decomposed v4 rows, their audit rows are the whole trail of that edit.
     /// Connector re-syncs of the single path are system-attributed by the sync scope's own audit
-    /// context rather than here. <see cref="ProfileDecomposer"/> has no batch path at all, so it
-    /// takes no scope.
+    /// context rather than here. <see cref="ProfileDecomposer"/> takes no scope on either path: a
+    /// profile persists only as its decomposed rows, so their audit rows are the whole trail of a
+    /// user's profile edit, and an unchanged re-upsert writes nothing to audit.
     /// </remarks>
     protected static IDisposable SystemAttributedBatchWrites(IAuditContext auditContext)
         => SystemAuditScope.Push(auditContext);

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -111,7 +111,7 @@ public class ProfileDecomposer : DecomposerBase, IProfileDecomposer, IDecomposer
         if (groups.Count < entries.Count)
         {
             Logger.LogDebug(
-                "Skipped schedules for {Count} profile store(s) whose therapy settings identity is already held",
+                "Skipped schedules for {Count} profile store(s) whose therapy settings were not written: identity held by a deleted row, or the legacy id repeated in the batch",
                 entries.Count - groups.Count);
         }
 

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -16,7 +16,8 @@ namespace Nocturne.API.Services.V4;
 /// <see cref="V4Models.CarbRatioSchedule"/>, <see cref="V4Models.SensitivitySchedule"/>, and
 /// <see cref="V4Models.TargetRangeSchedule"/>.
 /// Iterates through the <see cref="Profile.Store"/> dictionary and uses a composite
-/// <c>LegacyId</c> of the form <c>"{profileId}:{storeName}"</c> for idempotent upserts.
+/// <c>LegacyId</c> of the form <c>"{profileId}:{storeName}"</c> for idempotent upserts, one
+/// create-or-update round per table for the whole batch.
 /// </summary>
 /// <seealso cref="IProfileDecomposer"/>
 /// <seealso cref="IDecomposer{T}"/>
@@ -51,67 +52,103 @@ public class ProfileDecomposer : DecomposerBase, IProfileDecomposer, IDecomposer
     }
 
     /// <inheritdoc />
-    public async Task<V4Models.DecompositionResult> DecomposeAsync(Profile profile, WriteOrigin origin, CancellationToken ct = default)
+    public Task<V4Models.DecompositionResult> DecomposeAsync(Profile profile, WriteOrigin origin, CancellationToken ct = default)
+        => DecomposeBatchAsync([profile], origin, ct);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// No system attribution here (see <see cref="DecomposerBase.SystemAttributedBatchWrites"/>).
+    /// <para>
+    /// The therapy settings row anchors each group's correlation id, and the four schedules are
+    /// stamped with whatever it resolves to. Reading it back rather than reusing the minted id is
+    /// what keeps an unchanged re-upsert free of writes, and stamping the schedules from it is
+    /// what keeps the group whole: the five tables are written in five separate saves, so a
+    /// sibling lost to a cancelled sync is recreated on the next one, and it has to rejoin the
+    /// group rather than fork it. ProfileProjectionService loads the schedules by this id. A refused
+    /// anchor leaves its schedules nothing to converge on, so they are not written: under the minted
+    /// id they would fork off the settings row they belong to rather than join it.
+    /// </para>
+    /// </remarks>
+    public async Task<V4Models.DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Profile> profiles, WriteOrigin origin, CancellationToken ct = default)
     {
-        var mintedCorrelationId = Guid.CreateVersion7();
-        var result = new V4Models.DecompositionResult
+        var firstMinted = Guid.CreateVersion7();
+        var result = new V4Models.DecompositionResult { CorrelationId = firstMinted };
+
+        var entries = new List<StoreEntry>();
+        var first = true;
+        foreach (var profile in profiles)
         {
-            CorrelationId = mintedCorrelationId
-        };
-
-        if (profile.Store.Count == 0)
-        {
-            Logger.LogWarning("Profile {Id} has no store entries, skipping decomposition", profile.Id);
-            return result;
-        }
-
-        // No system attribution here — there is no batch path to take it on (see
-        // DecomposerBase.SystemAttributedBatchWrites): a profile write is a user's profile edit,
-        // and byte-identical re-upserts diff to empty and are skipped.
-        //
-        // The therapy settings row anchors the group's correlation id, and the four schedules are
-        // stamped with whatever it resolves to. Reading it back rather than reusing the minted id is
-        // what keeps an unchanged re-upsert free of writes, and stamping the schedules from it is
-        // what keeps the group whole: the five rows are written in five separate transactions, so a
-        // sibling lost to a cancelled sync is recreated on the next one, and it has to rejoin the
-        // group rather than fork it. ProfileProjectionService loads the schedules by this id.
-        foreach (var (storeName, profileData) in profile.Store)
-        {
-            var legacyId = $"{profile.Id}:{storeName}";
-            var isDefault = string.Equals(storeName, profile.DefaultProfile, StringComparison.OrdinalIgnoreCase);
-
-            var anchor = await UpsertByLegacyIdAsync(
-                _therapySettingsRepo, legacyId,
-                MapToTherapySettings(profile, profileData, storeName, legacyId, isDefault, result.CorrelationId),
-                result, origin, ct, preserveStoredCorrelationId: true);
-
-            // A refused anchor leaves the schedules nothing to converge on. Writing them under the
-            // minted id would fork the group off the settings row they belong to rather than join
-            // it, which is the damage the stamping above exists to prevent.
-            if (anchor is not ({ } settings, _))
+            if (profile.Store.Count == 0)
+            {
+                Logger.LogWarning("Profile {Id} has no store entries, skipping decomposition", profile.Id);
                 continue;
+            }
 
-            var groupCorrelationId = settings.CorrelationId ?? mintedCorrelationId;
-
-            await UpsertByLegacyIdAsync(
-                _basalScheduleRepo, legacyId,
-                MapToBasalSchedule(profile, profileData, storeName, legacyId, groupCorrelationId),
-                result, origin, ct);
-            await UpsertByLegacyIdAsync(
-                _carbRatioScheduleRepo, legacyId,
-                MapToCarbRatioSchedule(profile, profileData, storeName, legacyId, groupCorrelationId),
-                result, origin, ct);
-            await UpsertByLegacyIdAsync(
-                _sensitivityScheduleRepo, legacyId,
-                MapToSensitivitySchedule(profile, profileData, storeName, legacyId, groupCorrelationId),
-                result, origin, ct);
-            await UpsertByLegacyIdAsync(
-                _targetRangeScheduleRepo, legacyId,
-                MapToTargetRangeSchedule(profile, profileData, storeName, legacyId, groupCorrelationId),
-                result, origin, ct);
+            // One id per profile, as the single-profile path always minted, so a profile's stores
+            // created together share it and two profiles created together do not.
+            var minted = first ? firstMinted : Guid.CreateVersion7();
+            first = false;
+            foreach (var (storeName, profileData) in profile.Store)
+                entries.Add(new StoreEntry(profile, storeName, profileData, $"{profile.Id}:{storeName}", minted));
         }
+
+        if (entries.Count == 0)
+            return result;
+
+        var anchors = await _therapySettingsRepo.BulkUpsertByLegacyIdAsync(
+            entries.Select(e => MapToTherapySettings(
+                e.Profile, e.Data, e.StoreName, e.LegacyId,
+                string.Equals(e.StoreName, e.Profile.DefaultProfile, StringComparison.OrdinalIgnoreCase),
+                e.MintedCorrelationId)).ToList(),
+            origin, preserveStoredCorrelationId: true, ct);
+        Record(result, anchors);
+
+        var groups = entries
+            .Where(e => anchors.ContainsKey(e.LegacyId))
+            .Select(e => (Entry: e, CorrelationId: anchors[e.LegacyId].Record.CorrelationId ?? e.MintedCorrelationId))
+            .ToList();
+        if (groups.Count < entries.Count)
+        {
+            Logger.LogDebug(
+                "Skipped schedules for {Count} profile store(s) whose therapy settings identity is already held",
+                entries.Count - groups.Count);
+        }
+
+        if (groups.Count == 0)
+            return result;
+
+        Record(result, await _basalScheduleRepo.BulkUpsertByLegacyIdAsync(
+            groups.Select(g => MapToBasalSchedule(g.Entry.Profile, g.Entry.Data, g.Entry.StoreName, g.Entry.LegacyId, g.CorrelationId)).ToList(),
+            origin, ct: ct));
+        Record(result, await _carbRatioScheduleRepo.BulkUpsertByLegacyIdAsync(
+            groups.Select(g => MapToCarbRatioSchedule(g.Entry.Profile, g.Entry.Data, g.Entry.StoreName, g.Entry.LegacyId, g.CorrelationId)).ToList(),
+            origin, ct: ct));
+        Record(result, await _sensitivityScheduleRepo.BulkUpsertByLegacyIdAsync(
+            groups.Select(g => MapToSensitivitySchedule(g.Entry.Profile, g.Entry.Data, g.Entry.StoreName, g.Entry.LegacyId, g.CorrelationId)).ToList(),
+            origin, ct: ct));
+        Record(result, await _targetRangeScheduleRepo.BulkUpsertByLegacyIdAsync(
+            groups.Select(g => MapToTargetRangeSchedule(g.Entry.Profile, g.Entry.Data, g.Entry.StoreName, g.Entry.LegacyId, g.CorrelationId)).ToList(),
+            origin, ct: ct));
 
         return result;
+    }
+
+    /// <summary>One named profile inside one legacy profile document, with the id minted for that document.</summary>
+    private sealed record StoreEntry(
+        Profile Profile, string StoreName, ProfileData Data, string LegacyId, Guid MintedCorrelationId);
+
+    private static void Record<TRecord>(
+        V4Models.DecompositionResult result, IReadOnlyDictionary<string, LegacyUpsert<TRecord>> outcomes)
+        where TRecord : class, V4Models.IV4Record
+    {
+        foreach (var outcome in outcomes.Values)
+        {
+            if (outcome.Created)
+                result.CreatedRecords.Add(outcome.Record);
+            else
+                result.UpdatedRecords.Add(outcome.Record);
+        }
     }
 
     #region Mapping Methods

--- a/src/Core/Nocturne.Core.Contracts/V4/IProfileDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IProfileDecomposer.cs
@@ -34,7 +34,8 @@ public interface IProfileDecomposer
     /// <param name="ct">Cancellation token</param>
     /// <returns>
     /// A single <see cref="DecompositionResult"/> containing every created or updated V4 record; its
-    /// <see cref="DecompositionResult.CorrelationId"/> is the id minted for the first profile.
+    /// <see cref="DecompositionResult.CorrelationId"/> is the id minted for the first profile that has
+    /// a store entry.
     /// </returns>
     Task<DecompositionResult> DecomposeBatchAsync(
         IReadOnlyList<Profile> profiles, WriteOrigin origin, CancellationToken ct = default);

--- a/src/Core/Nocturne.Core.Contracts/V4/IProfileDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IProfileDecomposer.cs
@@ -26,6 +26,20 @@ public interface IProfileDecomposer
     Task<DecompositionResult> DecomposeAsync(Profile profile, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
+    /// Decomposes a batch of legacy Profiles with one create-or-update round per V4 table, so a
+    /// connector re-publishing its profile set costs five table round trips rather than ten per named
+    /// profile. Same records, same idempotency, as <see cref="DecomposeAsync"/> per profile.
+    /// </summary>
+    /// <param name="profiles">The legacy Profiles to decompose</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>
+    /// A single <see cref="DecompositionResult"/> containing every created or updated V4 record; its
+    /// <see cref="DecompositionResult.CorrelationId"/> is the id minted for the first profile.
+    /// </returns>
+    Task<DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Profile> profiles, WriteOrigin origin, CancellationToken ct = default);
+
+    /// <summary>
     /// Deletes all V4 records that were decomposed from a legacy Profile with the given ID.
     /// Uses prefix matching since one legacy Profile fans out to multiple composite LegacyIds.
     /// </summary>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ILegacyKeyedRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ILegacyKeyedRepository.cs
@@ -25,9 +25,35 @@ public interface IBulkCreateRepository<TRecord>
 /// one generic place (<c>DecomposerBase.UpsertByLegacyIdAsync</c>).
 /// </summary>
 /// <typeparam name="TRecord">The V4 record type stored by this repository.</typeparam>
+/// <summary>
+///     One record's outcome from <see cref="ILegacyKeyedRepository{TRecord}.BulkUpsertByLegacyIdAsync"/>:
+///     the persisted record and whether it was inserted rather than updated in place.
+/// </summary>
+public sealed record LegacyUpsert<TRecord>(TRecord Record, bool Created);
+
 public interface ILegacyKeyedRepository<TRecord> : IV4Repository<TRecord>, IBulkCreateRepository<TRecord>
     where TRecord : class, IV4Record
 {
+    /// <summary>
+    ///     Create-or-update every record under its <see cref="IV4Record.LegacyId"/> in one context: one
+    ///     query for the stored rows, one for the identities that block re-creation, one save. A stored
+    ///     row is updated in place (its <see cref="IV4Record.Id"/> is written back onto the record); a
+    ///     record with no stored row is inserted; a record whose identity is already held is dropped and
+    ///     absent from the result, the outcome <see cref="IV4Repository{T}.CreateAsync"/> reports as
+    ///     <see cref="RecreationBlockedException"/>. Records without a legacy id are ignored, and a legacy
+    ///     id repeated in the batch keeps its last record.
+    /// </summary>
+    /// <param name="preserveStoredCorrelationId">
+    ///     Whether a stored, non-empty correlation id outlives the record's own. Only an anchor record
+    ///     whose group is then stamped from what it reads back may ask for this.
+    /// </param>
+    /// <returns>The outcomes keyed by legacy id.</returns>
+    Task<IReadOnlyDictionary<string, LegacyUpsert<TRecord>>> BulkUpsertByLegacyIdAsync(
+        IReadOnlyList<TRecord> records,
+        WriteOrigin origin,
+        bool preserveStoredCorrelationId = false,
+        CancellationToken ct = default);
+
     Task<TRecord?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
 
     /// <returns>Number of records deleted.</returns>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ILegacyKeyedRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ILegacyKeyedRepository.cs
@@ -20,32 +20,39 @@ public interface IBulkCreateRepository<TRecord>
 }
 
 /// <summary>
-/// A V4 repository addressable by the legacy MongoDB <c>_id</c> its records were decomposed from.
-/// This is the surface the decomposers upsert through, so their create-or-update body can live in
-/// one generic place (<c>DecomposerBase.UpsertByLegacyIdAsync</c>).
+/// One record's outcome from <see cref="ILegacyKeyedRepository{TRecord}.BulkUpsertByLegacyIdAsync"/>:
+/// the persisted record and whether it was inserted rather than updated in place.
 /// </summary>
-/// <typeparam name="TRecord">The V4 record type stored by this repository.</typeparam>
-/// <summary>
-///     One record's outcome from <see cref="ILegacyKeyedRepository{TRecord}.BulkUpsertByLegacyIdAsync"/>:
-///     the persisted record and whether it was inserted rather than updated in place.
-/// </summary>
+/// <typeparam name="TRecord">The V4 record type.</typeparam>
 public sealed record LegacyUpsert<TRecord>(TRecord Record, bool Created);
 
+/// <summary>
+/// A V4 repository addressable by the legacy MongoDB <c>_id</c> its records were decomposed from.
+/// This is the surface the decomposers upsert through, so their create-or-update body can live in
+/// one generic place (<c>DecomposerBase.UpsertByLegacyIdAsync</c> per record,
+/// <see cref="BulkUpsertByLegacyIdAsync"/> per batch).
+/// </summary>
+/// <typeparam name="TRecord">The V4 record type stored by this repository.</typeparam>
 public interface ILegacyKeyedRepository<TRecord> : IV4Repository<TRecord>, IBulkCreateRepository<TRecord>
     where TRecord : class, IV4Record
 {
     /// <summary>
-    ///     Create-or-update every record under its <see cref="IV4Record.LegacyId"/> in one context: one
-    ///     query for the stored rows, one for the identities that block re-creation, one save. A stored
-    ///     row is updated in place (its <see cref="IV4Record.Id"/> is written back onto the record); a
-    ///     record with no stored row is inserted; a record whose identity is already held is dropped and
-    ///     absent from the result, the outcome <see cref="IV4Repository{T}.CreateAsync"/> reports as
-    ///     <see cref="RecreationBlockedException"/>. Records without a legacy id are ignored, and a legacy
-    ///     id repeated in the batch keeps its last record.
+    /// Create-or-update every record under its <see cref="IV4Record.LegacyId"/> in one context: one
+    /// query for the stored rows, one for the identities that block re-creation, one save. A stored
+    /// row is updated in place (its <see cref="IV4Record.Id"/> is written back onto the record); a
+    /// record with no stored row is inserted; a record whose identity is held by a row the user
+    /// deleted is dropped and absent from the result. Records without a legacy id are ignored, and a
+    /// legacy id repeated in the batch keeps its last record.
     /// </summary>
+    /// <remarks>
+    /// The legacy id is the only identity this method matches on. The types whose creates upsert on a
+    /// sync key (sensor glucose, boluses, carb intakes, the device-status snapshots) do not support it
+    /// and throw <see cref="NotSupportedException"/>; their batch path is
+    /// <see cref="IBulkCreateRepository{TRecord}.BulkCreateAsync"/>.
+    /// </remarks>
     /// <param name="preserveStoredCorrelationId">
-    ///     Whether a stored, non-empty correlation id outlives the record's own. Only an anchor record
-    ///     whose group is then stamped from what it reads back may ask for this.
+    /// Whether a stored, non-empty correlation id outlives the record's own. Only an anchor record
+    /// whose group is then stamped from what it reads back may ask for this.
     /// </param>
     /// <returns>The outcomes keyed by legacy id.</returns>
     Task<IReadOnlyDictionary<string, LegacyUpsert<TRecord>>> BulkUpsertByLegacyIdAsync(

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
@@ -35,6 +35,18 @@ public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepos
     }
 
     /// <summary>
+    /// Identity for this type is the sync key, which a legacy-id match neither honours nor
+    /// deduplicates through; the batch path is <see cref="V4RepositoryBase{TModel,TEntity}.BulkCreateAsync"/>.
+    /// </summary>
+    public override Task<IReadOnlyDictionary<string, LegacyUpsert<TModel>>> BulkUpsertByLegacyIdAsync(
+        IReadOnlyList<TModel> records,
+        WriteOrigin origin,
+        bool preserveStoredCorrelationId = false,
+        CancellationToken ct = default) =>
+        throw new NotSupportedException(
+            $"{typeof(TModel).Name} upserts on its sync key; use BulkCreateAsync for a batch.");
+
+    /// <summary>
     /// Creates a record, or updates in place the stored row carrying the same
     /// (DataSource, SyncIdentifier).
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -276,11 +276,14 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     /// The batch twin of <see cref="GetByLegacyIdAsync"/> followed by <see cref="CreateAsync"/> or
     /// <see cref="UpdateAsync"/> per record, with the same soft-delete visibility (the stored-row query
     /// runs under the context's filters), the same recreation guard, and the same
-    /// <see cref="HasMaterialChange"/> gate on the update broadcast. Change detection runs once over the
-    /// batch before the predicate reads it; <see cref="NocturneDbContext.SaveChangesAsync(CancellationToken)"/>
-    /// runs its own pass.
+    /// <see cref="HasMaterialChange"/> gate on the update broadcast. The gate decides the broadcast
+    /// only: the save always runs, because a change the gate does not count — a correlation id
+    /// converging onto its anchor's — still has to reach the row. Change detection runs once over the
+    /// batch and stays off through the save, the contract
+    /// <see cref="NocturneDbContext.SaveChangesAsync(CancellationToken)"/> honours for a caller that
+    /// has already detected.
     /// </remarks>
-    public async Task<IReadOnlyDictionary<string, LegacyUpsert<TModel>>> BulkUpsertByLegacyIdAsync(
+    public virtual async Task<IReadOnlyDictionary<string, LegacyUpsert<TModel>>> BulkUpsertByLegacyIdAsync(
         IReadOnlyList<TModel> records,
         WriteOrigin origin,
         bool preserveStoredCorrelationId = false,
@@ -345,14 +348,12 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         try
         {
             materiallyChanged.AddRange(updated.Select(u => u.Entity).Where(e => HasMaterialChange(ctx, e)));
+            await ctx.SaveChangesAsync(ct);
         }
         finally
         {
             ctx.ChangeTracker.AutoDetectChangesEnabled = autoDetect;
         }
-
-        if (inserted.Count > 0 || materiallyChanged.Count > 0)
-            await ctx.SaveChangesAsync(ct);
 
         foreach (var (legacyId, entity) in inserted)
             outcomes[legacyId] = new LegacyUpsert<TModel>(ToDomain(entity), Created: true);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -281,7 +281,9 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     /// converging onto its anchor's — still has to reach the row. Change detection runs once over the
     /// batch and stays off through the save, the contract
     /// <see cref="NocturneDbContext.SaveChangesAsync(CancellationToken)"/> honours for a caller that
-    /// has already detected.
+    /// has already detected. Inserted rows go through <see cref="PostCommitDedupAsync"/> as
+    /// <see cref="BulkCreateAsync"/>'s do, so the dedup participants keyed by legacy id alone link
+    /// their canonical groups on this path too.
     /// </remarks>
     public virtual async Task<IReadOnlyDictionary<string, LegacyUpsert<TModel>>> BulkUpsertByLegacyIdAsync(
         IReadOnlyList<TModel> records,
@@ -354,6 +356,8 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         {
             ctx.ChangeTracker.AutoDetectChangesEnabled = autoDetect;
         }
+
+        await PostCommitDedupAsync(ctx, inserted.Select(i => i.Entity).ToList(), origin, ct);
 
         foreach (var (legacyId, entity) in inserted)
             outcomes[legacyId] = new LegacyUpsert<TModel>(ToDomain(entity), Created: true);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -271,6 +271,103 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         return updated;
     }
 
+    /// <inheritdoc cref="ILegacyKeyedRepository{T}.BulkUpsertByLegacyIdAsync" />
+    /// <remarks>
+    /// The batch twin of <see cref="GetByLegacyIdAsync"/> followed by <see cref="CreateAsync"/> or
+    /// <see cref="UpdateAsync"/> per record, with the same soft-delete visibility (the stored-row query
+    /// runs under the context's filters), the same recreation guard, and the same
+    /// <see cref="HasMaterialChange"/> gate on the update broadcast. Change detection runs once over the
+    /// batch before the predicate reads it; <see cref="NocturneDbContext.SaveChangesAsync(CancellationToken)"/>
+    /// runs its own pass.
+    /// </remarks>
+    public async Task<IReadOnlyDictionary<string, LegacyUpsert<TModel>>> BulkUpsertByLegacyIdAsync(
+        IReadOnlyList<TModel> records,
+        WriteOrigin origin,
+        bool preserveStoredCorrelationId = false,
+        CancellationToken ct = default)
+    {
+        var byLegacyId = new Dictionary<string, TModel>(StringComparer.Ordinal);
+        foreach (var record in records)
+        {
+            if (!string.IsNullOrEmpty(record.LegacyId))
+                byLegacyId[record.LegacyId] = record;
+        }
+
+        var outcomes = new Dictionary<string, LegacyUpsert<TModel>>(StringComparer.Ordinal);
+        if (byLegacyId.Count == 0)
+            return outcomes;
+
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+
+        var legacyIds = byLegacyId.Keys.ToList();
+        var stored = await ctx.Set<TEntity>()
+            .Where(e => e.LegacyId != null && legacyIds.Contains(e.LegacyId))
+            .ToListAsync(ct);
+        var storedByLegacyId = new Dictionary<string, TEntity>(StringComparer.Ordinal);
+        foreach (var entity in stored)
+            storedByLegacyId.TryAdd(entity.LegacyId!, entity);
+
+        var inserted = new List<(string LegacyId, TEntity Entity)>();
+        var updated = new List<(string LegacyId, TEntity Entity)>();
+        foreach (var (legacyId, model) in byLegacyId)
+        {
+            if (storedByLegacyId.TryGetValue(legacyId, out var entity))
+            {
+                if (preserveStoredCorrelationId
+                    && entity.CorrelationId is { } storedCorrelationId
+                    && storedCorrelationId != Guid.Empty)
+                {
+                    model.CorrelationId = storedCorrelationId;
+                }
+
+                model.Id = entity.Id;
+                ApplyUpdate(entity, model);
+                updated.Add((legacyId, entity));
+            }
+            else
+            {
+                inserted.Add((legacyId, ToEntity(model)));
+            }
+        }
+
+        if (inserted.Count > 0)
+        {
+            var blocked = await ctx.GetBlockingLegacyIdsAsync<TEntity>(
+                inserted.Select(i => i.LegacyId).ToHashSet(StringComparer.Ordinal), ct);
+            inserted.RemoveAll(i => blocked.Contains(i.LegacyId));
+            ctx.Set<TEntity>().AddRange(inserted.Select(i => i.Entity));
+        }
+
+        var materiallyChanged = new List<TEntity>();
+        var autoDetect = ctx.ChangeTracker.AutoDetectChangesEnabled;
+        ctx.ChangeTracker.DetectChanges();
+        ctx.ChangeTracker.AutoDetectChangesEnabled = false;
+        try
+        {
+            materiallyChanged.AddRange(updated.Select(u => u.Entity).Where(e => HasMaterialChange(ctx, e)));
+        }
+        finally
+        {
+            ctx.ChangeTracker.AutoDetectChangesEnabled = autoDetect;
+        }
+
+        if (inserted.Count > 0 || materiallyChanged.Count > 0)
+            await ctx.SaveChangesAsync(ct);
+
+        foreach (var (legacyId, entity) in inserted)
+            outcomes[legacyId] = new LegacyUpsert<TModel>(ToDomain(entity), Created: true);
+        foreach (var (legacyId, entity) in updated)
+            outcomes[legacyId] = new LegacyUpsert<TModel>(ToDomain(entity), Created: false);
+
+        await RaiseBroadcastAsync(
+            inserted.Select(i => outcomes[i.LegacyId].Record).ToList(),
+            materiallyChanged.Select(ToDomain).ToList(),
+            [],
+            origin, ct);
+
+        return outcomes;
+    }
+
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.DeleteAsync" />
     public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
@@ -2,9 +2,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.V4;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
-using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.V4;
 
@@ -13,59 +13,19 @@ public class ProfileDecomposerTests
     /// <summary>
     /// Profiles persist ONLY as the five decomposed granular records, so on the HTTP path
     /// (v1/v3 profile create/update) their audit rows are the entire mutation trail for a
-    /// user's profile edit. DecomposeAsync must NOT push a SystemAuditScope — connector
+    /// user's profile edit. Decomposition must NOT push a SystemAuditScope — connector
     /// re-syncs are suppressed by the sync scope's system audit context instead, and
-    /// byte-identical re-upserts diff to empty and are skipped — see
-    /// <see cref="DecomposeAsync_KeepsStoredCorrelationId_WhenRecordsAlreadyExist"/> for the one
-    /// column that otherwise stops that being true.
+    /// byte-identical re-upserts diff to empty and are skipped.
     /// </summary>
     [Fact]
     public async Task DecomposeAsync_PreservesCallerAuditAttribution()
     {
         var auditContext = new AuditContext { AuthType = "ApiKey", SubjectName = "someone" };
-
         var attributionDuringUpsert = new List<(bool IsSystem, string? AuthType)>();
-        void Capture() => attributionDuringUpsert.Add((auditContext.IsSystem, auditContext.AuthType));
+        var repos = new Repositories(onUpsert: () =>
+            attributionDuringUpsert.Add((auditContext.IsSystem, auditContext.AuthType)));
 
-        var therapySettingsRepo = new Mock<ITherapySettingsRepository>();
-        therapySettingsRepo
-            .Setup(x => x.CreateAsync(It.IsAny<TherapySettings>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback(Capture)
-            .ReturnsAsync((TherapySettings m, WriteOrigin _, CancellationToken _) => m);
-
-        var basalScheduleRepo = new Mock<IBasalScheduleRepository>();
-        basalScheduleRepo
-            .Setup(x => x.CreateAsync(It.IsAny<BasalSchedule>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback(Capture)
-            .ReturnsAsync((BasalSchedule m, WriteOrigin _, CancellationToken _) => m);
-
-        var carbRatioScheduleRepo = new Mock<ICarbRatioScheduleRepository>();
-        carbRatioScheduleRepo
-            .Setup(x => x.CreateAsync(It.IsAny<CarbRatioSchedule>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback(Capture)
-            .ReturnsAsync((CarbRatioSchedule m, WriteOrigin _, CancellationToken _) => m);
-
-        var sensitivityScheduleRepo = new Mock<ISensitivityScheduleRepository>();
-        sensitivityScheduleRepo
-            .Setup(x => x.CreateAsync(It.IsAny<SensitivitySchedule>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback(Capture)
-            .ReturnsAsync((SensitivitySchedule m, WriteOrigin _, CancellationToken _) => m);
-
-        var targetRangeScheduleRepo = new Mock<ITargetRangeScheduleRepository>();
-        targetRangeScheduleRepo
-            .Setup(x => x.CreateAsync(It.IsAny<TargetRangeSchedule>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback(Capture)
-            .ReturnsAsync((TargetRangeSchedule m, WriteOrigin _, CancellationToken _) => m);
-
-        var decomposer = new ProfileDecomposer(
-            therapySettingsRepo.Object,
-            basalScheduleRepo.Object,
-            carbRatioScheduleRepo.Object,
-            sensitivityScheduleRepo.Object,
-            targetRangeScheduleRepo.Object,
-            NullLogger<ProfileDecomposer>.Instance);
-
-        var result = await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
+        var result = await repos.Decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
 
         result.CreatedRecords.Should().HaveCount(5);
         attributionDuringUpsert.Should().HaveCount(5).And.AllSatisfy(a =>
@@ -76,150 +36,206 @@ public class ProfileDecomposerTests
     }
 
     /// <summary>
-    /// A decomposer mints a fresh correlation id per call, so re-upserting an unchanged profile
-    /// rewrote correlation_id on all five siblings. Such an update carries no material change, so it
-    /// neither audits nor broadcasts — but the column is indexed, so the update cannot be HOT and
-    /// appends an entry to every index on the table, which took production to 1.24% leaf density.
-    /// That the reassignment then leaves the entity clean is pinned by
-    /// <c>CorrelationIdChurnTests</c>; this asserts the id the decomposer hands down.
+    /// Only the therapy settings row may keep its stored correlation id; the four schedules are
+    /// stamped from what it reads back, so preserving on them would let a fork survive.
     /// </summary>
     [Fact]
-    public async Task DecomposeAsync_KeepsStoredCorrelationId_WhenRecordsAlreadyExist()
+    public async Task DecomposeAsync_PreservesTheStoredCorrelationIdOnTheAnchorOnly()
     {
-        var stored = Guid.CreateVersion7();
-        var written = SetUp(stored, stored, out var decomposer);
+        var repos = new Repositories();
 
-        var result = await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
+        await repos.Decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
 
-        result.UpdatedRecords.Should().HaveCount(5);
-        written().Should().HaveCount(5).And.AllSatisfy(record => record.CorrelationId.Should().Be(
-            stored,
-            "an unchanged re-upsert must leave correlation_id alone, or every sync writes a new row version into every index"));
+        repos.PreserveFlags.Should().HaveCount(5);
+        repos.PreserveFlags[typeof(TherapySettings)].Should().BeTrue();
+        repos.PreserveFlags.Where(p => p.Key != typeof(TherapySettings))
+            .Should().AllSatisfy(p => p.Value.Should().BeFalse());
     }
 
     /// <summary>
-    /// The five siblings are written in five separate transactions, so one lost to a cancelled sync is
+    /// The five siblings are written in five separate saves, so one lost to a cancelled sync is
     /// recreated on the next one. It must rejoin the group rather than fork it: ProfileProjectionService
     /// loads the schedules by the therapy settings row's correlation id, and on a miss serves an empty
-    /// schedule rather than failing. Rewriting every id on every sync is what repairs that today, so
-    /// preserving without converging would make a fork permanent.
+    /// schedule rather than failing.
     /// </summary>
     [Fact]
-    public async Task DecomposeAsync_ConvergesDivergedSiblingsOntoTheAnchorsCorrelationId()
+    public async Task DecomposeAsync_StampsTheSchedulesWithTheAnchorsStoredCorrelationId()
     {
         var anchor = Guid.CreateVersion7();
-        var forked = Guid.CreateVersion7();
-        var written = SetUp(anchor, forked, out var decomposer);
+        var repos = new Repositories(anchorCorrelationId: anchor);
 
-        await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
+        await repos.Decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
 
-        written().Should().HaveCount(5).And.AllSatisfy(record => record.CorrelationId.Should().Be(
-            anchor,
-            "a sibling that drifted must be pulled back onto the therapy settings row's id"));
+        repos.Written.Where(r => r is not TherapySettings).Should().HaveCount(4).And.AllSatisfy(
+            r => r.CorrelationId.Should().Be(anchor, "a sibling must land on the therapy settings row's id"));
     }
 
     /// <summary>
     /// A stored id of null must not leave the anchor on a fresh id while the siblings keep theirs.
     /// </summary>
     [Fact]
-    public async Task DecomposeAsync_StampsTheWholeGroup_WhenTheAnchorHasNoStoredCorrelationId()
+    public async Task DecomposeAsync_StampsTheWholeGroupWithTheMintedId_WhenTheAnchorStoresNone()
     {
-        var written = SetUp(null, Guid.CreateVersion7(), out var decomposer);
+        var repos = new Repositories(anchorCorrelationId: null);
 
-        await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
+        var result = await repos.Decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
 
-        var ids = written().Select(r => r.CorrelationId).ToList();
+        var ids = repos.Written.Select(r => r.CorrelationId).ToList();
         ids.Should().HaveCount(5);
-        ids.Should().AllSatisfy(id => id.Should().NotBeNull());
-        ids.Distinct().Should().ContainSingle("the group must not fork when the anchor stored no id");
+        ids.Distinct().Should().ContainSingle().Which.Should().Be(result.CorrelationId!.Value,
+            "the group must not fork when the anchor stored no id");
     }
 
     /// <summary>
-    /// The write API binds a whole <see cref="TherapySettings"/> from the request body and validates
-    /// only the timestamp, so a caller can store an empty correlation id. Freezing that would stamp it
-    /// across all four schedules and merge the group with every other group carrying it, leaving
-    /// same-named stores to resolve against each other. It has to keep self-healing.
+    /// A refused anchor leaves the schedules nothing to converge on; writing them under the minted id
+    /// would fork the group off the settings row they belong to.
     /// </summary>
     [Fact]
-    public async Task DecomposeAsync_DoesNotPreserveAnEmptyStoredCorrelationId()
+    public async Task DecomposeAsync_WritesNoSchedules_ForAStoreWhoseAnchorWasRefused()
     {
-        var written = SetUp(Guid.Empty, Guid.CreateVersion7(), out var decomposer);
+        var repos = new Repositories(refusedLegacyIds: ["profile1:Weekend"]);
 
-        await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
+        var result = await repos.Decomposer.DecomposeAsync(BuildProfile(stores: ["Default", "Weekend"]), WriteOrigin.Live);
 
-        var ids = written().Select(r => r.CorrelationId).ToList();
-        ids.Should().HaveCount(5);
-        ids.Should().AllSatisfy(id => id.Should().NotBe(Guid.Empty).And.NotBeNull());
-        ids.Distinct().Should().ContainSingle("the group must converge on the freshly minted id");
+        repos.Written.Select(r => r.LegacyId).Should().OnlyContain(id => id == "profile1:Default");
+        repos.Written.Should().HaveCount(5);
+        result.CreatedRecords.Should().HaveCount(5);
     }
 
     /// <summary>
-    /// Five repositories each already holding a record — the therapy settings anchor under
-    /// <paramref name="anchorCorrelationId"/> and the four schedules under
-    /// <paramref name="scheduleCorrelationId"/> — returning the models handed to <c>UpdateAsync</c>.
+    /// The point of the batch: a connector's whole profile set costs one round per table, not ten
+    /// per named profile, and every store of every profile is in it.
     /// </summary>
-    private static Func<List<IV4Record>> SetUp(
-        Guid? anchorCorrelationId, Guid? scheduleCorrelationId, out ProfileDecomposer decomposer)
+    [Fact]
+    public async Task DecomposeBatchAsync_CallsEachRepositoryOnce_WithEveryStoreEntry()
     {
-        var therapy = ExistingRecord<ITherapySettingsRepository, TherapySettings>(anchorCorrelationId, out var therapyUpdates);
-        var basal = ExistingRecord<IBasalScheduleRepository, BasalSchedule>(scheduleCorrelationId, out var basalUpdates);
-        var carbRatio = ExistingRecord<ICarbRatioScheduleRepository, CarbRatioSchedule>(scheduleCorrelationId, out var carbRatioUpdates);
-        var sensitivity = ExistingRecord<ISensitivityScheduleRepository, SensitivitySchedule>(scheduleCorrelationId, out var sensitivityUpdates);
-        var targetRange = ExistingRecord<ITargetRangeScheduleRepository, TargetRangeSchedule>(scheduleCorrelationId, out var targetRangeUpdates);
+        var repos = new Repositories();
+        var profiles = new[]
+        {
+            BuildProfile(id: "profile1", stores: ["Default", "Weekend"]),
+            BuildProfile(id: "profile2", stores: ["Default"]),
+        };
 
-        decomposer = new ProfileDecomposer(
-            therapy.Object, basal.Object, carbRatio.Object, sensitivity.Object, targetRange.Object,
-            NullLogger<ProfileDecomposer>.Instance);
+        var result = await repos.Decomposer.DecomposeBatchAsync(profiles, WriteOrigin.Live);
 
-        return () => therapyUpdates.Cast<IV4Record>()
-            .Concat(basalUpdates)
-            .Concat(carbRatioUpdates)
-            .Concat(sensitivityUpdates)
-            .Concat(targetRangeUpdates)
-            .ToList();
+        repos.Calls.Should().HaveCount(5);
+        repos.Calls.Should().AllSatisfy(c => c.Should().Be(3));
+        repos.Written.Select(r => r.LegacyId).Distinct()
+            .Should().BeEquivalentTo(["profile1:Default", "profile1:Weekend", "profile2:Default"]);
+        result.CreatedRecords.Should().HaveCount(15);
     }
 
     /// <summary>
-    /// A repository already holding one record under any legacy id, capturing the models handed to
-    /// <c>UpdateAsync</c> so a test can assert what would actually have been written.
+    /// Two profiles created together must not share a correlation id, while the stores of one profile
+    /// do — the ids the single-profile path always minted.
     /// </summary>
-    private static Mock<TRepo> ExistingRecord<TRepo, TRecord>(Guid? storedCorrelationId, out List<TRecord> updates)
-        where TRepo : class, ILegacyKeyedRepository<TRecord>
-        where TRecord : class, IV4Record, new()
+    [Fact]
+    public async Task DecomposeBatchAsync_MintsOneCorrelationIdPerProfile()
     {
-        var captured = new List<TRecord>();
-        updates = captured;
+        var repos = new Repositories(anchorCorrelationId: null);
+        var profiles = new[]
+        {
+            BuildProfile(id: "profile1", stores: ["Default", "Weekend"]),
+            BuildProfile(id: "profile2", stores: ["Default"]),
+        };
 
-        var repo = new Mock<TRepo>();
-        repo
-            .Setup(x => x.GetByLegacyIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() => new TRecord { Id = Guid.CreateVersion7(), CorrelationId = storedCorrelationId });
-        repo
-            .Setup(x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<TRecord>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback((Guid _, TRecord m, WriteOrigin _, CancellationToken _) => captured.Add(m))
-            .ReturnsAsync((Guid _, TRecord m, WriteOrigin _, CancellationToken _) => m);
-        return repo;
+        var result = await repos.Decomposer.DecomposeBatchAsync(profiles, WriteOrigin.Live);
+
+        var byProfile = repos.Written
+            .GroupBy(r => r.LegacyId!.Split(':')[0])
+            .ToDictionary(g => g.Key, g => g.Select(r => r.CorrelationId).Distinct().ToList());
+        byProfile["profile1"].Should().ContainSingle().Which.Should().Be(result.CorrelationId!.Value);
+        byProfile["profile2"].Should().ContainSingle().Which.Should().NotBe(result.CorrelationId!.Value);
     }
 
-    private static Profile BuildProfile() => new()
+    [Fact]
+    public async Task DecomposeBatchAsync_WithNoStoreEntries_WritesNothing()
     {
-        Id = "profile1",
+        var repos = new Repositories();
+
+        var result = await repos.Decomposer.DecomposeBatchAsync(
+            [BuildProfile(stores: [])], WriteOrigin.Live);
+
+        repos.Calls.Should().BeEmpty();
+        result.CreatedRecords.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Five mocked repositories whose bulk upsert answers every record as created, under the
+    /// correlation id it was handed — except the therapy settings anchor, which answers with
+    /// <paramref name="anchorCorrelationId"/> as its stored id when one is given, and drops any
+    /// record whose legacy id is in <paramref name="refusedLegacyIds"/>.
+    /// </summary>
+    private sealed class Repositories
+    {
+        public ProfileDecomposer Decomposer { get; }
+        public List<IV4Record> Written { get; } = [];
+        public Dictionary<Type, bool> PreserveFlags { get; } = [];
+        public List<int> Calls { get; } = [];
+
+        public Repositories(
+            Guid? anchorCorrelationId = null,
+            IReadOnlyCollection<string>? refusedLegacyIds = null,
+            Action? onUpsert = null)
+        {
+            var refused = refusedLegacyIds ?? [];
+
+            Decomposer = new ProfileDecomposer(
+                Mock<ITherapySettingsRepository, TherapySettings>(anchorCorrelationId, refused, onUpsert),
+                Mock<IBasalScheduleRepository, BasalSchedule>(null, [], onUpsert),
+                Mock<ICarbRatioScheduleRepository, CarbRatioSchedule>(null, [], onUpsert),
+                Mock<ISensitivityScheduleRepository, SensitivitySchedule>(null, [], onUpsert),
+                Mock<ITargetRangeScheduleRepository, TargetRangeSchedule>(null, [], onUpsert),
+                NullLogger<ProfileDecomposer>.Instance);
+        }
+
+        private TRepo Mock<TRepo, TRecord>(
+            Guid? storedCorrelationId, IReadOnlyCollection<string> refused, Action? onUpsert)
+            where TRepo : class, ILegacyKeyedRepository<TRecord>
+            where TRecord : class, IV4Record
+        {
+            var repo = new Moq.Mock<TRepo>();
+            repo
+                .Setup(x => x.BulkUpsertByLegacyIdAsync(
+                    It.IsAny<IReadOnlyList<TRecord>>(), It.IsAny<WriteOrigin>(), It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IReadOnlyList<TRecord> records, WriteOrigin _, bool preserve, CancellationToken _) =>
+                {
+                    onUpsert?.Invoke();
+                    Calls.Add(records.Count);
+                    PreserveFlags[typeof(TRecord)] = preserve;
+                    var outcomes = new Dictionary<string, LegacyUpsert<TRecord>>(StringComparer.Ordinal);
+                    foreach (var record in records)
+                    {
+                        if (refused.Contains(record.LegacyId!))
+                            continue;
+                        if (storedCorrelationId is { } stored)
+                            record.CorrelationId = stored;
+                        Written.Add(record);
+                        outcomes[record.LegacyId!] = new LegacyUpsert<TRecord>(record, Created: true);
+                    }
+                    return outcomes;
+                });
+            return repo.Object;
+        }
+    }
+
+    private static Profile BuildProfile(string id = "profile1", IReadOnlyList<string>? stores = null) => new()
+    {
+        Id = id,
         Mills = 1700000000000,
         DefaultProfile = "Default",
         EnteredBy = "test",
-        Store = new Dictionary<string, ProfileData>
+        Store = (stores ?? ["Default"]).ToDictionary(name => name, _ => new ProfileData
         {
-            ["Default"] = new ProfileData
-            {
-                Dia = 3.0,
-                Timezone = "UTC",
-                Basal = [new TimeValue { Time = "00:00", Value = 1.0 }],
-                CarbRatio = [new TimeValue { Time = "00:00", Value = 10.0 }],
-                Sens = [new TimeValue { Time = "00:00", Value = 50.0 }],
-                TargetLow = [new TimeValue { Time = "00:00", Value = 80.0 }],
-                TargetHigh = [new TimeValue { Time = "00:00", Value = 120.0 }],
-            },
-        },
+            Dia = 3.0,
+            Timezone = "UTC",
+            Basal = [new TimeValue { Time = "00:00", Value = 1.0 }],
+            CarbRatio = [new TimeValue { Time = "00:00", Value = 10.0 }],
+            Sens = [new TimeValue { Time = "00:00", Value = 50.0 }],
+            TargetLow = [new TimeValue { Time = "00:00", Value = 80.0 }],
+            TargetHigh = [new TimeValue { Time = "00:00", Value = 120.0 }],
+        }),
     };
 
     [Theory]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
@@ -51,6 +51,17 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
         };
     }
 
+    /// <summary>
+    /// A snapshot's identity is its sync key; a legacy-id batch would insert duplicates past it.
+    /// </summary>
+    [Fact]
+    public async Task BulkUpsertByLegacyIdAsync_IsRefused_ForASyncKeyedType()
+    {
+        var act = () => _repository.BulkUpsertByLegacyIdAsync([CreateSnapshot("sync-1")], WriteOrigin.Live);
+
+        await act.Should().ThrowAsync<NotSupportedException>();
+    }
+
     [Fact]
     public async Task BulkCreateAsync_InsertsNewRecords()
     {

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TherapySettingsRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TherapySettingsRepositoryBulkUpsertTests.cs
@@ -1,0 +1,208 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Nocturne.Tests.Shared.Mocks;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// <c>BulkUpsertByLegacyIdAsync</c> is the batch form of get-by-legacy-id then create-or-update, so
+/// every rule the per-record pair enforces has to hold for the batch: existing rows update in place,
+/// new rows insert, a held identity is refused, a stored correlation id is kept only when asked, and
+/// an unchanged re-upsert is silent.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class TherapySettingsRepositoryBulkUpsertTests : IDisposable
+{
+    private static readonly Guid Tenant = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly RecordingBroadcaster _broadcaster = new();
+    private readonly TherapySettingsRepository _repository;
+
+    public TherapySettingsRepositoryBulkUpsertTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryContext($"therapy_settings_bulk_upsert_{Guid.NewGuid()}");
+        _context.TenantId = Tenant;
+        _repository = new TherapySettingsRepository(
+            new TestTenantDbContextFactory(_context),
+            new SystemAuditContext(),
+            NullLogger<TherapySettingsRepository>.Instance,
+            _broadcaster);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static TherapySettings Settings(string legacyId, double dia = 3.0, Guid? correlationId = null) => new()
+    {
+        LegacyId = legacyId,
+        Timestamp = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+        ProfileName = legacyId.Split(':')[^1],
+        Dia = dia,
+        CorrelationId = correlationId,
+    };
+
+    [Fact]
+    public async Task BulkUpsert_InsertsNewRecords_AndReportsThemCreated()
+    {
+        var outcomes = await _repository.BulkUpsertByLegacyIdAsync(
+            [Settings("p1:Default"), Settings("p1:Weekend")], WriteOrigin.Live);
+
+        outcomes.Keys.Should().BeEquivalentTo(["p1:Default", "p1:Weekend"]);
+        outcomes.Values.Should().AllSatisfy(o => o.Created.Should().BeTrue());
+        _context.TherapySettings.Count().Should().Be(2);
+        _broadcaster.Created.Should().HaveCount(2);
+        _broadcaster.Updated.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BulkUpsert_UpdatesAStoredRowInPlace_AndWritesItsIdBack()
+    {
+        var first = await _repository.BulkUpsertByLegacyIdAsync([Settings("p1:Default", dia: 3.0)], WriteOrigin.Live);
+        var storedId = first["p1:Default"].Record.Id;
+        var changed = Settings("p1:Default", dia: 4.5);
+
+        var outcomes = await _repository.BulkUpsertByLegacyIdAsync([changed], WriteOrigin.Live);
+
+        outcomes["p1:Default"].Created.Should().BeFalse();
+        outcomes["p1:Default"].Record.Id.Should().Be(storedId);
+        changed.Id.Should().Be(storedId, "the update path hands the caller the stored identity");
+        _context.TherapySettings.Count().Should().Be(1);
+        _context.TherapySettings.Single().Dia.Should().Be(4.5);
+        _broadcaster.Updated.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A connector re-publishes its whole profile set every cycle; a byte-identical re-send must
+    /// neither write nor broadcast, the same gate <c>UpdateAsync</c> applies per record.
+    /// </summary>
+    [Fact]
+    public async Task BulkUpsert_UnchangedReUpsert_IsReportedUpdatedButBroadcastsNothing()
+    {
+        await _repository.BulkUpsertByLegacyIdAsync([Settings("p1:Default")], WriteOrigin.Live);
+        _broadcaster.Clear();
+
+        var outcomes = await _repository.BulkUpsertByLegacyIdAsync([Settings("p1:Default")], WriteOrigin.Live);
+
+        outcomes["p1:Default"].Created.Should().BeFalse();
+        _broadcaster.Created.Should().BeEmpty();
+        _broadcaster.Updated.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BulkUpsert_MixedBatch_InsertsAndUpdatesTogether()
+    {
+        await _repository.BulkUpsertByLegacyIdAsync([Settings("p1:Default", dia: 3.0)], WriteOrigin.Live);
+
+        var outcomes = await _repository.BulkUpsertByLegacyIdAsync(
+            [Settings("p1:Default", dia: 5.0), Settings("p1:Weekend")], WriteOrigin.Live);
+
+        outcomes["p1:Default"].Created.Should().BeFalse();
+        outcomes["p1:Weekend"].Created.Should().BeTrue();
+        _context.TherapySettings.Count().Should().Be(2);
+        _context.TherapySettings.Single(t => t.LegacyId == "p1:Default").Dia.Should().Be(5.0);
+    }
+
+    [Fact]
+    public async Task BulkUpsert_KeepsTheStoredCorrelationId_OnlyWhenAsked()
+    {
+        var stored = Guid.CreateVersion7();
+        await _repository.BulkUpsertByLegacyIdAsync([Settings("p1:Default", correlationId: stored)], WriteOrigin.Live);
+
+        var preserving = await _repository.BulkUpsertByLegacyIdAsync(
+            [Settings("p1:Default", correlationId: Guid.CreateVersion7())], WriteOrigin.Live,
+            preserveStoredCorrelationId: true);
+        preserving["p1:Default"].Record.CorrelationId.Should().Be(stored);
+
+        var fresh = Guid.CreateVersion7();
+        var overwriting = await _repository.BulkUpsertByLegacyIdAsync(
+            [Settings("p1:Default", correlationId: fresh)], WriteOrigin.Live);
+        overwriting["p1:Default"].Record.CorrelationId.Should().Be(fresh);
+    }
+
+    /// <summary>
+    /// An empty stored id is a client artefact, not an identity; freezing it would merge the group
+    /// with every other group carrying it.
+    /// </summary>
+    [Fact]
+    public async Task BulkUpsert_DoesNotPreserveAnEmptyStoredCorrelationId()
+    {
+        await _repository.BulkUpsertByLegacyIdAsync([Settings("p1:Default", correlationId: Guid.Empty)], WriteOrigin.Live);
+        var minted = Guid.CreateVersion7();
+
+        var outcomes = await _repository.BulkUpsertByLegacyIdAsync(
+            [Settings("p1:Default", correlationId: minted)], WriteOrigin.Live, preserveStoredCorrelationId: true);
+
+        outcomes["p1:Default"].Record.CorrelationId.Should().Be(minted);
+    }
+
+    /// <summary>
+    /// A row the user deleted holds its legacy id against re-creation, exactly as
+    /// <c>CreateAsync</c> refuses it with <see cref="RecreationBlockedException"/>; the batch drops the
+    /// record instead of throwing, so its siblings still land.
+    /// </summary>
+    [Fact]
+    public async Task BulkUpsert_DropsARecordWhoseIdentityIsHeldByAUserTombstone()
+    {
+        var created = await _repository.BulkUpsertByLegacyIdAsync([Settings("p1:Default")], WriteOrigin.Live);
+        var entity = _context.TherapySettings.Single(t => t.Id == created["p1:Default"].Record.Id);
+        entity.DeletedAt = DateTime.UtcNow;
+        _context.Entry(entity).Property("DeletedByUser").CurrentValue = true;
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var outcomes = await _repository.BulkUpsertByLegacyIdAsync(
+            [Settings("p1:Default"), Settings("p1:Weekend")], WriteOrigin.Live);
+
+        outcomes.Keys.Should().BeEquivalentTo(["p1:Weekend"]);
+        _context.TherapySettings.IgnoreQueryFilters().Count().Should().Be(2, "the tombstone and the new sibling");
+    }
+
+    [Fact]
+    public async Task BulkUpsert_IgnoresRecordsWithoutALegacyId_AndKeepsTheLastOfADuplicate()
+    {
+        var outcomes = await _repository.BulkUpsertByLegacyIdAsync(
+            [Settings("p1:Default", dia: 1.0), Settings("p1:Default", dia: 2.0), new TherapySettings { ProfileName = "loose" }],
+            WriteOrigin.Live);
+
+        outcomes.Should().ContainSingle();
+        outcomes["p1:Default"].Record.Dia.Should().Be(2.0);
+        _context.TherapySettings.Count().Should().Be(1);
+    }
+
+    private sealed class RecordingBroadcaster : IV4RecordBroadcaster<TherapySettings>
+    {
+        public List<TherapySettings> Created { get; } = [];
+        public List<TherapySettings> Updated { get; } = [];
+
+        public Task BroadcastCreatedAsync(IReadOnlyList<TherapySettings> items, CancellationToken ct = default)
+        {
+            Created.AddRange(items);
+            return Task.CompletedTask;
+        }
+
+        public Task BroadcastUpdatedAsync(IReadOnlyList<TherapySettings> items, CancellationToken ct = default)
+        {
+            Updated.AddRange(items);
+            return Task.CompletedTask;
+        }
+
+        public void Clear()
+        {
+            Created.Clear();
+            Updated.Clear();
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TherapySettingsRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TherapySettingsRepositoryBulkUpsertTests.cs
@@ -125,11 +125,23 @@ public class TherapySettingsRepositoryBulkUpsertTests : IDisposable
             [Settings("p1:Default", correlationId: Guid.CreateVersion7())], WriteOrigin.Live,
             preserveStoredCorrelationId: true);
         preserving["p1:Default"].Record.CorrelationId.Should().Be(stored);
+        StoredCorrelationId("p1:Default").Should().Be(stored);
 
+        // A correlation id is bookkeeping the audit gate ignores, so this write changes nothing the
+        // broadcast counts as material and still has to reach the row: it is the sibling-convergence
+        // repair the anchor's preservation exists for.
         var fresh = Guid.CreateVersion7();
         var overwriting = await _repository.BulkUpsertByLegacyIdAsync(
             [Settings("p1:Default", correlationId: fresh)], WriteOrigin.Live);
         overwriting["p1:Default"].Record.CorrelationId.Should().Be(fresh);
+        StoredCorrelationId("p1:Default").Should().Be(fresh, "a correlation-id-only change must be persisted");
+        _broadcaster.Updated.Should().BeEmpty("a correlation-id-only change is not a material update");
+    }
+
+    private Guid? StoredCorrelationId(string legacyId)
+    {
+        _context.ChangeTracker.Clear();
+        return _context.TherapySettings.AsNoTracking().Single(t => t.LegacyId == legacyId).CorrelationId;
     }
 
     /// <summary>
@@ -146,6 +158,7 @@ public class TherapySettingsRepositoryBulkUpsertTests : IDisposable
             [Settings("p1:Default", correlationId: minted)], WriteOrigin.Live, preserveStoredCorrelationId: true);
 
         outcomes["p1:Default"].Record.CorrelationId.Should().Be(minted);
+        StoredCorrelationId("p1:Default").Should().Be(minted, "the empty id self-heals on the row, not only in the answer");
     }
 
     /// <summary>


### PR DESCRIPTION
First slice of #1278.

## What changed

After #1280 the largest query family on the hosted instance is the profile publish path: every Nightscout-family connector re-publishes its profile documents on every sync, and `ProfileDecomposer` wrote each named profile through five `GetByLegacyIdAsync` + `UpdateAsync` pairs, one per V4 table. Each of those ten single-row queries is its own DbContext and pooled-connection lease (`set_config`, query, `DISCARD ALL`), so a ten-profile publish cost ~100 queries and ~300 statements to change nothing. Measured over five minutes on 2026-09-09 01:05-01:10Z: ~17,700 such lookups, about 37 % of all statements once their ceremony is counted (#1278).

- **`ILegacyKeyedRepository<T>.BulkUpsertByLegacyIdAsync`** (implemented once in `V4RepositoryBase`): create-or-update a batch under its legacy ids in one context — one query for the stored rows, one for identities that block re-creation (only when something is to insert), one save (only when something changed). Same soft-delete visibility as `GetByLegacyIdAsync`, same recreation guard as `CreateAsync` (a held identity drops the record instead of throwing), same `HasMaterialChange` gate on the update broadcast as `UpdateAsync` (the gate decides the broadcast only; the save always runs, because `CorrelationId` is audit-ignored and a sibling converging onto its anchor's id must still reach the row), and the stored `Id` is written back onto the record. Change detection runs once over the batch and stays off through the save. The sync-keyed repositories (sensor glucose, boluses, carb intakes, the device-status snapshots) throw `NotSupportedException` from this method: their identity is the sync key and their batch path is `BulkCreateAsync`. Returns the outcomes keyed by legacy id (`LegacyUpsert<T>(Record, Created)`); refused records are absent.
- **`IProfileDecomposer.DecomposeBatchAsync`**: the therapy-settings anchors for every store entry of every profile go in one call with `preserveStoredCorrelationId: true`, the four schedule tables follow with one call each, stamped from what the anchors read back. `DecomposeAsync` is now a batch of one, so there is a single implementation of the anchoring rule. A profile's stores share one minted correlation id and two profiles in a batch do not, as before. A refused anchor still means no schedules for that store.
- **`ProfileWriteService.CreateProfilesAsync`** decomposes its list in one batch. `UpdateProfileAsync`, the migration importer and the v1/v3 controllers' single-profile paths are unchanged in shape (they go through the batch-of-one).

Per ten-profile publish: 5 table round trips (up to 15 statements plus ceremony) instead of ~100 queries. No schema change.

## Tests

- `TherapySettingsRepositoryBulkUpsertTests` (InMemory): inserts report created; a stored row updates in place and hands its id back; an unchanged re-upsert is reported updated but broadcasts nothing; a mixed batch inserts and updates together; the stored correlation id is kept only when asked and never when empty, asserted on the stored row, and a correlation-id-only change is persisted without an update broadcast; a user tombstone drops the record and its siblings still land; records without a legacy id are ignored and a repeated id keeps its last record.
- `ProfileDecomposerTests` rewritten to the new surface: caller audit attribution preserved; preservation asked on the anchor only; schedules stamped from the anchor's stored id, or the minted id when it stores none; no schedules for a refused anchor; one repository call per table carrying every store entry of a two-profile batch; one minted id per profile; empty stores write nothing. Unit-conversion tests unchanged.

Infrastructure.Data (1,004) and API (6,701) unit suites pass locally. Known limits, accepted: a batch is one save per table, so a unique-index race between two concurrent publishes of one tenant now fails the whole table's batch rather than one record (the publisher logs and the next cycle re-publishes); the batch is not chunked, which is fine for profile sets and would want chunking before any larger caller adopts it.

The hostile review of the first revision found the save gate dropping correlation-id-only writes; fixed in the second commit with a stored-row assertion.

