### PR TITLE
perf(connectors): look at a tenant only when it is due, and nudge the poller on configuration writes

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -920,6 +920,8 @@ public static class ServiceRegistrationExtensions
             pollingService: typeof(ConnectorBackgroundService<,>)
         );
         services.AddSingleton(ConnectorSyncBudget.FromConfiguration(configuration, services));
+        services.AddSingleton<ConnectorPollerNudge>();
+        services.AddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<ConnectorPollerNudge>());
 
         // Demo service health monitor
         services.AddHttpClient("DemoServiceHealth");

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -920,6 +920,8 @@ public static class ServiceRegistrationExtensions
             pollingService: typeof(ConnectorBackgroundService<,>)
         );
         services.AddSingleton(ConnectorSyncBudget.FromConfiguration(configuration, services));
+        // After AddConnectors: the installers register the token caches as IConnectorCacheInvalidator
+        // with TryAddSingleton, which a prior registration of the interface would silently suppress.
         services.AddSingleton<ConnectorPollerNudge>();
         services.AddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<ConnectorPollerNudge>());
 

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -23,7 +23,7 @@ namespace Nocturne.API.Services.BackgroundServices;
 /// <remarks>
 /// The service polls every minute and only syncs a given tenant when its configured
 /// <c>SyncIntervalMinutes</c> has elapsed since the last sync, and looks at a tenant only when it is
-/// due (<see cref="_nextCheckByTenant"/>). Per-tenant configuration
+/// due (see <see cref="UnconfiguredRecheckInterval"/>). Per-tenant configuration
 /// is loaded fresh each cycle via <see cref="IConnectorConfigurationLoader{TConfig}"/>.
 /// </remarks>
 public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
@@ -50,10 +50,9 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     /// <summary>
     /// When each tenant next needs a look: a tenant with no usable configuration for this connector
     /// after <see cref="UnconfiguredRecheckInterval"/>, a configured one when its interval has
-    /// elapsed. A tenant not yet due costs the tick nothing — no budget slot, no DI scope, no
-    /// configuration read. Cleared by <see cref="RequestImmediateSync"/>, which
-    /// <see cref="ConnectorPollerNudge"/> drives from every configuration write, so a saved or
-    /// enabled connector syncs on the next tick.
+    /// elapsed. A tenant not yet due takes no budget slot, opens no scope and reads nothing this tick.
+    /// Cleared by <see cref="RequestImmediateSync"/>, which <see cref="ConnectorPollerNudge"/> drives
+    /// from every configuration write, so a saved or enabled connector is looked at on the next tick.
     /// </summary>
     private readonly ConcurrentDictionary<Guid, DateTime> _nextCheckByTenant = new();
 
@@ -108,12 +107,17 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     {
         var now = DateTime.UtcNow;
 
+        // The schedule is cleared ahead of the debounce: the debounce protects the sync itself from
+        // an event storm, whereas a look costs one configuration read, and a tenant's enable flow
+        // writes configuration, secrets and the active flag in quick succession — the last of those
+        // is the one that must be seen.
+        _nextCheckByTenant.TryRemove(tenantId, out _);
+
         if (_lastNudgeByTenant.TryGetValue(tenantId, out var lastNudge) && now - lastNudge < NudgeDebounceWindow)
             return;
 
         _lastNudgeByTenant[tenantId] = now;
         _lastSyncByTenant.TryRemove(tenantId, out _);
-        _nextCheckByTenant.TryRemove(tenantId, out _);
 
         Logger.LogDebug(
             "Immediate sync requested for {ConnectorName} tenant {TenantId}",

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -22,7 +22,8 @@ namespace Nocturne.API.Services.BackgroundServices;
 /// </typeparam>
 /// <remarks>
 /// The service polls every minute and only syncs a given tenant when its configured
-/// <c>SyncIntervalMinutes</c> has elapsed since the last sync. Per-tenant configuration
+/// <c>SyncIntervalMinutes</c> has elapsed since the last sync, and looks at a tenant only when it is
+/// due (<see cref="_nextCheckByTenant"/>). Per-tenant configuration
 /// is loaded fresh each cycle via <see cref="IConnectorConfigurationLoader{TConfig}"/>.
 /// </remarks>
 public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
@@ -45,6 +46,16 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     /// used to debounce rapid consecutive calls.
     /// </summary>
     private readonly ConcurrentDictionary<Guid, DateTime> _lastNudgeByTenant = new();
+
+    /// <summary>
+    /// When each tenant next needs a look: a tenant with no usable configuration for this connector
+    /// after <see cref="UnconfiguredRecheckInterval"/>, a configured one when its interval has
+    /// elapsed. A tenant not yet due costs the tick nothing — no budget slot, no DI scope, no
+    /// configuration read. Cleared by <see cref="RequestImmediateSync"/>, which
+    /// <see cref="ConnectorPollerNudge"/> drives from every configuration write, so a saved or
+    /// enabled connector syncs on the next tick.
+    /// </summary>
+    private readonly ConcurrentDictionary<Guid, DateTime> _nextCheckByTenant = new();
 
     private static readonly TimeSpan NudgeDebounceWindow = TimeSpan.FromSeconds(10);
 
@@ -72,15 +83,18 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     /// <param name="serviceProvider">Root DI service provider; a new scope is created per tenant sync.</param>
     /// <param name="budget">The process-wide budget.</param>
     /// <param name="logger">Logger instance.</param>
+    /// <param name="nudge">Delivers configuration writes for this connector; absent, a change is noticed on the tenant's next scheduled look.</param>
     protected ConnectorBackgroundService(
         IServiceProvider serviceProvider,
         ConnectorSyncBudget budget,
-        ILogger logger
+        ILogger logger,
+        ConnectorPollerNudge? nudge = null
     )
     {
         ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         _budget = budget ?? throw new ArgumentNullException(nameof(budget));
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        nudge?.Subscribe(ConnectorName, RequestImmediateSync);
     }
 
     /// <summary>
@@ -99,6 +113,7 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
         _lastNudgeByTenant[tenantId] = now;
         _lastSyncByTenant.TryRemove(tenantId, out _);
+        _nextCheckByTenant.TryRemove(tenantId, out _);
 
         Logger.LogDebug(
             "Immediate sync requested for {ConnectorName} tenant {TenantId}",
@@ -140,6 +155,13 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     /// SyncIntervalMinutes has elapsed since its last sync. Overridable for tests.
     /// </summary>
     protected virtual TimeSpan PollInterval => TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// How long a tenant with no usable configuration for this connector is left alone before its
+    /// configuration is read again. Bounds the enable latency on an instance the configuration
+    /// write did not reach (<see cref="ConnectorPollerNudge"/> is in-process). Overridable for tests.
+    /// </summary>
+    protected virtual TimeSpan UnconfiguredRecheckInterval => TimeSpan.FromMinutes(5);
 
     private DateTime _lastRealtimeSupervision = DateTime.MinValue;
 
@@ -342,10 +364,13 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         using var lookupScope = ServiceProvider.CreateScope();
         var factory = lookupScope.ServiceProvider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
         await using var lookupContext = await factory.CreateDbContextAsync(stoppingToken);
-        var tenants = await lookupContext.Tenants.AsNoTracking()
-            .Where(t => t.IsActive)
-            .Select(t => new { t.Id, t.Slug, t.DisplayName })
-            .ToListAsync(stoppingToken);
+        var now = DateTime.UtcNow;
+        var tenants = (await lookupContext.Tenants.AsNoTracking()
+                .Where(t => t.IsActive)
+                .Select(t => new { t.Id, t.Slug, t.DisplayName })
+                .ToListAsync(stoppingToken))
+            .Where(t => !_nextCheckByTenant.TryGetValue(t.Id, out var nextCheck) || nextCheck <= now)
+            .ToList();
 
         // Sync tenants concurrently so each tenant is independent: one tenant's slow or failing sync
         // must never delay or block another's. Each tenant already runs in its own DI scope (own
@@ -455,18 +480,25 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
             return;
         }
 
+        var now = DateTime.UtcNow;
         if (!config.Enabled || config.SyncIntervalMinutes <= 0)
+        {
+            _nextCheckByTenant[tenantId] = now + UnconfiguredRecheckInterval;
             return;
+        }
 
         // Only sync when the tenant's configured interval has elapsed
-        var now = DateTime.UtcNow;
         var interval = TimeSpan.FromMinutes(config.SyncIntervalMinutes);
         if (_lastSyncByTenant.TryGetValue(tenantId, out var lastSync) && now - lastSync < interval)
+        {
+            _nextCheckByTenant[tenantId] = lastSync + interval;
             return;
+        }
 
         Logger.LogDebug("Syncing {ConnectorName} for tenant {TenantSlug}", ConnectorName, tenantSlug);
 
         _lastSyncByTenant[tenantId] = now;
+        _nextCheckByTenant[tenantId] = now + interval;
 
         await UpdateHealthStateAsync(
             scope.ServiceProvider,
@@ -531,8 +563,9 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 public class ConnectorBackgroundService<TService, TConfig>(
     IServiceProvider serviceProvider,
     ConnectorSyncBudget budget,
-    ILogger<ConnectorBackgroundService<TService, TConfig>> logger)
-    : ConnectorBackgroundService<TConfig>(serviceProvider, budget, logger)
+    ILogger<ConnectorBackgroundService<TService, TConfig>> logger,
+    ConnectorPollerNudge? nudge = null)
+    : ConnectorBackgroundService<TConfig>(serviceProvider, budget, logger, nudge)
     where TService : class, IConnectorService<TConfig>
     where TConfig : BaseConnectorConfiguration
 {

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorPollerNudge.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorPollerNudge.cs
@@ -22,6 +22,10 @@ public sealed class ConnectorPollerNudge : IConnectorCacheInvalidator
     public void Subscribe(string connectorName, Action<Guid> onChanged) =>
         _subscribers.GetOrAdd(connectorName, _ => []).Add(onChanged);
 
+    /// <summary>Whether any poller has subscribed under <paramref name="connectorName"/>.</summary>
+    public bool HasSubscribers(string connectorName) =>
+        _subscribers.TryGetValue(connectorName, out var subscribers) && !subscribers.IsEmpty;
+
     /// <inheritdoc />
     public void Invalidate(string connectorName, Guid tenantId)
     {

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorPollerNudge.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorPollerNudge.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+using Nocturne.Connectors.Core.Interfaces;
+
+namespace Nocturne.API.Services.BackgroundServices;
+
+/// <summary>
+/// Carries a tenant's connector-configuration change to the poller scheduling that connector, so a
+/// poller that skips tenants until they are due picks the change up on its next tick rather than at
+/// the end of the tenant's recheck interval. It is the cache-invalidation hook the configuration
+/// service already calls on every write, so the write paths need no second plumbing.
+/// </summary>
+/// <remarks>
+/// In-process only: on a multi-instance deployment the other instances' pollers notice within
+/// <c>ConnectorBackgroundService.UnconfiguredRecheckInterval</c> instead.
+/// </remarks>
+public sealed class ConnectorPollerNudge : IConnectorCacheInvalidator
+{
+    private readonly ConcurrentDictionary<string, ConcurrentBag<Action<Guid>>> _subscribers =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Registers <paramref name="onChanged"/> to run with the tenant id whenever that connector's configuration is written.</summary>
+    public void Subscribe(string connectorName, Action<Guid> onChanged) =>
+        _subscribers.GetOrAdd(connectorName, _ => []).Add(onChanged);
+
+    /// <inheritdoc />
+    public void Invalidate(string connectorName, Guid tenantId)
+    {
+        if (!_subscribers.TryGetValue(connectorName, out var subscribers))
+            return;
+
+        foreach (var subscriber in subscribers)
+            subscriber(tenantId);
+    }
+}

--- a/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
@@ -43,12 +43,14 @@ public class NightscoutConnectorBackgroundService
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
     /// <param name="budget">The process-wide budget.</param>
     /// <param name="logger">Logger instance for this background service.</param>
+    /// <param name="nudge">Delivers configuration writes for this connector.</param>
     public NightscoutConnectorBackgroundService(
         IServiceProvider serviceProvider,
         ConnectorSyncBudget budget,
-        ILogger<NightscoutConnectorBackgroundService> logger
+        ILogger<NightscoutConnectorBackgroundService> logger,
+        ConnectorPollerNudge? nudge = null
     )
-        : base(serviceProvider, budget, logger) { }
+        : base(serviceProvider, budget, logger, nudge) { }
 
     /// <inheritdoc />
     protected override async Task StartRealtimeListenersAsync(CancellationToken cancellationToken)

--- a/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
@@ -23,12 +23,14 @@ public class NocturneRemoteConnectorBackgroundService
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
     /// <param name="budget">The process-wide budget.</param>
     /// <param name="logger">Logger instance for this background service.</param>
+    /// <param name="nudge">Delivers configuration writes for this connector.</param>
     public NocturneRemoteConnectorBackgroundService(
         IServiceProvider serviceProvider,
         ConnectorSyncBudget budget,
-        ILogger<NocturneRemoteConnectorBackgroundService> logger
+        ILogger<NocturneRemoteConnectorBackgroundService> logger,
+        ConnectorPollerNudge? nudge = null
     )
-        : base(serviceProvider, budget, logger) { }
+        : base(serviceProvider, budget, logger, nudge) { }
 
     /// <inheritdoc />
     protected override async Task StartRealtimeListenersAsync(CancellationToken cancellationToken)

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
@@ -184,11 +184,7 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
         }
 
         await _context.SaveChangesAsync(ct);
-
-        // Invalidate cached auth tokens so the next sync uses fresh credentials
-        var tenantId = _context.TenantId;
-        foreach (var invalidator in _cacheInvalidators)
-            invalidator.Invalidate(connectorName, tenantId);
+        InvalidateCaches(connectorName);
 
         // Broadcast configuration change
         await _broadcastService.BroadcastConfigChangeAsync(new ConfigurationChangeEvent
@@ -253,6 +249,7 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
         }
 
         await _context.SaveChangesAsync(ct);
+        InvalidateCaches(connectorName);
 
         // When saving Nightscout connector secrets that include an API secret,
         // create a DirectGrant with the SHA-1 hash so existing uploaders keep working.
@@ -481,6 +478,7 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
         }
 
         await _context.SaveChangesAsync(ct);
+        InvalidateCaches(connectorName);
         _logger.LogInformation("Set connector {ConnectorName} active={IsActive}", connectorName, isActive);
 
         // Broadcast enable/disable change
@@ -490,6 +488,17 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
             ChangeType = isActive ? "enabled" : "disabled",
             ModifiedBy = modifiedBy
         });
+    }
+
+    /// <summary>
+    /// Tells every tenant-keyed cache — auth tokens, sessions, the pollers' schedules — that this
+    /// connector's stored configuration changed, so the next sync reads it afresh and runs now.
+    /// </summary>
+    private void InvalidateCaches(string connectorName)
+    {
+        var tenantId = _context.TenantId;
+        foreach (var invalidator in _cacheInvalidators)
+            invalidator.Invalidate(connectorName, tenantId);
     }
 
     /// <summary>
@@ -530,6 +539,7 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
 
         _context.ConnectorConfigurations.Remove(entity);
         await _context.SaveChangesAsync(ct);
+        InvalidateCaches(connectorName);
         _logger.LogInformation("Deleted configuration for connector {ConnectorName}", connectorName);
 
         // Broadcast deletion

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationLoader.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationLoader.cs
@@ -26,19 +26,22 @@ public class ConnectorConfigurationLoader<TConfig>(
         try
         {
             var dbConfig = await configService.GetConfigurationAsync(registration.ConnectorName, ct);
-            if (dbConfig?.Configuration != null)
-            {
-                ConnectorConfigurationBinder.ApplyJsonToConfig(dbConfig.Configuration, config);
-            }
-            else
+            if (dbConfig is null)
             {
                 // No per-tenant configuration row exists, so this connector is not configured for
                 // this tenant and must not sync. registration.Defaults sets Enabled = true (a C#
                 // property initializer, not a deliberate opt-in); without this, every connector
                 // would poll every tenant with empty credentials — producing auth failures and
-                // "configuration not found" health-state noise across all tenants.
+                // "configuration not found" health-state noise across all tenants. The secrets live
+                // on the same row, so there is nothing to read for them either.
                 config.Enabled = false;
+                return config;
             }
+
+            if (dbConfig.Configuration != null)
+                ConnectorConfigurationBinder.ApplyJsonToConfig(dbConfig.Configuration, config);
+            else
+                config.Enabled = false;
 
             var secrets = await configService.GetSecretsAsync(registration.ConnectorName, ct);
             if (secrets.Count > 0)

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorPollingRegistrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorPollingRegistrationTests.cs
@@ -80,17 +80,27 @@ public class ConnectorPollingRegistrationTests
 
     /// <summary>
     /// A configuration write reaches a poller only through the <see cref="ConnectorPollerNudge"/> its
-    /// constructor forwards to the base. A hand-written poller whose constructor omits it is scheduled
-    /// and syncs, but never hears that a tenant saved or enabled the connector, and waits out the
-    /// recheck interval instead.
+    /// constructor forwards to the base. A hand-written poller that takes the parameter but does not
+    /// forward it, or omits it, is scheduled and syncs, but never hears that a tenant saved or enabled
+    /// the connector, and waits out the recheck interval instead. Each scheduled poller is built the
+    /// way the host builds it and the nudge is asked whether it subscribed.
     /// </summary>
     [Fact]
-    public void EveryScheduledPoller_TakesTheNudge()
+    public void EveryScheduledPoller_SubscribesToTheNudge()
     {
+        var nudge = new ConnectorPollerNudge();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new ConnectorSyncBudget());
+        services.AddSingleton(nudge);
+        using var provider = services.BuildServiceProvider();
+
         foreach (var poller in ScheduledPollers())
         {
-            poller.GetConstructors().Should().Contain(
-                ctor => ctor.GetParameters().Any(p => p.ParameterType == typeof(ConnectorPollerNudge)),
+            var connectorName = ConnectorRegistrationAttribute.DeclaredOn(PolledConfigurationOf(poller)).ConnectorName;
+            using var _ = (IDisposable)ActivatorUtilities.CreateInstance(provider, poller);
+
+            nudge.HasSubscribers(connectorName).Should().BeTrue(
                 "{0} must forward ConnectorPollerNudge to the base constructor", poller.Name);
         }
     }

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorPollingRegistrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorPollingRegistrationTests.cs
@@ -79,6 +79,23 @@ public class ConnectorPollingRegistrationTests
     }
 
     /// <summary>
+    /// A configuration write reaches a poller only through the <see cref="ConnectorPollerNudge"/> its
+    /// constructor forwards to the base. A hand-written poller whose constructor omits it is scheduled
+    /// and syncs, but never hears that a tenant saved or enabled the connector, and waits out the
+    /// recheck interval instead.
+    /// </summary>
+    [Fact]
+    public void EveryScheduledPoller_TakesTheNudge()
+    {
+        foreach (var poller in ScheduledPollers())
+        {
+            poller.GetConstructors().Should().Contain(
+                ctor => ctor.GetParameters().Any(p => p.ParameterType == typeof(ConnectorPollerNudge)),
+                "{0} must forward ConnectorPollerNudge to the base constructor", poller.Name);
+        }
+    }
+
+    /// <summary>
     /// A poller subclassing the abstract base without closing the generic compiles and reads as
     /// registered, but neither the scan nor the executor loop reaches it and its connector is polled
     /// by the generic instead, without the overrides the subclass declares. That is the shape the ten

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -1028,9 +1028,9 @@ public class ConnectorBackgroundServiceTests
     }
 
     /// <summary>
-    /// Almost every tenant has no configuration for almost every connector, and each poller used to
-    /// open a DI scope and read that absent row for all of them every minute. A tenant found
-    /// unconfigured is left alone until <see cref="ConnectorBackgroundService{TConfig}.UnconfiguredRecheckInterval"/>.
+    /// Almost every tenant has no configuration for almost every connector. A tenant found
+    /// unconfigured is left alone until <see cref="ConnectorBackgroundService{TConfig}.UnconfiguredRecheckInterval"/>
+    /// rather than having its absent row read on every tick.
     /// </summary>
     [Fact]
     public async Task SyncAllTenants_ForAnUnconfiguredTenant_ReadsConfigOnceUntilTheRecheckInterval()
@@ -1075,8 +1075,8 @@ public class ConnectorBackgroundServiceTests
     }
 
     /// <summary>
-    /// A configured tenant inside its interval used to cost a scope and a config read every tick just
-    /// to learn it was not due; now the tick skips it until the interval has elapsed.
+    /// A configured tenant inside its interval is skipped until the interval has elapsed; the tick
+    /// does not read its configuration to learn it is not due.
     /// </summary>
     [Fact]
     public async Task SyncAllTenants_ForAConfiguredTenantInsideItsInterval_DoesNotReadConfig()

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -41,6 +41,7 @@ public class ConnectorBackgroundServiceTests
         private readonly Action<IServiceProvider>? _onSyncScope;
         private readonly Action? _onSyncCompleted;
         private readonly TimeSpan? _perTenantTimeout;
+        private readonly TimeSpan? _unconfiguredRecheck;
         private readonly int _hangFirstNCalls;
         private int _callCount;
 
@@ -53,8 +54,10 @@ public class ConnectorBackgroundServiceTests
             TimeSpan? perTenantTimeout = null,
             int hangFirstNCalls = 0,
             Action? onSyncCompleted = null,
-            ConnectorSyncBudget? budget = null)
-            : base(serviceProvider, budget ?? new ConnectorSyncBudget(), logger)
+            ConnectorSyncBudget? budget = null,
+            ConnectorPollerNudge? nudge = null,
+            TimeSpan? unconfiguredRecheck = null)
+            : base(serviceProvider, budget ?? new ConnectorSyncBudget(), logger, nudge)
         {
             _syncResult = syncResult;
             _onSync = onSync;
@@ -62,9 +65,12 @@ public class ConnectorBackgroundServiceTests
             _perTenantTimeout = perTenantTimeout;
             _hangFirstNCalls = hangFirstNCalls;
             _onSyncCompleted = onSyncCompleted;
+            _unconfiguredRecheck = unconfiguredRecheck;
         }
 
         protected override TimeSpan PerTenantSyncTimeout => _perTenantTimeout ?? base.PerTenantSyncTimeout;
+
+        protected override TimeSpan UnconfiguredRecheckInterval => _unconfiguredRecheck ?? base.UnconfiguredRecheckInterval;
 
         /// <summary>Number of times PerformSyncAsync has been entered (across all tenants).</summary>
         public int CallCount => _callCount;
@@ -1019,6 +1025,109 @@ public class ConnectorBackgroundServiceTests
         // Sync count should remain at 2 because the nudge was debounced
         // and the 60-minute interval hasn't elapsed
         Assert.Equal(2, syncCount);
+    }
+
+    /// <summary>
+    /// Almost every tenant has no configuration for almost every connector, and each poller used to
+    /// open a DI scope and read that absent row for all of them every minute. A tenant found
+    /// unconfigured is left alone until <see cref="ConnectorBackgroundService{TConfig}.UnconfiguredRecheckInterval"/>.
+    /// </summary>
+    [Fact]
+    public async Task SyncAllTenants_ForAnUnconfiguredTenant_ReadsConfigOnceUntilTheRecheckInterval()
+    {
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+        var configLoads = 0;
+        var serviceProvider = BuildServiceProvider(
+            connStr, BuildEnabledConfigMock(), new TestConnectorConfig { Enabled = false },
+            onConfigLoad: () => Interlocked.Increment(ref configLoads));
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider, new SyncResult { Success = true }, NullLogger<TestConnectorBackgroundService>.Instance,
+            unconfiguredRecheck: TimeSpan.FromHours(1));
+
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+
+        configLoads.Should().Be(1, "an unconfigured tenant is not asked again inside the recheck interval");
+        sut.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SyncAllTenants_ForAnUnconfiguredTenant_ReadsConfigAgainOnceTheRecheckIntervalHasPassed()
+    {
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+        var configLoads = 0;
+        var serviceProvider = BuildServiceProvider(
+            connStr, BuildEnabledConfigMock(), new TestConnectorConfig { Enabled = false },
+            onConfigLoad: () => Interlocked.Increment(ref configLoads));
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider, new SyncResult { Success = true }, NullLogger<TestConnectorBackgroundService>.Instance,
+            unconfiguredRecheck: TimeSpan.Zero);
+
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+
+        configLoads.Should().Be(2);
+    }
+
+    /// <summary>
+    /// A configured tenant inside its interval used to cost a scope and a config read every tick just
+    /// to learn it was not due; now the tick skips it until the interval has elapsed.
+    /// </summary>
+    [Fact]
+    public async Task SyncAllTenants_ForAConfiguredTenantInsideItsInterval_DoesNotReadConfig()
+    {
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+        var configLoads = 0;
+        var serviceProvider = BuildServiceProvider(
+            connStr, BuildEnabledConfigMock(), new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 60 },
+            onConfigLoad: () => Interlocked.Increment(ref configLoads));
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider, new SyncResult { Success = true }, NullLogger<TestConnectorBackgroundService>.Instance);
+
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+
+        sut.CallCount.Should().Be(1);
+        configLoads.Should().Be(1, "the interval is known from the first read; the next reads wait for it to elapse");
+    }
+
+    /// <summary>
+    /// The schedule must never hide a configuration the tenant just saved: the configuration
+    /// service's cache-invalidation hook reaches the poller through <see cref="ConnectorPollerNudge"/>
+    /// and clears the tenant's next-check, so the next tick reads and syncs.
+    /// </summary>
+    [Fact]
+    public async Task SyncAllTenants_AfterAConfigurationWriteNudge_ReadsTheUnconfiguredTenantAgain()
+    {
+        var (cleanup, connStr, tenantId) = CreateSqliteDbWithTenantId();
+        using var _ = cleanup;
+        var configLoads = 0;
+        var serviceProvider = BuildServiceProvider(
+            connStr, BuildEnabledConfigMock(), new TestConnectorConfig { Enabled = false },
+            onConfigLoad: () => Interlocked.Increment(ref configLoads));
+        var nudge = new ConnectorPollerNudge();
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider, new SyncResult { Success = true }, NullLogger<TestConnectorBackgroundService>.Instance,
+            nudge: nudge, unconfiguredRecheck: TimeSpan.FromHours(1));
+
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        configLoads.Should().Be(1);
+
+        // The configuration service names the connector as its row does, lower-case.
+        nudge.Invalidate("testconnector", tenantId);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+
+        configLoads.Should().Be(2, "a configuration write must be seen on the next tick, not after the recheck interval");
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorPollerNudgeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorPollerNudgeTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Services.BackgroundServices;
+
+namespace Nocturne.API.Tests.Services.BackgroundServices;
+
+public class ConnectorPollerNudgeTests
+{
+    [Fact]
+    public void Invalidate_ReachesEverySubscriberOfThatConnector_CaseInsensitively()
+    {
+        var nudge = new ConnectorPollerNudge();
+        var tenant = Guid.CreateVersion7();
+        var seen = new List<(string Poller, Guid Tenant)>();
+        nudge.Subscribe("Glooko", id => seen.Add(("glooko-a", id)));
+        nudge.Subscribe("Glooko", id => seen.Add(("glooko-b", id)));
+        nudge.Subscribe("Dexcom", id => seen.Add(("dexcom", id)));
+
+        nudge.Invalidate("glooko", tenant);
+
+        seen.Should().BeEquivalentTo([("glooko-a", tenant), ("glooko-b", tenant)]);
+    }
+
+    [Fact]
+    public void Invalidate_ForAConnectorNobodyPolls_IsANoOp()
+    {
+        var nudge = new ConnectorPollerNudge();
+
+        var act = () => nudge.Invalidate("nobody", Guid.CreateVersion7());
+
+        act.Should().NotThrow();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorConfigurationInvalidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorConfigurationInvalidationTests.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Services.Connectors;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Every write to a connector's stored configuration must reach the tenant-keyed caches: the auth
+/// token caches so the next sync uses the new credentials, and the pollers' schedules so a connector
+/// the tenant just saved, enabled or removed is looked at on the next tick rather than after its
+/// recheck interval. Saving secrets and toggling active are writes too, not only the full save.
+/// </summary>
+public class ConnectorConfigurationInvalidationTests : IDisposable
+{
+    private const string ConnectorName = "Glooko";
+
+    private readonly SqliteTestDatabase _db;
+    private readonly NocturneDbContext _dbContext;
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly List<(string Connector, Guid Tenant)> _invalidated = [];
+    private readonly ConnectorConfigurationService _service;
+
+    public ConnectorConfigurationInvalidationTests()
+    {
+        _db = TestDbContextFactory.CreateSqlite();
+        _dbContext = _db.CreateContext(_tenantId);
+        _dbContext.Tenants.Add(new TenantEntity
+        {
+            Id = _tenantId,
+            Slug = "tenant",
+            DisplayName = "Tenant",
+            IsActive = true,
+        });
+        _dbContext.SaveChanges();
+
+        var encryption = new Mock<ISecretEncryptionService>();
+        encryption.Setup(e => e.IsConfigured).Returns(true);
+        encryption
+            .Setup(e => e.EncryptSecrets(It.IsAny<Dictionary<string, string>>()))
+            .Returns<Dictionary<string, string>>(d => d);
+
+        _service = new ConnectorConfigurationService(
+            _dbContext,
+            encryption.Object,
+            Mock.Of<ISignalRBroadcastService>(),
+            Mock.Of<IAuditContext>(),
+            new ConfigurationBuilder().Build(),
+            Mock.Of<IHostEnvironment>(),
+            [new RecordingInvalidator(_invalidated)],
+            NullLogger<ConnectorConfigurationService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task SaveConfigurationAsync_InvalidatesForTheTenant()
+    {
+        await _service.SaveConfigurationAsync(ConnectorName, JsonDocument.Parse("{\"enabled\":true}"));
+
+        _invalidated.Should().ContainSingle().Which.Should().Be((ConnectorName, _tenantId));
+    }
+
+    [Fact]
+    public async Task SaveSecretsAsync_InvalidatesForTheTenant()
+    {
+        await _service.SaveSecretsAsync(ConnectorName, new Dictionary<string, string> { ["password"] = "x" });
+
+        _invalidated.Should().ContainSingle().Which.Should().Be((ConnectorName, _tenantId));
+    }
+
+    [Fact]
+    public async Task SetActiveAsync_InvalidatesForTheTenant()
+    {
+        await _service.SetActiveAsync(ConnectorName, isActive: true);
+
+        _invalidated.Should().ContainSingle().Which.Should().Be((ConnectorName, _tenantId));
+    }
+
+    [Fact]
+    public async Task DeleteConfigurationAsync_InvalidatesOnlyWhenARowWasDeleted()
+    {
+        (await _service.DeleteConfigurationAsync(ConnectorName)).Should().BeFalse();
+        _invalidated.Should().BeEmpty();
+
+        await _service.SetActiveAsync(ConnectorName, isActive: true);
+        _invalidated.Clear();
+
+        (await _service.DeleteConfigurationAsync(ConnectorName)).Should().BeTrue();
+        _invalidated.Should().ContainSingle().Which.Should().Be((ConnectorName, _tenantId));
+    }
+
+    private sealed class RecordingInvalidator(List<(string Connector, Guid Tenant)> sink) : IConnectorCacheInvalidator
+    {
+        public void Invalidate(string connectorName, Guid tenantId) => sink.Add((connectorName, tenantId));
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationLoaderTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationLoaderTests.cs
@@ -50,7 +50,7 @@ public class ConnectorConfigurationLoaderTests
             "a connector with no per-tenant config row must not run, even though the defaults set Enabled = true");
         configService.Verify(
             s => s.GetSecretsAsync(ConnectorName, It.IsAny<CancellationToken>()), Times.Never,
-            "the secrets live on the row that does not exist; every poller asked this for every unconfigured tenant every tick");
+            "the secrets live on the row that does not exist");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationLoaderTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationLoaderTests.cs
@@ -48,6 +48,9 @@ public class ConnectorConfigurationLoaderTests
 
         config.Enabled.Should().BeFalse(
             "a connector with no per-tenant config row must not run, even though the defaults set Enabled = true");
+        configService.Verify(
+            s => s.GetSecretsAsync(ConnectorName, It.IsAny<CancellationToken>()), Times.Never,
+            "the secrets live on the row that does not exist; every poller asked this for every unconfigured tenant every tick");
     }
 
     [Fact]


### PR DESCRIPTION
Second slice of #1278; closes #1144.

## What changed

Every connector poller (13 of them) fanned out over every active tenant every minute, and for each one opened a DI scope, took a budget slot and read the tenant's configuration row before learning that the tenant has no configuration for that connector, or that its interval had not elapsed. The loader read the row twice: once for the configuration and once more for the secrets, even when the first read found no row. On the hosted instance that was ~8,700 `connector_configurations` queries per five minutes with two ceremony statements each, about 18 % of all statements, for tenants that almost all had nothing to sync (#1278).

- **`ConnectorBackgroundService` keeps a per-tenant next-check.** A tenant found unconfigured (no row, disabled, or missing required configuration) is not looked at again for `UnconfiguredRecheckInterval` (5 minutes); a configured tenant is not looked at again until its `SyncIntervalMinutes` has elapsed. A tenant that is not due takes no budget slot, opens no scope and reads nothing that tick. The tenant list itself is still read once per poller per tick. `RequestImmediateSync` clears the tenant's next-check before its debounce guard, so a tenant whose enable flow writes configuration, secrets and the active flag within ten seconds is looked at after the last write, not only the first.
- **`ConnectorPollerNudge`**, a singleton implementing the `IConnectorCacheInvalidator` hook the configuration service already calls on save: every scheduled poller, including the two hand-written ones (Nightscout, NocturneRemote), forwards it to the base and subscribes under its connector name, so a configuration write for a tenant clears that tenant's next-check and the next tick reads and syncs it. Enabling a connector therefore syncs within one tick on the instance that took the write. The nudge is in-process.
- **`ConnectorConfigurationService`** invalidates on every write, not only `SaveConfigurationAsync`: saving secrets, toggling active and deleting the row reach the token caches and the pollers. Saving secrets without invalidating the token cache was a latent gap in its own right (a rotated password left a cached session in use).
- **`ConnectorConfigurationLoader`** stops after the configuration read when there is no row; the secrets live on the same row.

#1144 had rejected an in-memory next-due cache because it "cannot skip unconfigured tenants"; this one remembers their absence for the recheck interval, which is what removes the objection. With #1144's numbers (66 tenants × 13 pollers, 100 configured rows) the configuration reads fall from ~858 per minute to ~150 per 5 minutes for the unconfigured pairs plus one per due sync, roughly a 9× cut; the recheck of unconfigured pairs is the larger remaining term, not the due syncs.

Behavioural deltas, declared:
- On an instance the configuration write did not reach (multi-instance deployments only), an enabled connector waits up to 5 minutes instead of 1, and a lowered `SyncIntervalMinutes` takes effect after the old interval (at most 60 minutes) rather than the next tick.
- A tenant whose configuration read failed in a way the loader swallows (it logs and returns defaults, which then fail the required-property check) is treated as unconfigured for the recheck interval rather than retried next tick. A load that throws is still retried next tick.
- A deactivated tenant keeps its next-check; on reactivation it is looked at when that expires, which for an unconfigured pair is within 5 minutes.
- Dev-only code that inserts configuration rows directly (`DevAdminController`) bypasses the invalidation and waits for the recheck.

## Tests

- `ConnectorBackgroundServiceTests`: an unconfigured tenant is read once across three ticks with a one-hour recheck and once per tick with a zero recheck; a configured tenant inside a 60-minute interval is read once across three ticks and synced once; a nudge through `ConnectorPollerNudge` for the unconfigured tenant makes the next tick read it again.
- `ConnectorPollingRegistrationTests.EveryScheduledPoller_SubscribesToTheNudge`: every scheduled poller type, hand-written ones included, is built the way the host builds it and the nudge reports a subscriber under its connector name.
- `ConnectorPollerNudgeTests`: every subscriber of the connector is reached, case-insensitively; an unknown connector is a no-op.
- `ConnectorConfigurationInvalidationTests` (SQLite): save, save-secrets, set-active and delete each invalidate for the tenant; a delete that removed nothing invalidates nothing.
- `ConnectorConfigurationLoaderTests`: no row means the secrets are never queried.

Connectors.Core (203) and API (6,708) unit suites pass locally. The hostile review of the first revision found the two hand-written pollers not forwarding the nudge and the debounce swallowing the enable flow's last write; both fixed in the second commit with the registration test above.

