### PR TITLE
perf(v1): probe stored entries once per upload batch, and log a re-upload loop

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -623,6 +623,12 @@ public class EntriesController : ControllerBase
             cancellationToken
         );
 
+        if (duplicates.Count != processedArray.Length)
+        {
+            throw new InvalidOperationException(
+                $"Duplicate check returned {duplicates.Count} results for {processedArray.Length} entries");
+        }
+
         var uniqueEntries = new List<Entry>();
         var responseEntries = new List<Entry>(processedArray.Length);
 
@@ -671,16 +677,14 @@ public class EntriesController : ControllerBase
         if (duplicates < submitted * ReuploadLoopDuplicateRatio)
             return;
 
-        var userAgent = Request?.Headers.UserAgent.ToString() ?? string.Empty;
-        if (userAgent.Length > MaxLoggedUserAgentLength)
-            userAgent = userAgent[..MaxLoggedUserAgentLength];
+        var userAgent = SanitizeForLog(Request?.Headers.UserAgent.ToString());
 
         _logger.LogInformation(
             "Entries upload of {Submitted} entries was already stored ({Duplicates} duplicates); "
                 + "client {UserAgent} is re-sending stored readings",
             submitted,
             duplicates,
-            userAgent.Length == 0 ? "(no User-Agent)" : userAgent
+            userAgent
         );
     }
 
@@ -692,6 +696,26 @@ public class EntriesController : ControllerBase
 
     /// <summary>Cap on the logged User-Agent, which is attacker-controlled free text.</summary>
     private const int MaxLoggedUserAgentLength = 200;
+
+    /// <summary>
+    /// Renders a caller-supplied header safe to log: the only log sink is a line-oriented console
+    /// exporter, so an unescaped control character in a header value forges log lines.
+    /// </summary>
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return "(none)";
+
+        var capped = value.Length > MaxLoggedUserAgentLength
+            ? value[..MaxLoggedUserAgentLength]
+            : value;
+
+        return string.Create(capped.Length, capped, static (span, source) =>
+        {
+            for (var i = 0; i < source.Length; i++)
+                span[i] = char.IsControl(source[i]) ? ' ' : source[i];
+        });
+    }
 
     /// <summary>
     /// Parses the loosely-typed entries request body (JsonElement, a single Entry, an Entry[]/

--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -698,8 +699,9 @@ public class EntriesController : ControllerBase
     private const int MaxLoggedUserAgentLength = 200;
 
     /// <summary>
-    /// Renders a caller-supplied header safe to log: the only log sink is a line-oriented console
-    /// exporter, so an unescaped control character in a header value forges log lines.
+    /// Renders a caller-supplied header safe to log. Logs reach a line-oriented console exporter
+    /// and are shipped verbatim over OTLP, so a control, format or line-separator character in a
+    /// header value forges log lines or spoofs how they read.
     /// </summary>
     private static string SanitizeForLog(string? value)
     {
@@ -713,9 +715,19 @@ public class EntriesController : ControllerBase
         return string.Create(capped.Length, capped, static (span, source) =>
         {
             for (var i = 0; i < source.Length; i++)
-                span[i] = char.IsControl(source[i]) ? ' ' : source[i];
+                span[i] = IsUnsafeForLog(source[i]) ? ' ' : source[i];
         });
     }
+
+    /// <summary>
+    /// Control characters (which include ESC, so ANSI sequences are covered), Unicode format
+    /// characters such as the right-to-left override, and the line and paragraph separators.
+    /// </summary>
+    private static bool IsUnsafeForLog(char value) =>
+        char.IsControl(value)
+        || char.GetUnicodeCategory(value) is UnicodeCategory.Format
+            or UnicodeCategory.LineSeparator
+            or UnicodeCategory.ParagraphSeparator;
 
     /// <summary>
     /// Parses the loosely-typed entries request body (JsonElement, a single Entry, an Entry[]/

--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -12,6 +12,7 @@ using Nocturne.Core.Contracts.Legacy;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Extensions;
+using Nocturne.Core.Contracts.Entries;
 
 namespace Nocturne.API.Controllers.V1;
 
@@ -558,40 +559,9 @@ public class EntriesController : ControllerBase
             // submitted entry, and treat a shorter array as a failed upload — the
             // batch is then retried forever and the client never uploads anything
             // newer. Legacy cgm-remote-monitor echoed dedup hits back with their _id.
-            var uniqueEntries = new List<Entry>();
-            var responseEntries = new List<Entry>();
-            foreach (var entry in processedArray)
-            {
-                var duplicate = await _entryService.CheckForDuplicateEntryAsync(
-                    entry.Device,
-                    entry.Type ?? "sgv",
-                    entry.Sgv,
-                    entry.Mills,
-                    windowMinutes: 5,
-                    cancellationToken
-                );
-
-                if (duplicate != null)
-                {
-                    _logger.LogDebug(
-                        "Skipping duplicate entry: device={Device}, type={Type}, sgv={Sgv}, mills={Mills}",
-                        entry.Device,
-                        entry.Type,
-                        entry.Sgv,
-                        entry.Mills
-                    );
-                    responseEntries.Add(duplicate);
-                    continue;
-                }
-
-                uniqueEntries.Add(entry);
-                responseEntries.Add(entry);
-            }
-
-            _logger.LogDebug(
-                "Filtered {Original} entries to {Unique} unique entries",
-                processedArray.Length,
-                uniqueEntries.Count
+            var (uniqueEntries, responseEntries) = await PartitionStoredEntriesAsync(
+                processedArray,
+                cancellationToken
             );
 
             // Create entries in database
@@ -622,6 +592,106 @@ public class EntriesController : ControllerBase
             );
         }
     }
+
+    /// <summary>
+    /// Splits a processed upload batch into the entries to write and the entries to echo, using
+    /// one duplicate query per entry type for the whole batch instead of one per entry.
+    /// </summary>
+    /// <remarks>
+    /// The echo list carries the stored entry for every duplicate and the submitted entry
+    /// otherwise, so it always has one element per submitted entry — the response shape v1
+    /// uploaders require. Callers that do not echo (the async endpoint) discard it.
+    /// </remarks>
+    private async Task<(List<Entry> Unique, List<Entry> Response)> PartitionStoredEntriesAsync(
+        Entry[] processedArray,
+        CancellationToken cancellationToken
+    )
+    {
+        var probes = Array.ConvertAll(
+            processedArray,
+            entry => new EntryDuplicateProbe(
+                entry.Device,
+                entry.Type ?? "sgv",
+                entry.Sgv,
+                entry.Mills
+            )
+        );
+
+        var duplicates = await _entryService.CheckForDuplicateEntriesAsync(
+            probes,
+            windowMinutes: 5,
+            cancellationToken
+        );
+
+        var uniqueEntries = new List<Entry>();
+        var responseEntries = new List<Entry>(processedArray.Length);
+
+        for (var i = 0; i < processedArray.Length; i++)
+        {
+            var entry = processedArray[i];
+            var duplicate = duplicates[i];
+
+            if (duplicate != null)
+            {
+                _logger.LogDebug(
+                    "Skipping duplicate entry: device={Device}, type={Type}, sgv={Sgv}, mills={Mills}",
+                    entry.Device,
+                    entry.Type,
+                    entry.Sgv,
+                    entry.Mills
+                );
+                responseEntries.Add(duplicate);
+                continue;
+            }
+
+            uniqueEntries.Add(entry);
+            responseEntries.Add(entry);
+        }
+
+        _logger.LogDebug(
+            "Filtered {Original} entries to {Unique} unique entries",
+            processedArray.Length,
+            uniqueEntries.Count
+        );
+
+        LogReuploadLoop(processedArray.Length, processedArray.Length - uniqueEntries.Count);
+
+        return (uniqueEntries, responseEntries);
+    }
+
+    /// <summary>
+    /// Records one line when a large upload is almost entirely already stored, which is what a
+    /// client re-sending its backlog every cycle looks like from the server. Names the uploader
+    /// (User-Agent) and the counts only — no entry values.
+    /// </summary>
+    private void LogReuploadLoop(int submitted, int duplicates)
+    {
+        if (submitted < ReuploadLoopMinimumBatch)
+            return;
+        if (duplicates < submitted * ReuploadLoopDuplicateRatio)
+            return;
+
+        var userAgent = Request?.Headers.UserAgent.ToString() ?? string.Empty;
+        if (userAgent.Length > MaxLoggedUserAgentLength)
+            userAgent = userAgent[..MaxLoggedUserAgentLength];
+
+        _logger.LogInformation(
+            "Entries upload of {Submitted} entries was already stored ({Duplicates} duplicates); "
+                + "client {UserAgent} is re-sending stored readings",
+            submitted,
+            duplicates,
+            userAgent.Length == 0 ? "(no User-Agent)" : userAgent
+        );
+    }
+
+    /// <summary>Smallest upload that can be reported as a re-upload loop.</summary>
+    private const int ReuploadLoopMinimumBatch = 100;
+
+    /// <summary>Share of an upload that must already be stored to report a re-upload loop.</summary>
+    private const double ReuploadLoopDuplicateRatio = 0.95;
+
+    /// <summary>Cap on the logged User-Agent, which is attacker-controlled free text.</summary>
+    private const int MaxLoggedUserAgentLength = 200;
 
     /// <summary>
     /// Parses the loosely-typed entries request body (JsonElement, a single Entry, an Entry[]/
@@ -1054,37 +1124,9 @@ public class EntriesController : ControllerBase
             var processedArray = processedEntries.ToArray();
 
             // Filter out duplicates using database-backed detection
-            var uniqueEntries = new List<Entry>();
-            foreach (var entry in processedArray)
-            {
-                var duplicate = await _entryService.CheckForDuplicateEntryAsync(
-                    entry.Device,
-                    entry.Type ?? "sgv",
-                    entry.Sgv,
-                    entry.Mills,
-                    windowMinutes: 5,
-                    cancellationToken
-                );
-
-                if (duplicate != null)
-                {
-                    _logger.LogDebug(
-                        "Skipping duplicate entry: device={Device}, type={Type}, sgv={Sgv}, mills={Mills}",
-                        entry.Device,
-                        entry.Type,
-                        entry.Sgv,
-                        entry.Mills
-                    );
-                    continue;
-                }
-
-                uniqueEntries.Add(entry);
-            }
-
-            _logger.LogDebug(
-                "Filtered {Original} entries to {Unique} unique entries",
-                processedArray.Length,
-                uniqueEntries.Count
+            var (uniqueEntries, _) = await PartitionStoredEntriesAsync(
+                processedArray,
+                cancellationToken
             );
 
             // Create entries in database synchronously

--- a/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
+++ b/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Projections;
 using Nocturne.Core.Models.Queries;
+using Nocturne.Core.Models.V4;
 namespace Nocturne.API.Services.Entries;
 
 /// <summary>
@@ -55,16 +56,21 @@ public class EntryReadService : IEntryStore
     private const int MaxFilterFetch = 100_000;
 
     /// <summary>
-    /// Widest time span one batch duplicate query may cover, and so the bound on the stored
-    /// readings it pulls into memory: seven days of one tenant's ingest.
+    /// Widest time span one batch duplicate query may cover, whatever the batch asks for.
     /// </summary>
     private static readonly TimeSpan MaxProbeChunkSpan = TimeSpan.FromDays(7);
 
     /// <summary>
-    /// Time span each entry in a batch earns towards its chunk. It stops a two-entry batch a week
-    /// apart from reading a week of readings: a chunk only widens when enough entries share it.
+    /// Time span each entry in a chunk earns towards that chunk's span. It stops a sparse batch
+    /// from buying a wide query: two entries a week apart get a query each, not a week-wide read.
     /// </summary>
     private static readonly TimeSpan ProbeChunkSpanPerEntry = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Entries per chunk, so rows-per-query has a ceiling that does not depend on how densely the
+    /// tenant's stored readings happen to fill the chunk's span.
+    /// </summary>
+    private const int MaxProbeChunkEntries = 500;
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<Entry>> QueryAsync(EntryQuery query, CancellationToken ct = default)
@@ -188,31 +194,42 @@ public class EntryReadService : IEntryStore
     {
         var results = new Entry?[probes.Count];
         var windowMs = (long)windowMinutes * 60 * 1000;
+        var sgvProbes = new List<(EntryDuplicateProbe probe, int index)>();
 
-        foreach (var group in probes
-            .Select((probe, index) => (probe, index))
-            .GroupBy(x => x.probe.Type, StringComparer.Ordinal))
+        for (var i = 0; i < probes.Count; i++)
         {
-            // Unknown types are never duplicates (CheckDuplicateAsync's default arm) and cost no query.
-            if (group.Key is not ("sgv" or "mbg" or "cal"))
+            var probe = probes[i];
+            if (string.Equals(probe.Type, "sgv", StringComparison.Ordinal))
+            {
+                sgvProbes.Add((probe, i));
                 continue;
+            }
 
-            foreach (var chunk in ChunkByTimeSpan(group))
-                await ClassifyChunkAsync(group.Key, chunk, windowMs, results, ct);
+            // Only sgv arrives in the thousands-per-cycle uploads this batching exists for. mbg and
+            // cal keep the per-entry probe: theirs reads a device-filtered page of the entry's own
+            // window, and a batch-wide read is a strict superset of that — it reports duplicates
+            // the per-entry probe does not, dropping a reading that would have been stored.
+            // Unknown types return null here without a query, as they always did.
+            results[i] = await CheckDuplicateAsync(
+                probe.Device, probe.Type, probe.Sgv, probe.Mills, windowMinutes, ct);
         }
+
+        foreach (var chunk in ChunkByTimeSpan(sgvProbes))
+            await ClassifySgvChunkAsync(chunk, windowMs, results, ct);
 
         return results;
     }
 
     /// <summary>
-    /// Splits one type's probes into time-contiguous chunks, each of which becomes a single query.
+    /// Splits the sgv probes into time-contiguous chunks, each of which becomes a single query.
     /// A chunk widens only while its entries pay for the span (<see cref="ProbeChunkSpanPerEntry"/>
-    /// each, never past <see cref="MaxProbeChunkSpan"/>), so the rows a chunk reads stay
-    /// proportional to the entries it classifies. In the worst case there is one chunk per probe —
-    /// the per-entry probing this replaces — and for an ordinary CGM backlog there is exactly one.
+    /// each, never past <see cref="MaxProbeChunkSpan"/>) and holds at most
+    /// <see cref="MaxProbeChunkEntries"/> of them, so the rows one query reads stay tied to the
+    /// entries it classifies. An ordinary CGM backlog is one chunk; the worst case is one chunk per
+    /// probe, which is the per-entry probing this replaces.
     /// </summary>
     private static List<List<(EntryDuplicateProbe probe, int index)>> ChunkByTimeSpan(
-        IEnumerable<(EntryDuplicateProbe probe, int index)> items)
+        List<(EntryDuplicateProbe probe, int index)> items)
     {
         var chunks = new List<List<(EntryDuplicateProbe probe, int index)>>();
         var current = new List<(EntryDuplicateProbe probe, int index)>();
@@ -220,24 +237,14 @@ public class EntryReadService : IEntryStore
 
         foreach (var item in items.OrderBy(x => x.probe.Mills))
         {
-            if (current.Count == 0)
+            if (current.Count > 0 && !FitsInChunk(item.probe.Mills - chunkStart, current.Count))
             {
-                chunkStart = item.probe.Mills;
+                chunks.Add(current);
+                current = [];
             }
-            else
-            {
-                var span = TimeSpan.FromMilliseconds(item.probe.Mills - chunkStart);
-                var budget = ProbeChunkSpanPerEntry * current.Count;
-                if (budget > MaxProbeChunkSpan)
-                    budget = MaxProbeChunkSpan;
 
-                if (span > budget)
-                {
-                    chunks.Add(current);
-                    current = [];
-                    chunkStart = item.probe.Mills;
-                }
-            }
+            if (current.Count == 0)
+                chunkStart = item.probe.Mills;
 
             current.Add(item);
         }
@@ -246,6 +253,24 @@ public class EntryReadService : IEntryStore
             chunks.Add(current);
 
         return chunks;
+    }
+
+    /// <summary>
+    /// Whether an entry <paramref name="spanMs"/> past the chunk's first entry still belongs to it.
+    /// The span comparison is strict, so entries spaced exactly
+    /// <see cref="ProbeChunkSpanPerEntry"/> apart split rather than each one paying for the next
+    /// and walking the budget upwards without bound.
+    /// </summary>
+    private static bool FitsInChunk(long spanMs, int chunkCount)
+    {
+        if (chunkCount >= MaxProbeChunkEntries)
+            return false;
+
+        var budget = ProbeChunkSpanPerEntry * chunkCount;
+        if (budget > MaxProbeChunkSpan)
+            budget = MaxProbeChunkSpan;
+
+        return TimeSpan.FromMilliseconds(spanMs) < budget;
     }
 
     /// <inheritdoc />
@@ -456,8 +481,7 @@ public class EntryReadService : IEntryStore
     /// Loads one chunk's stored readings in a single query and classifies every probe in it.
     /// <paramref name="chunk"/> is ordered by timestamp, so its ends give the query's window.
     /// </summary>
-    private async Task ClassifyChunkAsync(
-        string type,
+    private async Task ClassifySgvChunkAsync(
         List<(EntryDuplicateProbe probe, int index)> chunk,
         long windowMs,
         Entry?[] results,
@@ -466,90 +490,65 @@ public class EntryReadService : IEntryStore
         var from = MillsToUtc(chunk[0].probe.Mills - windowMs);
         var to = MillsToUtc(chunk[^1].probe.Mills + windowMs);
 
-        switch (type)
-        {
-            case "sgv":
-            {
-                var candidates = await _sgRepo.FindStoredDuplicateCandidatesAsync(
-                    ResolveProbeDevices(chunk), from, to, ct);
-                Classify(chunk, candidates, windowMs, results,
-                    c => c.Timestamp, c => c.Device, c => c.Mgdl, EntryProjection.FromSensorGlucose);
-                return;
-            }
-            case "mbg":
-            {
-                // Unpaged, and across every device: a probe without a device matches a reading
-                // from any device, and the chunk's span is what keeps the row count bounded.
-                var candidates = (await _mgRepo.GetAsync(
-                    from, to, device: null, source: null, limit: int.MaxValue, offset: 0,
-                    descending: true, ct: ct)).ToList();
-                Classify(chunk, candidates, windowMs, results,
-                    c => c.Timestamp, c => c.Device, c => c.Mgdl, EntryProjection.FromMeterGlucose);
-                return;
-            }
-            default:
-            {
-                var candidates = (await _calRepo.GetAsync(
-                    from, to, device: null, source: null, limit: int.MaxValue, offset: 0,
-                    descending: true, ct: ct)).ToList();
-                // Calibrations carry no comparable value: the single-entry probe matches on
-                // device and window alone, so no value selector is supplied.
-                Classify(chunk, candidates, windowMs, results,
-                    c => c.Timestamp, c => c.Device, valueOf: null, EntryProjection.FromCalibration);
-                return;
-            }
-        }
-    }
+        var candidates = await _sgRepo.FindStoredDuplicateCandidatesAsync(
+            ResolveProbeDevices(chunk), from, to, ct);
 
-    private static void Classify<TRecord>(
-        List<(EntryDuplicateProbe probe, int index)> items,
-        IReadOnlyList<TRecord> candidates,
-        long windowMs,
-        Entry?[] results,
-        Func<TRecord, DateTime> timestampOf,
-        Func<TRecord, string?> deviceOf,
-        Func<TRecord, double>? valueOf,
-        Func<TRecord, Entry> project)
-        where TRecord : class
-    {
-        foreach (var (probe, index) in items)
+        foreach (var (probe, index) in chunk)
         {
-            var match = MatchInWindow(candidates, probe, windowMs, timestampOf, deviceOf, valueOf);
-            results[index] = match is null ? null : project(match);
+            ct.ThrowIfCancellationRequested();
+            var match = MatchInWindow(candidates, probe, windowMs);
+            results[index] = match is null ? null : EntryProjection.FromSensorGlucose(match);
         }
     }
 
     /// <summary>
-    /// The single-entry probe's match rule, applied in memory: the first candidate inside the
+    /// The single-entry probe's match rule, applied in memory: the newest candidate inside the
     /// probe's own window whose device and value match. <paramref name="candidates"/> arrive
-    /// newest-first in the order the per-entry query resolved ties by, so the first match is the
-    /// same row it returned.
+    /// newest-first in the order that probe resolved ties by, so the first match is the row it
+    /// returned.
     /// </summary>
-    private static TRecord? MatchInWindow<TRecord>(
-        IReadOnlyList<TRecord> candidates,
-        EntryDuplicateProbe probe,
-        long windowMs,
-        Func<TRecord, DateTime> timestampOf,
-        Func<TRecord, string?> deviceOf,
-        Func<TRecord, double>? valueOf)
-        where TRecord : class
+    private static SensorGlucose? MatchInWindow(
+        IReadOnlyList<SensorGlucose> candidates, EntryDuplicateProbe probe, long windowMs)
     {
         var from = MillsToUtc(probe.Mills - windowMs);
         var to = MillsToUtc(probe.Mills + windowMs);
 
-        foreach (var candidate in candidates)
+        for (var i = NewestAtOrBefore(candidates, to); i < candidates.Count; i++)
         {
-            var timestamp = timestampOf(candidate);
-            if (timestamp < from || timestamp > to)
+            var candidate = candidates[i];
+            if (candidate.Timestamp < from)
+                break;
+            if (probe.Device is not null
+                && !string.Equals(candidate.Device, probe.Device, StringComparison.Ordinal))
                 continue;
-            if (probe.Device is not null && !string.Equals(deviceOf(candidate), probe.Device, StringComparison.Ordinal))
-                continue;
-            if (valueOf is not null && probe.Sgv.HasValue && Math.Abs(valueOf(candidate) - probe.Sgv.Value) >= 0.01)
+            if (probe.Sgv.HasValue && Math.Abs(candidate.Mgdl - probe.Sgv.Value) >= 0.01)
                 continue;
             return candidate;
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Index of the newest candidate at or before <paramref name="to"/>. A chunk's candidate list
+    /// covers every probe's window, so scanning it from the front for each probe is quadratic in
+    /// the batch; the list is sorted newest-first, so the probe's slice is a binary search away.
+    /// </summary>
+    private static int NewestAtOrBefore(IReadOnlyList<SensorGlucose> candidates, DateTime to)
+    {
+        var low = 0;
+        var high = candidates.Count;
+
+        while (low < high)
+        {
+            var mid = low + ((high - low) / 2);
+            if (candidates[mid].Timestamp > to)
+                low = mid + 1;
+            else
+                high = mid;
+        }
+
+        return low;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
+++ b/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
@@ -61,16 +61,22 @@ public class EntryReadService : IEntryStore
     private static readonly TimeSpan MaxProbeChunkSpan = TimeSpan.FromDays(7);
 
     /// <summary>
-    /// Time span each entry in a chunk earns towards that chunk's span. It stops a sparse batch
-    /// from buying a wide query: two entries a week apart get a query each, not a week-wide read.
+    /// Gap between neighbouring entries at which a chunk ends. Measured against the neighbour
+    /// rather than the chunk's start: a budget that grows with the entry count is walked open by
+    /// entries spaced just under it, each paying for the next.
     /// </summary>
-    private static readonly TimeSpan ProbeChunkSpanPerEntry = TimeSpan.FromHours(1);
+    private static readonly TimeSpan MaxProbeChunkGap = TimeSpan.FromHours(1);
+
+    /// <summary>Entries per chunk, bounding the work one query's results are matched against.</summary>
+    private const int MaxProbeChunkEntries = 500;
 
     /// <summary>
-    /// Entries per chunk, so rows-per-query has a ceiling that does not depend on how densely the
-    /// tenant's stored readings happen to fill the chunk's span.
+    /// Rows one chunk may pull into memory. The span and gap limits bound the chunk's *window*, but
+    /// how many stored readings fall inside it is the tenant's ingest density, which no limit on
+    /// the batch can constrain — so above this the chunk falls back to the per-entry probe, which
+    /// reads one row per entry. This is the only bound here that holds whatever the density is.
     /// </summary>
-    private const int MaxProbeChunkEntries = 500;
+    private const int MaxProbeChunkRows = 20_000;
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<Entry>> QueryAsync(EntryQuery query, CancellationToken ct = default)
@@ -193,7 +199,6 @@ public class EntryReadService : IEntryStore
         IReadOnlyList<EntryDuplicateProbe> probes, int windowMinutes = 5, CancellationToken ct = default)
     {
         var results = new Entry?[probes.Count];
-        var windowMs = (long)windowMinutes * 60 * 1000;
         var sgvProbes = new List<(EntryDuplicateProbe probe, int index)>();
 
         for (var i = 0; i < probes.Count; i++)
@@ -215,18 +220,17 @@ public class EntryReadService : IEntryStore
         }
 
         foreach (var chunk in ChunkByTimeSpan(sgvProbes))
-            await ClassifySgvChunkAsync(chunk, windowMs, results, ct);
+            await ClassifySgvChunkAsync(chunk, windowMinutes, results, ct);
 
         return results;
     }
 
     /// <summary>
-    /// Splits the sgv probes into time-contiguous chunks, each of which becomes a single query.
-    /// A chunk widens only while its entries pay for the span (<see cref="ProbeChunkSpanPerEntry"/>
-    /// each, never past <see cref="MaxProbeChunkSpan"/>) and holds at most
-    /// <see cref="MaxProbeChunkEntries"/> of them, so the rows one query reads stay tied to the
-    /// entries it classifies. An ordinary CGM backlog is one chunk; the worst case is one chunk per
-    /// probe, which is the per-entry probing this replaces.
+    /// Splits the sgv probes into time-contiguous chunks, each of which becomes a single query. A
+    /// chunk continues while each entry is within <see cref="MaxProbeChunkGap"/> of its neighbour,
+    /// the chunk's whole span is within <see cref="MaxProbeChunkSpan"/>, and it holds fewer than
+    /// <see cref="MaxProbeChunkEntries"/> entries. An ordinary CGM backlog is one or two chunks;
+    /// the worst case is one chunk per probe, which is the per-entry probing this replaces.
     /// </summary>
     private static List<List<(EntryDuplicateProbe probe, int index)>> ChunkByTimeSpan(
         List<(EntryDuplicateProbe probe, int index)> items)
@@ -234,10 +238,12 @@ public class EntryReadService : IEntryStore
         var chunks = new List<List<(EntryDuplicateProbe probe, int index)>>();
         var current = new List<(EntryDuplicateProbe probe, int index)>();
         var chunkStart = 0L;
+        var previousMills = 0L;
 
         foreach (var item in items.OrderBy(x => x.probe.Mills))
         {
-            if (current.Count > 0 && !FitsInChunk(item.probe.Mills - chunkStart, current.Count))
+            if (current.Count > 0
+                && !FitsInChunk(item.probe.Mills - previousMills, item.probe.Mills - chunkStart, current.Count))
             {
                 chunks.Add(current);
                 current = [];
@@ -246,6 +252,7 @@ public class EntryReadService : IEntryStore
             if (current.Count == 0)
                 chunkStart = item.probe.Mills;
 
+            previousMills = item.probe.Mills;
             current.Add(item);
         }
 
@@ -256,21 +263,19 @@ public class EntryReadService : IEntryStore
     }
 
     /// <summary>
-    /// Whether an entry <paramref name="spanMs"/> past the chunk's first entry still belongs to it.
-    /// The span comparison is strict, so entries spaced exactly
-    /// <see cref="ProbeChunkSpanPerEntry"/> apart split rather than each one paying for the next
-    /// and walking the budget upwards without bound.
+    /// Whether an entry <paramref name="gapMs"/> past its neighbour, and <paramref name="spanMs"/>
+    /// past the chunk's first entry, still belongs to that chunk. The gap is measured against the
+    /// neighbour, not the chunk start: a budget that grows with the entry count can be walked open
+    /// by entries spaced just under it.
     /// </summary>
-    private static bool FitsInChunk(long spanMs, int chunkCount)
+    private static bool FitsInChunk(long gapMs, long spanMs, int chunkCount)
     {
         if (chunkCount >= MaxProbeChunkEntries)
             return false;
+        if (TimeSpan.FromMilliseconds(gapMs) >= MaxProbeChunkGap)
+            return false;
 
-        var budget = ProbeChunkSpanPerEntry * chunkCount;
-        if (budget > MaxProbeChunkSpan)
-            budget = MaxProbeChunkSpan;
-
-        return TimeSpan.FromMilliseconds(spanMs) < budget;
+        return TimeSpan.FromMilliseconds(spanMs) <= MaxProbeChunkSpan;
     }
 
     /// <inheritdoc />
@@ -483,15 +488,33 @@ public class EntryReadService : IEntryStore
     /// </summary>
     private async Task ClassifySgvChunkAsync(
         List<(EntryDuplicateProbe probe, int index)> chunk,
-        long windowMs,
+        int windowMinutes,
         Entry?[] results,
         CancellationToken ct)
     {
+        var windowMs = (long)windowMinutes * 60 * 1000;
         var from = MillsToUtc(chunk[0].probe.Mills - windowMs);
         var to = MillsToUtc(chunk[^1].probe.Mills + windowMs);
 
+        // One row over the cap is enough to know the window held more than this may hold.
         var candidates = await _sgRepo.FindStoredDuplicateCandidatesAsync(
-            ResolveProbeDevices(chunk), from, to, ct);
+            ResolveProbeDevices(chunk), from, to, MaxProbeChunkRows + 1, ct);
+
+        if (candidates.Count > MaxProbeChunkRows)
+        {
+            _logger.LogDebug(
+                "Duplicate candidates for {Count} sgv entries exceed {Cap} rows; probing per entry",
+                chunk.Count, MaxProbeChunkRows);
+
+            foreach (var (probe, index) in chunk)
+            {
+                ct.ThrowIfCancellationRequested();
+                results[index] = await CheckDuplicateAsync(
+                    probe.Device, probe.Type, probe.Sgv, probe.Mills, windowMinutes, ct);
+            }
+
+            return;
+        }
 
         foreach (var (probe, index) in chunk)
         {
@@ -518,6 +541,10 @@ public class EntryReadService : IEntryStore
             var candidate = candidates[i];
             if (candidate.Timestamp < from)
                 break;
+            // The search is a starting point, not the bound: a wrong index here would report a
+            // reading outside the probe's window as a duplicate and drop a real one.
+            if (candidate.Timestamp > to)
+                continue;
             if (probe.Device is not null
                 && !string.Equals(candidate.Device, probe.Device, StringComparison.Ordinal))
                 continue;
@@ -533,6 +560,7 @@ public class EntryReadService : IEntryStore
     /// Index of the newest candidate at or before <paramref name="to"/>. A chunk's candidate list
     /// covers every probe's window, so scanning it from the front for each probe is quadratic in
     /// the batch; the list is sorted newest-first, so the probe's slice is a binary search away.
+    /// The caller re-checks the bound, so this is an optimisation and not a correctness dependency.
     /// </summary>
     private static int NewestAtOrBefore(IReadOnlyList<SensorGlucose> candidates, DateTime to)
     {

--- a/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
+++ b/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
@@ -54,6 +54,18 @@ public class EntryReadService : IEntryStore
     /// </summary>
     private const int MaxFilterFetch = 100_000;
 
+    /// <summary>
+    /// Widest time span one batch duplicate query may cover, and so the bound on the stored
+    /// readings it pulls into memory: seven days of one tenant's ingest.
+    /// </summary>
+    private static readonly TimeSpan MaxProbeChunkSpan = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// Time span each entry in a batch earns towards its chunk. It stops a two-entry batch a week
+    /// apart from reading a week of readings: a chunk only widens when enough entries share it.
+    /// </summary>
+    private static readonly TimeSpan ProbeChunkSpanPerEntry = TimeSpan.FromHours(1);
+
     /// <inheritdoc />
     public async Task<IReadOnlyList<Entry>> QueryAsync(EntryQuery query, CancellationToken ct = default)
     {
@@ -158,8 +170,8 @@ public class EntryReadService : IEntryStore
         int windowMinutes = 5, CancellationToken ct = default)
     {
         var windowMs = (long)windowMinutes * 60 * 1000;
-        var from = DateTimeOffset.FromUnixTimeMilliseconds(mills - windowMs).UtcDateTime;
-        var to = DateTimeOffset.FromUnixTimeMilliseconds(mills + windowMs).UtcDateTime;
+        var from = MillsToUtc(mills - windowMs);
+        var to = MillsToUtc(mills + windowMs);
 
         return type switch
         {
@@ -168,6 +180,72 @@ public class EntryReadService : IEntryStore
             "cal" => await CheckCalDuplicateAsync(device, from, to, ct),
             _ => null,
         };
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Entry?>> CheckDuplicatesAsync(
+        IReadOnlyList<EntryDuplicateProbe> probes, int windowMinutes = 5, CancellationToken ct = default)
+    {
+        var results = new Entry?[probes.Count];
+        var windowMs = (long)windowMinutes * 60 * 1000;
+
+        foreach (var group in probes
+            .Select((probe, index) => (probe, index))
+            .GroupBy(x => x.probe.Type, StringComparer.Ordinal))
+        {
+            // Unknown types are never duplicates (CheckDuplicateAsync's default arm) and cost no query.
+            if (group.Key is not ("sgv" or "mbg" or "cal"))
+                continue;
+
+            foreach (var chunk in ChunkByTimeSpan(group))
+                await ClassifyChunkAsync(group.Key, chunk, windowMs, results, ct);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Splits one type's probes into time-contiguous chunks, each of which becomes a single query.
+    /// A chunk widens only while its entries pay for the span (<see cref="ProbeChunkSpanPerEntry"/>
+    /// each, never past <see cref="MaxProbeChunkSpan"/>), so the rows a chunk reads stay
+    /// proportional to the entries it classifies. In the worst case there is one chunk per probe —
+    /// the per-entry probing this replaces — and for an ordinary CGM backlog there is exactly one.
+    /// </summary>
+    private static List<List<(EntryDuplicateProbe probe, int index)>> ChunkByTimeSpan(
+        IEnumerable<(EntryDuplicateProbe probe, int index)> items)
+    {
+        var chunks = new List<List<(EntryDuplicateProbe probe, int index)>>();
+        var current = new List<(EntryDuplicateProbe probe, int index)>();
+        var chunkStart = 0L;
+
+        foreach (var item in items.OrderBy(x => x.probe.Mills))
+        {
+            if (current.Count == 0)
+            {
+                chunkStart = item.probe.Mills;
+            }
+            else
+            {
+                var span = TimeSpan.FromMilliseconds(item.probe.Mills - chunkStart);
+                var budget = ProbeChunkSpanPerEntry * current.Count;
+                if (budget > MaxProbeChunkSpan)
+                    budget = MaxProbeChunkSpan;
+
+                if (span > budget)
+                {
+                    chunks.Add(current);
+                    current = [];
+                    chunkStart = item.probe.Mills;
+                }
+            }
+
+            current.Add(item);
+        }
+
+        if (current.Count > 0)
+            chunks.Add(current);
+
+        return chunks;
     }
 
     /// <inheritdoc />
@@ -373,6 +451,126 @@ public class EntryReadService : IEntryStore
         var match = results.FirstOrDefault();
         return match is null ? null : EntryProjection.FromCalibration(match);
     }
+
+    /// <summary>
+    /// Loads one chunk's stored readings in a single query and classifies every probe in it.
+    /// <paramref name="chunk"/> is ordered by timestamp, so its ends give the query's window.
+    /// </summary>
+    private async Task ClassifyChunkAsync(
+        string type,
+        List<(EntryDuplicateProbe probe, int index)> chunk,
+        long windowMs,
+        Entry?[] results,
+        CancellationToken ct)
+    {
+        var from = MillsToUtc(chunk[0].probe.Mills - windowMs);
+        var to = MillsToUtc(chunk[^1].probe.Mills + windowMs);
+
+        switch (type)
+        {
+            case "sgv":
+            {
+                var candidates = await _sgRepo.FindStoredDuplicateCandidatesAsync(
+                    ResolveProbeDevices(chunk), from, to, ct);
+                Classify(chunk, candidates, windowMs, results,
+                    c => c.Timestamp, c => c.Device, c => c.Mgdl, EntryProjection.FromSensorGlucose);
+                return;
+            }
+            case "mbg":
+            {
+                // Unpaged, and across every device: a probe without a device matches a reading
+                // from any device, and the chunk's span is what keeps the row count bounded.
+                var candidates = (await _mgRepo.GetAsync(
+                    from, to, device: null, source: null, limit: int.MaxValue, offset: 0,
+                    descending: true, ct: ct)).ToList();
+                Classify(chunk, candidates, windowMs, results,
+                    c => c.Timestamp, c => c.Device, c => c.Mgdl, EntryProjection.FromMeterGlucose);
+                return;
+            }
+            default:
+            {
+                var candidates = (await _calRepo.GetAsync(
+                    from, to, device: null, source: null, limit: int.MaxValue, offset: 0,
+                    descending: true, ct: ct)).ToList();
+                // Calibrations carry no comparable value: the single-entry probe matches on
+                // device and window alone, so no value selector is supplied.
+                Classify(chunk, candidates, windowMs, results,
+                    c => c.Timestamp, c => c.Device, valueOf: null, EntryProjection.FromCalibration);
+                return;
+            }
+        }
+    }
+
+    private static void Classify<TRecord>(
+        List<(EntryDuplicateProbe probe, int index)> items,
+        IReadOnlyList<TRecord> candidates,
+        long windowMs,
+        Entry?[] results,
+        Func<TRecord, DateTime> timestampOf,
+        Func<TRecord, string?> deviceOf,
+        Func<TRecord, double>? valueOf,
+        Func<TRecord, Entry> project)
+        where TRecord : class
+    {
+        foreach (var (probe, index) in items)
+        {
+            var match = MatchInWindow(candidates, probe, windowMs, timestampOf, deviceOf, valueOf);
+            results[index] = match is null ? null : project(match);
+        }
+    }
+
+    /// <summary>
+    /// The single-entry probe's match rule, applied in memory: the first candidate inside the
+    /// probe's own window whose device and value match. <paramref name="candidates"/> arrive
+    /// newest-first in the order the per-entry query resolved ties by, so the first match is the
+    /// same row it returned.
+    /// </summary>
+    private static TRecord? MatchInWindow<TRecord>(
+        IReadOnlyList<TRecord> candidates,
+        EntryDuplicateProbe probe,
+        long windowMs,
+        Func<TRecord, DateTime> timestampOf,
+        Func<TRecord, string?> deviceOf,
+        Func<TRecord, double>? valueOf)
+        where TRecord : class
+    {
+        var from = MillsToUtc(probe.Mills - windowMs);
+        var to = MillsToUtc(probe.Mills + windowMs);
+
+        foreach (var candidate in candidates)
+        {
+            var timestamp = timestampOf(candidate);
+            if (timestamp < from || timestamp > to)
+                continue;
+            if (probe.Device is not null && !string.Equals(deviceOf(candidate), probe.Device, StringComparison.Ordinal))
+                continue;
+            if (valueOf is not null && probe.Sgv.HasValue && Math.Abs(valueOf(candidate) - probe.Sgv.Value) >= 0.01)
+                continue;
+            return candidate;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The device filter for a chunk's fetch: <c>null</c> (every device) when any probe has no
+    /// device, because such a probe matches a stored reading from any device.
+    /// </summary>
+    private static IReadOnlyCollection<string>? ResolveProbeDevices(
+        List<(EntryDuplicateProbe probe, int index)> items)
+    {
+        var devices = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (probe, _) in items)
+        {
+            if (probe.Device is null)
+                return null;
+            devices.Add(probe.Device);
+        }
+        return devices;
+    }
+
+    private static DateTime MillsToUtc(long mills) =>
+        DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime;
 
     #endregion
 

--- a/src/API/Nocturne.API/Services/Glucose/EntryService.cs
+++ b/src/API/Nocturne.API/Services/Glucose/EntryService.cs
@@ -115,6 +115,15 @@ public class EntryService : IEntryService
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyList<Entry?>> CheckForDuplicateEntriesAsync(
+        IReadOnlyList<EntryDuplicateProbe> probes,
+        int windowMinutes = 5,
+        CancellationToken cancellationToken = default)
+    {
+        return await _store.CheckDuplicatesAsync(probes, windowMinutes, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<Entry?> GetCurrentEntryAsync(CancellationToken cancellationToken = default)
     {
         return await _cache.GetOrComputeCurrentAsync(

--- a/src/Core/Nocturne.Core.Contracts/Entries/EntryDuplicateProbe.cs
+++ b/src/Core/Nocturne.Core.Contracts/Entries/EntryDuplicateProbe.cs
@@ -1,0 +1,11 @@
+namespace Nocturne.Core.Contracts.Entries;
+
+/// <summary>
+/// One entry's identity for the upload duplicate check: the fields
+/// <see cref="IEntryStore.CheckDuplicatesAsync"/> matches against stored readings.
+/// </summary>
+/// <param name="Device">Device identifier, or <c>null</c> to match any device.</param>
+/// <param name="Type">Entry type ("sgv", "mbg", "cal"); other types are never duplicates.</param>
+/// <param name="Sgv">Glucose value in mg/dL, or <c>null</c> to match any value.</param>
+/// <param name="Mills">Entry timestamp in Unix milliseconds.</param>
+public readonly record struct EntryDuplicateProbe(string? Device, string Type, double? Sgv, long Mills);

--- a/src/Core/Nocturne.Core.Contracts/Entries/IEntryStore.cs
+++ b/src/Core/Nocturne.Core.Contracts/Entries/IEntryStore.cs
@@ -50,6 +50,23 @@ public interface IEntryStore
         int windowMinutes = 5, CancellationToken ct = default);
 
     /// <summary>
+    /// Checks a whole upload batch for duplicates, returning one result per probe in the order
+    /// given (<c>null</c> where nothing is stored).
+    /// </summary>
+    /// <remarks>
+    /// Classification is identical to <see cref="CheckDuplicateAsync"/> per probe, but the stored
+    /// readings covering the batch's time span are loaded in a query per entry type instead of a
+    /// query per entry: a 1,000-entry upload is one query rather than a thousand, each of which
+    /// carried its own context, connection lease and plan.
+    /// </remarks>
+    /// <param name="probes">The entries to classify, in submission order.</param>
+    /// <param name="windowMinutes">Time window in minutes to check for duplicates. Defaults to 5.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Positionally aligned results: the stored <see cref="Entry"/>, or <c>null</c>.</returns>
+    Task<IReadOnlyList<Entry?>> CheckDuplicatesAsync(
+        IReadOnlyList<EntryDuplicateProbe> probes, int windowMinutes = 5, CancellationToken ct = default);
+
+    /// <summary>
     /// Counts entries matching the optional filter and type.
     /// </summary>
     /// <param name="find">Optional MongoDB-style find query for time-range extraction.</param>

--- a/src/Core/Nocturne.Core.Contracts/Entries/IEntryStore.cs
+++ b/src/Core/Nocturne.Core.Contracts/Entries/IEntryStore.cs
@@ -54,10 +54,11 @@ public interface IEntryStore
     /// given (<c>null</c> where nothing is stored).
     /// </summary>
     /// <remarks>
-    /// Classification is identical to <see cref="CheckDuplicateAsync"/> per probe, but the stored
-    /// readings covering the batch's time span are loaded in a query per entry type instead of a
-    /// query per entry: a 1,000-entry upload is one query rather than a thousand, each of which
-    /// carried its own context, connection lease and plan.
+    /// Classification is identical to <see cref="CheckDuplicateAsync"/> per probe. For <c>sgv</c> —
+    /// the only type that arrives in thousands-per-cycle uploads — the stored readings covering the
+    /// batch are loaded in one query instead of a query per entry, so a 1,000-entry upload costs
+    /// one query rather than a thousand, each of which carried its own context, connection lease
+    /// and plan. Other types are probed one at a time, as before.
     /// </remarks>
     /// <param name="probes">The entries to classify, in submission order.</param>
     /// <param name="windowMinutes">Time window in minutes to check for duplicates. Defaults to 5.</param>

--- a/src/Core/Nocturne.Core.Contracts/Glucose/IEntryService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Glucose/IEntryService.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
+using Nocturne.Core.Contracts.Entries;
 
 namespace Nocturne.Core.Contracts.Glucose;
 
@@ -67,6 +68,25 @@ public interface IEntryService
         string type,
         double? sgv,
         long mills,
+        int windowMinutes = 5,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Check a whole upload batch for duplicates in one pass
+    /// </summary>
+    /// <remarks>
+    /// Same per-entry classification as
+    /// <see cref="CheckForDuplicateEntryAsync(string?, string, double?, long, int, CancellationToken)"/>,
+    /// but the stored readings covering the batch are loaded in a query per entry type rather than
+    /// a query per entry.
+    /// </remarks>
+    /// <param name="probes">Entries to classify, in submission order</param>
+    /// <param name="windowMinutes">Time window in minutes to check for duplicates (default: 5)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>One result per probe in the order given: the existing entry, or null</returns>
+    Task<IReadOnlyList<Entry?>> CheckForDuplicateEntriesAsync(
+        IReadOnlyList<EntryDuplicateProbe> probes,
         int windowMinutes = 5,
         CancellationToken cancellationToken = default
     );

--- a/src/Core/Nocturne.Core.Contracts/Glucose/IEntryService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Glucose/IEntryService.cs
@@ -78,8 +78,8 @@ public interface IEntryService
     /// <remarks>
     /// Same per-entry classification as
     /// <see cref="CheckForDuplicateEntryAsync(string?, string, double?, long, int, CancellationToken)"/>,
-    /// but the stored readings covering the batch are loaded in a query per entry type rather than
-    /// a query per entry.
+    /// but the stored readings covering an <c>sgv</c> batch are loaded in one query rather than a
+    /// query per entry. Other types are probed one at a time.
     /// </remarks>
     /// <param name="probes">Entries to classify, in submission order</param>
     /// <param name="windowMinutes">Time window in minutes to check for duplicates (default: 5)</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
@@ -86,6 +86,29 @@ public interface ISensorGlucoseRepository
         string? device, double? mgdl, DateTime from, DateTime to, CancellationToken ct = default);
 
     /// <summary>
+    /// Raw-storage duplicate probe for a whole upload batch: returns the stored readings in
+    /// <paramref name="from"/>..<paramref name="to"/> for the given devices, newest first, so the
+    /// caller can match every submitted entry in memory instead of querying per entry.
+    /// </summary>
+    /// <remarks>
+    /// Same raw semantics as
+    /// <see cref="FindStoredDuplicateAsync(string?, double?, DateTime, DateTime, CancellationToken)"/> —
+    /// non-primary duplicate copies are included, and the ordering (timestamp then id, both
+    /// descending) is the one the single-entry probe resolves ties by, so scanning the returned
+    /// list in order and taking the first match reproduces its result exactly.
+    /// </remarks>
+    /// <param name="devices">Device identifiers to include, or <c>null</c> for every device
+    /// (required when any submitted entry has no device, since such an entry matches any).</param>
+    /// <param name="from">Inclusive start of the time window.</param>
+    /// <param name="to">Inclusive end of the time window.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Every stored reading in the window — unpaged, so the caller must keep the window
+    /// narrow enough to hold in memory.</returns>
+    Task<IReadOnlyList<SensorGlucose>> FindStoredDuplicateCandidatesAsync(
+        IReadOnlyCollection<string>? devices, DateTime from, DateTime to,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="SensorGlucose"/> reading, optionally scoped to a data source.
     /// </summary>
     /// <remarks>Used by connectors to determine the last sync time and avoid re-fetching already-stored data.</remarks>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
@@ -101,11 +101,11 @@ public interface ISensorGlucoseRepository
     /// (required when any submitted entry has no device, since such an entry matches any).</param>
     /// <param name="from">Inclusive start of the time window.</param>
     /// <param name="to">Inclusive end of the time window.</param>
+    /// <param name="limit">Maximum rows to return. A caller that needs to know whether the window
+    /// held more than it can use should ask for one row more than that.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Every stored reading in the window — unpaged, so the caller must keep the window
-    /// narrow enough to hold in memory.</returns>
     Task<IReadOnlyList<SensorGlucose>> FindStoredDuplicateCandidatesAsync(
-        IReadOnlyCollection<string>? devices, DateTime from, DateTime to,
+        IReadOnlyCollection<string>? devices, DateTime from, DateTime to, int limit,
         CancellationToken ct = default);
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -277,17 +277,46 @@ public class SensorGlucoseRepository : SyncUpsertRepositoryBase<SensorGlucose, S
         string? device, double? mgdl, DateTime from, DateTime to, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = await StoredDuplicateQuery(ctx, device is null ? null : [device], mgdl, from, to)
+            .FirstOrDefaultAsync(ct);
+        return entity is null ? null : SensorGlucoseMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SensorGlucose>> FindStoredDuplicateCandidatesAsync(
+        IReadOnlyCollection<string>? devices, DateTime from, DateTime to,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entities = await StoredDuplicateQuery(ctx, devices, mgdl: null, from, to).ToListAsync(ct);
+        return entities.Select(SensorGlucoseMapper.ToDomainModel).ToList();
+    }
+
+    /// <summary>
+    /// The duplicate probe's query, shared by the single-entry and whole-batch forms so both see
+    /// the same rows in the same order. Deliberately without the non-primary LinkedRecords filter.
+    /// </summary>
+    private static IQueryable<SensorGlucoseEntity> StoredDuplicateQuery(
+        NocturneDbContext ctx, IReadOnlyCollection<string>? devices, double? mgdl,
+        DateTime from, DateTime to)
+    {
         var query = ctx.SensorGlucose.AsNoTracking()
             .Where(e => e.Timestamp >= from && e.Timestamp <= to);
-        if (device != null)
+        if (devices is { Count: 1 })
+        {
+            // One device is the overwhelmingly common case (a single uploader): keep it an
+            // equality so the plan stays the index seek the multi-device `= ANY` cannot be.
+            var device = devices.First();
             query = query.Where(e => e.Device == device);
+        }
+        else if (devices is { Count: > 1 })
+        {
+            query = query.Where(e => e.Device != null && devices.Contains(e.Device));
+        }
         if (mgdl.HasValue)
             query = query.Where(e => Math.Abs(e.Mgdl - mgdl.Value) < 0.01);
 
-        var entity = await query
-            .OrderByDescending(e => e.Timestamp).ThenByDescending(e => e.Id)
-            .FirstOrDefaultAsync(ct);
-        return entity is null ? null : SensorGlucoseMapper.ToDomainModel(entity);
+        return query.OrderByDescending(e => e.Timestamp).ThenByDescending(e => e.Id);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -311,6 +311,9 @@ public class SensorGlucoseRepository : SyncUpsertRepositoryBase<SensorGlucose, S
         }
         else if (devices is { Count: > 1 })
         {
+            // `= ANY($1)`. Custom-planned today, because nothing configures Npgsql auto-prepare;
+            // a generic plan cannot hash the array parameter and this shape has been measured at
+            // 19 s against 200 ms. Enabling auto-prepare has to account for this query.
             query = query.Where(e => e.Device != null && devices.Contains(e.Device));
         }
         if (mgdl.HasValue)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -284,11 +284,13 @@ public class SensorGlucoseRepository : SyncUpsertRepositoryBase<SensorGlucose, S
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<SensorGlucose>> FindStoredDuplicateCandidatesAsync(
-        IReadOnlyCollection<string>? devices, DateTime from, DateTime to,
+        IReadOnlyCollection<string>? devices, DateTime from, DateTime to, int limit,
         CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        var entities = await StoredDuplicateQuery(ctx, devices, mgdl: null, from, to).ToListAsync(ct);
+        var entities = await StoredDuplicateQuery(ctx, devices, mgdl: null, from, to)
+            .Take(limit)
+            .ToListAsync(ct);
         return entities.Select(SensorGlucoseMapper.ToDomainModel).ToList();
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
@@ -11,6 +11,7 @@ using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Extensions;
 using Xunit;
+using Nocturne.Core.Contracts.Entries;
 
 namespace Nocturne.API.Tests.Controllers.V1;
 
@@ -76,18 +77,7 @@ public class EntriesControllerTests
             .Callback<IEnumerable<Entry>>(entries => processedInput = entries.ToList())
             .Returns<IEnumerable<Entry>>(entries => entries);
 
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<int?>(),
-                    It.IsAny<long>(),
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync((Entry?)null);
+        StubNothingStored();
 
         _mockEntryService
             .Setup(x =>
@@ -139,18 +129,7 @@ public class EntriesControllerTests
             .Callback<IEnumerable<Entry>>(entries => processedInput = entries.ToList())
             .Returns<IEnumerable<Entry>>(entries => entries);
 
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<int?>(),
-                    It.IsAny<long>(),
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync((Entry?)null);
+        StubNothingStored();
 
         _mockEntryService
             .Setup(x =>
@@ -206,18 +185,7 @@ public class EntriesControllerTests
             .Callback<IEnumerable<Entry>>(entries => processedInput = entries.ToList())
             .Returns<IEnumerable<Entry>>(entries => entries);
 
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<int?>(),
-                    It.IsAny<long>(),
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync((Entry?)null);
+        StubNothingStored();
 
         _mockEntryService
             .Setup(x =>
@@ -265,18 +233,7 @@ public class EntriesControllerTests
             .Callback<IEnumerable<Entry>>(entries => processedInput = entries.ToList())
             .Returns<IEnumerable<Entry>>(entries => entries);
 
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<int?>(),
-                    It.IsAny<long>(),
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync((Entry?)null);
+        StubNothingStored();
 
         _mockEntryService
             .Setup(x =>
@@ -320,18 +277,7 @@ public class EntriesControllerTests
             .Callback<IEnumerable<Entry>>(entries => processedInput = entries.ToList())
             .Returns<IEnumerable<Entry>>(entries => entries);
 
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<int?>(),
-                    It.IsAny<long>(),
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync((Entry?)null);
+        StubNothingStored();
 
         _mockEntryService
             .Setup(x =>
@@ -380,18 +326,7 @@ public class EntriesControllerTests
             .Callback<IEnumerable<Entry>>(entries => processedInput = entries.ToList())
             .Returns<IEnumerable<Entry>>(entries => entries);
 
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<int?>(),
-                    It.IsAny<long>(),
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync((Entry?)null);
+        StubNothingStored();
 
         _mockEntryService
             .Setup(x =>
@@ -425,30 +360,7 @@ public class EntriesControllerTests
             .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
             .Returns<IEnumerable<Entry>>(entries => entries);
 
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<double?>(),
-                    1000L,
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync(stored1);
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<double?>(),
-                    2000L,
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync(stored2);
+        StubStoredAt((1000L, stored1), (2000L, stored2));
 
         List<Entry>? createInput = null;
         _mockEntryService
@@ -538,30 +450,7 @@ public class EntriesControllerTests
             .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
             .Returns<IEnumerable<Entry>>(entries => entries);
 
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<double?>(),
-                    It.IsAny<long>(),
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync((Entry?)null);
-        _mockEntryService
-            .Setup(x =>
-                x.CheckForDuplicateEntryAsync(
-                    It.IsAny<string?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<double?>(),
-                    2000L,
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync(storedDuplicate);
+        StubStoredAt((2000L, storedDuplicate));
 
         List<Entry>? createInput = null;
         _mockEntryService
@@ -597,4 +486,116 @@ public class EntriesControllerTests
         createInput.Should().NotBeNull();
         createInput!.Select(e => e.Mills).Should().Equal(1000, 3000);
     }
+
+    /// <summary>
+    /// The duplicate check finds nothing stored, so every submitted entry is written. Aligned with
+    /// the batch probe the controller uses: one result per submitted entry, in the same order.
+    /// </summary>
+    [Fact]
+    public async Task CreateEntries_LargeAllStoredBatch_ReportsTheUploaderOnce()
+    {
+        // The re-upload loop this exists to surface: a client re-sending a stored backlog every
+        // cycle. Without a log line the next tenant in this state is only findable in
+        // pg_stat_statements.
+        var submitted = StoredBacklog(120);
+        _controller.ControllerContext.HttpContext.Request.Headers.UserAgent = "Loop/57 CFNetwork Darwin";
+
+        await _controller.CreateEntries(submitted);
+
+        VerifyInformationLogged("re-sending stored readings", Times.Once());
+        VerifyInformationLogged("Loop/57 CFNetwork Darwin", Times.Once());
+    }
+
+    [Fact]
+    public async Task CreateEntries_SmallAllStoredBatch_IsNotReported()
+    {
+        // A handful of duplicates is the normal overlap between an uploader's cycles.
+        var submitted = StoredBacklog(20);
+
+        await _controller.CreateEntries(submitted);
+
+        VerifyInformationLogged("re-sending stored readings", Times.Never());
+    }
+
+    [Fact]
+    public async Task CreateEntries_LargeBatchMostlyNew_IsNotReported()
+    {
+        var submitted = Enumerable.Range(0, 120)
+            .Select(i => new Entry { Sgv = 100 + i, Mills = 1000 + i, Device = "Dexcom G7", Type = "sgv" })
+            .ToArray();
+        _mockDocumentProcessingService
+            .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
+            .Returns<IEnumerable<Entry>>(entries => entries);
+        // Half stored: below the share that marks a re-upload loop.
+        StubStoredAt(submitted.Take(60)
+            .Select(e => (e.Mills, new Entry { Id = $"stored-{e.Mills}", Mills = e.Mills, Type = "sgv" }))
+            .ToArray());
+        _mockEntryService
+            .Setup(x => x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<Entry> entries, WriteOrigin _, CancellationToken _) => entries.ToList());
+
+        await _controller.CreateEntries(submitted);
+
+        VerifyInformationLogged("re-sending stored readings", Times.Never());
+    }
+
+    /// <summary>
+    /// A batch of <paramref name="count"/> entries the server already holds, wired through the
+    /// processing and duplicate stubs.
+    /// </summary>
+    private Entry[] StoredBacklog(int count)
+    {
+        var submitted = Enumerable.Range(0, count)
+            .Select(i => new Entry { Sgv = 100 + i, Mills = 1000 + i, Device = "Dexcom G7", Type = "sgv" })
+            .ToArray();
+
+        _mockDocumentProcessingService
+            .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
+            .Returns<IEnumerable<Entry>>(entries => entries);
+        StubStoredAt(submitted
+            .Select(e => (e.Mills, new Entry { Id = $"stored-{e.Mills}", Mills = e.Mills, Type = "sgv" }))
+            .ToArray());
+        _mockEntryService
+            .Setup(x => x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Entry>());
+
+        return submitted;
+    }
+
+    private void VerifyInformationLogged(string fragment, Times times) =>
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains(fragment)),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            times);
+
+    private void StubNothingStored() => StubStoredAt();
+
+    /// <summary>
+    /// The duplicate check reports the given entries as already stored, keyed by the submitted
+    /// entry's <see cref="Entry.Mills"/>, and finds nothing for every other entry. Results are
+    /// aligned with the submitted batch, as the batch probe the controller uses returns them.
+    /// </summary>
+    private void StubStoredAt(params (long Mills, Entry Stored)[] stored)
+    {
+        var byMills = stored.ToDictionary(x => x.Mills, x => x.Stored);
+        _mockEntryService
+            .Setup(x =>
+                x.CheckForDuplicateEntriesAsync(
+                    It.IsAny<IReadOnlyList<EntryDuplicateProbe>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(
+                (IReadOnlyList<EntryDuplicateProbe> probes, int _, CancellationToken _) =>
+                    probes
+                        .Select(probe => byMills.GetValueOrDefault(probe.Mills))
+                        .ToArray()
+            );
+    }
+
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
@@ -507,6 +507,22 @@ public class EntriesControllerTests
     }
 
     [Fact]
+    public async Task CreateEntries_ReuploadLine_StripsControlCharactersFromTheUserAgent()
+    {
+        // The only log sink is a line-oriented console exporter, so a control character in a
+        // caller-supplied header forges log lines.
+        var submitted = StoredBacklog(120);
+        _controller.ControllerContext.HttpContext.Request.Headers.UserAgent =
+            "Loop/57\r\nLogRecord.Body: forged";
+
+        await _controller.CreateEntries(submitted);
+
+        VerifyInformationLogged("Loop/57", Times.Once());
+        VerifyInformationLogged("\n", Times.Never());
+        VerifyInformationLogged("\r", Times.Never());
+    }
+
+    [Fact]
     public async Task CreateEntries_SmallAllStoredBatch_IsNotReported()
     {
         // A handful of duplicates is the normal overlap between an uploader's cycles.

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
@@ -523,6 +523,32 @@ public class EntriesControllerTests
     }
 
     [Fact]
+    public async Task CreateEntries_ReuploadLine_CapsAndFoldsAwkwardUserAgents()
+    {
+        // Length is capped so one uploader cannot write unbounded log lines, and format and
+        // separator characters are folded as well as controls: a right-to-left override or a
+        // U+2028 spoofs how a line reads without being a control character.
+        var submitted = StoredBacklog(120);
+        _controller.ControllerContext.HttpContext.Request.Headers.UserAgent =
+            "Loop/57\u202e\u2028" + new string('x', 400);
+
+        await _controller.CreateEntries(submitted);
+
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("Loop/57")
+                    && !v.ToString()!.Contains('\u202e')
+                    && !v.ToString()!.Contains('\u2028')
+                    && !v.ToString()!.Contains(new string('x', 250))),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once());
+    }
+
+    [Fact]
     public async Task CreateEntries_SmallAllStoredBatch_IsNotReported()
     {
         // A handful of duplicates is the normal overlap between an uploader's cycles.

--- a/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceBatchProbeParityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceBatchProbeParityTests.cs
@@ -1,0 +1,225 @@
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Entries;
+using Nocturne.API.Services.Platform;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Entries;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Entries;
+
+/// <summary>
+/// Covers <see cref="EntryReadService.CheckDuplicatesAsync"/> against real repositories on SQLite:
+/// a v1 upload batch must cost one duplicate query per entry type, and must classify every entry
+/// exactly as the per-entry <see cref="EntryReadService.CheckDuplicateAsync"/> probe it replaces.
+/// One uploader re-sending its stored backlog in 1,000-entry POSTs made the per-entry probe the
+/// most-executed statement in the production database (95 M calls).
+/// </summary>
+[Trait("Category", "Unit")]
+public class EntryReadServiceBatchProbeParityTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly DateTime Start = new(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+
+    private readonly StatementRecorder _statements = new();
+    private readonly SqliteTestDatabase _db;
+    private readonly NocturneDbContext _context;
+    private readonly EntryReadService _sut;
+
+    public EntryReadServiceBatchProbeParityTests()
+    {
+        _db = TestDbContextFactory.CreateSqliteWithTenant(TestTenantId, "test", _statements);
+        _context = _db.CreateContext();
+
+        var factory = new TestTenantDbContextFactory(_context);
+        var audit = new Mock<IAuditContext>().Object;
+        var demoMode = new Mock<IDemoModeService>();
+        demoMode.Setup(d => d.IsEnabled).Returns(false);
+
+        _sut = new EntryReadService(
+            new SensorGlucoseRepository(
+                factory, new Mock<IDeduplicationService>().Object, audit,
+                NullLogger<SensorGlucoseRepository>.Instance),
+            new MeterGlucoseRepository(factory, audit, NullLogger<MeterGlucoseRepository>.Instance),
+            new CalibrationRepository(factory, audit, NullLogger<CalibrationRepository>.Instance),
+            TestDoubles.CanonicalGlucosePassThrough.Create(),
+            demoMode.Object,
+            NullLogger<EntryReadService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task ContiguousSgvBatch_IssuesOneSensorGlucoseQuery()
+    {
+        // A day of stored readings, and a 288-entry re-upload of exactly that day.
+        for (var i = 0; i < 288; i++)
+            SeedSgv(Start.AddMinutes(5 * i), 100 + (i % 60), "Dexcom G6");
+        _statements.Clear();
+
+        var probes = Enumerable.Range(0, 288)
+            .Select(i => Probe("Dexcom G6", "sgv", 100 + (i % 60), Start.AddMinutes(5 * i)))
+            .ToArray();
+
+        var results = await _sut.CheckDuplicatesAsync(probes);
+
+        results.Should().HaveCount(288).And.OnlyContain(r => r != null);
+        _statements.SelectsAgainst("sensor_glucose").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MixedBatch_ClassifiesEveryEntryAsThePerEntryProbeDoes()
+    {
+        SeedSgv(Start, 120, "Dexcom G6");
+        SeedSgv(Start.AddMinutes(5), 121, "Dexcom G6");
+        SeedSgv(Start.AddMinutes(10), 122, "xdrip");
+        SeedMbg(Start.AddMinutes(15), 150, "Contour");
+        SeedCal(Start.AddMinutes(20), "Dexcom G6");
+
+        var probes = new[]
+        {
+            Probe("Dexcom G6", "sgv", 120, Start),                        // stored
+            Probe("Dexcom G6", "sgv", 200, Start),                        // same time, other value
+            Probe("Dexcom G6", "sgv", 122, Start.AddMinutes(10)),         // stored, other device
+            Probe(null, "sgv", 122, Start.AddMinutes(10)),                // no device: matches any
+            Probe("Dexcom G6", "sgv", 121, Start.AddMinutes(7)),          // inside the window
+            Probe("Dexcom G6", "sgv", 121, Start.AddMinutes(40)),         // outside the window
+            Probe("Contour", "mbg", 150, Start.AddMinutes(15)),           // stored meter reading
+            Probe("Contour", "mbg", 90, Start.AddMinutes(15)),            // other value
+            Probe("Dexcom G6", "cal", null, Start.AddMinutes(20)),        // stored calibration
+            Probe("Dexcom G6", "cal", null, Start.AddHours(6)),           // no calibration near
+            Probe("Dexcom G6", "food", null, Start),                      // not a probed type
+        };
+
+        var expected = new List<string?>();
+        foreach (var probe in probes)
+        {
+            var single = await _sut.CheckDuplicateAsync(
+                probe.Device, probe.Type, probe.Sgv, probe.Mills, windowMinutes: 5);
+            expected.Add(single?.Id);
+        }
+
+        var batch = await _sut.CheckDuplicatesAsync(probes, windowMinutes: 5);
+
+        batch.Select(e => e?.Id).Should().Equal(expected);
+        // Not a vacuous comparison: the batch really did find duplicates and really did miss some.
+        expected.Should().Contain(id => id != null).And.Contain(id => id == null);
+    }
+
+    [Fact]
+    public async Task StoredCopyLinkedAsNonPrimary_IsStillADuplicate()
+    {
+        // The raw-storage semantics of the single-entry probe: a reading whose only copy is hidden
+        // from reads as a non-primary cross-connector duplicate is still stored, and re-inserting
+        // it on every upload cycle is the bug FindStoredDuplicateAsync exists to prevent.
+        var id = SeedSgv(Start, 120, "Dexcom G6");
+        _context.LinkedRecords.Add(new LinkedRecordEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestTenantId,
+            RecordId = id,
+            RecordType = "SensorGlucose",
+            SourceTimestamp = new DateTimeOffset(Start, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+            IsPrimary = false,
+            CanonicalId = Guid.NewGuid(),
+        });
+        _context.SaveChanges();
+
+        var batch = await _sut.CheckDuplicatesAsync([Probe("Dexcom G6", "sgv", 120, Start)]);
+
+        batch.Single().Should().NotBeNull();
+    }
+
+    private static EntryDuplicateProbe Probe(string? device, string type, double? sgv, DateTime at) =>
+        new(device, type, sgv, new DateTimeOffset(at, TimeSpan.Zero).ToUnixTimeMilliseconds());
+
+    private Guid SeedSgv(DateTime timestamp, double mgdl, string device)
+    {
+        var id = Guid.NewGuid();
+        _context.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            Mgdl = mgdl,
+            Device = device,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    private void SeedMbg(DateTime timestamp, double mgdl, string device)
+    {
+        _context.MeterGlucose.Add(new MeterGlucoseEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            Mgdl = mgdl,
+            Device = device,
+        });
+        _context.SaveChanges();
+    }
+
+    private void SeedCal(DateTime timestamp, string device)
+    {
+        _context.Calibrations.Add(new CalibrationEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            Slope = 1000,
+            Intercept = 25000,
+            Scale = 1,
+            Device = device,
+        });
+        _context.SaveChanges();
+    }
+
+    /// <summary>
+    /// Counts the statements the context issues, so a test can assert how many queries a batch
+    /// cost — the property this change exists to alter, and the one row counts cannot show.
+    /// </summary>
+    private sealed class StatementRecorder : DbCommandInterceptor
+    {
+        private readonly List<string> _statements = [];
+
+        public void Clear() => _statements.Clear();
+
+        public int SelectsAgainst(string table) => _statements.Count(s =>
+            s.StartsWith("SELECT", StringComparison.OrdinalIgnoreCase)
+            && s.Contains(table, StringComparison.OrdinalIgnoreCase));
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Record(command);
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Record(command);
+            return ValueTask.FromResult(result);
+        }
+
+        private void Record(DbCommand command) => _statements.Add(command.CommandText.Trim());
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceBatchProbeParityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceBatchProbeParityTests.cs
@@ -99,6 +99,7 @@ public class EntryReadServiceBatchProbeParityTests : IDisposable
             Probe(null, "sgv", 122, Start.AddMinutes(10)),                // no device: matches any
             Probe("Dexcom G6", "sgv", 121, Start.AddMinutes(7)),          // inside the window
             Probe("Dexcom G6", "sgv", 121, Start.AddMinutes(40)),         // outside the window
+            Probe("DEXCOM G6", "sgv", 120, Start),                        // device differs by case only
             Probe("Contour", "mbg", 150, Start.AddMinutes(15)),           // stored meter reading
             Probe("Contour", "mbg", 90, Start.AddMinutes(15)),            // other value
             Probe("Dexcom G6", "cal", null, Start.AddMinutes(20)),        // stored calibration
@@ -119,6 +120,65 @@ public class EntryReadServiceBatchProbeParityTests : IDisposable
         batch.Select(e => e?.Id).Should().Equal(expected);
         // Not a vacuous comparison: the batch really did find duplicates and really did miss some.
         expected.Should().Contain(id => id != null).And.Contain(id => id == null);
+    }
+
+    [Theory]
+    // The window is inclusive at both ends, as the per-entry probe's SQL was
+    // (`Timestamp >= from AND Timestamp <= to`): a reading exactly one window away is a duplicate,
+    // one millisecond further out is not.
+    [InlineData(-5, 0, true)]
+    [InlineData(5, 0, true)]
+    [InlineData(-5, -1, false)]
+    [InlineData(5, 1, false)]
+    public async Task WindowEndsAreInclusive(int offsetMinutes, int offsetMillis, bool expectDuplicate)
+    {
+        SeedSgv(Start, 120, "Dexcom G6");
+        var at = Start.AddMinutes(offsetMinutes).AddMilliseconds(offsetMillis);
+
+        var batch = await _sut.CheckDuplicatesAsync(
+            [Probe("Dexcom G6", "sgv", 120, at)], windowMinutes: 5);
+        var single = await _sut.CheckDuplicateAsync(
+            "Dexcom G6", "sgv", 120, ToMills(at), windowMinutes: 5);
+
+        (batch.Single() != null).Should().Be(expectDuplicate);
+        batch.Single()?.Id.Should().Be(single?.Id);
+    }
+
+    [Fact]
+    public async Task TiedTimestamps_EchoTheSameRowThePerEntryProbeReturns()
+    {
+        // Two stored readings identical but for their id: the probe's `id DESC` tie-break decides
+        // which one is echoed, and the batch path must not re-resolve it (a .NET Guid comparison
+        // does not order like Postgres, so re-sorting in memory would answer differently).
+        var lower = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var higher = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        SeedSgv(Start, 120, "Dexcom G6", lower);
+        SeedSgv(Start, 120, "Dexcom G6", higher);
+
+        var batch = await _sut.CheckDuplicatesAsync([Probe("Dexcom G6", "sgv", 120, Start)]);
+        var single = await _sut.CheckDuplicateAsync("Dexcom G6", "sgv", 120, ToMills(Start));
+
+        batch.Single()!.Id.Should().Be(single!.Id);
+        batch.Single()!.Id.Should().Be(higher.ToString());
+    }
+
+    [Fact]
+    public async Task MeterGlucose_KeepsThePerEntryProbe()
+    {
+        // Deliberate: the per-entry mbg probe reads a device-filtered page of the entry's own
+        // window. A batch-wide read is a strict superset, which suppresses a write the per-entry
+        // probe performs — a lost fingerstick. mbg never arrives in the volumes that motivated
+        // batching, so it is left alone.
+        for (var i = 0; i < 120; i++)
+            SeedMbg(Start.AddSeconds(60 + i), 999, "Contour");
+        SeedMbg(Start, 150, "Contour");
+
+        var probe = Probe("Contour", "mbg", 150, Start);
+        var batch = await _sut.CheckDuplicatesAsync([probe], windowMinutes: 5);
+        var single = await _sut.CheckDuplicateAsync("Contour", "mbg", 150, probe.Mills, windowMinutes: 5);
+
+        batch.Single()?.Id.Should().Be(single?.Id);
+        _statements.SelectsAgainst("sensor_glucose").Should().Be(0);
     }
 
     [Fact]
@@ -146,11 +206,14 @@ public class EntryReadServiceBatchProbeParityTests : IDisposable
     }
 
     private static EntryDuplicateProbe Probe(string? device, string type, double? sgv, DateTime at) =>
-        new(device, type, sgv, new DateTimeOffset(at, TimeSpan.Zero).ToUnixTimeMilliseconds());
+        new(device, type, sgv, ToMills(at));
 
-    private Guid SeedSgv(DateTime timestamp, double mgdl, string device)
+    private static long ToMills(DateTime at) =>
+        new DateTimeOffset(at, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+    private Guid SeedSgv(DateTime timestamp, double mgdl, string device, Guid? forcedId = null)
     {
-        var id = Guid.NewGuid();
+        var id = forcedId ?? Guid.NewGuid();
         _context.SensorGlucose.Add(new SensorGlucoseEntity
         {
             Id = id,

--- a/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
@@ -370,7 +370,7 @@ public class EntryReadServiceTests
         Assert.All(results, Assert.Null);
         _sgRepo.Verify(r => r.FindStoredDuplicateCandidatesAsync(
             It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-            It.IsAny<CancellationToken>()), Times.Once);
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
         _sgRepo.Verify(r => r.FindStoredDuplicateAsync(
             It.IsAny<string?>(), It.IsAny<double?>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
             It.IsAny<CancellationToken>()), Times.Never);
@@ -393,7 +393,7 @@ public class EntryReadServiceTests
 
         _sgRepo.Verify(r => r.FindStoredDuplicateCandidatesAsync(
             It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-            It.IsAny<CancellationToken>()), Times.Exactly(2));
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]
@@ -403,9 +403,9 @@ public class EntryReadServiceTests
         var captured = new List<(DateTime From, DateTime To)>();
         _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
                 It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
-                (_, from, to, _) => captured.Add((from, to)))
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, int, CancellationToken>(
+                (_, from, to, _, _) => captured.Add((from, to)))
             .ReturnsAsync(Array.Empty<SensorGlucose>());
 
         var probes = FiveMinutelyProbes(10, "xdrip");
@@ -427,9 +427,9 @@ public class EntryReadServiceTests
         IReadOnlyCollection<string>? devices = null;
         _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
                 It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
-                (d, _, _, _) => devices = d)
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, int, CancellationToken>(
+                (d, _, _, _, _) => devices = d)
             .ReturnsAsync(Array.Empty<SensorGlucose>());
 
         await _sut.CheckDuplicatesAsync(FiveMinutelyProbes(5, "xdrip"));
@@ -447,9 +447,9 @@ public class EntryReadServiceTests
         IReadOnlyCollection<string>? devices = new[] { "sentinel" };
         _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
                 It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
-                (d, _, _, _) => devices = d)
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, int, CancellationToken>(
+                (d, _, _, _, _) => devices = d)
             .ReturnsAsync(Array.Empty<SensorGlucose>());
 
         var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
@@ -485,7 +485,7 @@ public class EntryReadServiceTests
         var stored = MakeSg(Now.AddMinutes(-30), 99);
         _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
                 It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([stored]);
 
         // Submitted newest-first, so the stored reading answers the *last* probe: chunking sorts
@@ -550,9 +550,9 @@ public class EntryReadServiceTests
         IReadOnlyCollection<string>? devices = null;
         _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
                 It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
-                (d, _, _, _) => devices = d)
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, int, CancellationToken>(
+                (d, _, _, _, _) => devices = d)
             .ReturnsAsync(Array.Empty<SensorGlucose>());
 
         var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
@@ -589,14 +589,135 @@ public class EntryReadServiceTests
             100, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_ReadingOutsideAProbesOwnWindow_IsNotItsDuplicate()
+    {
+        // One chunk covers every probe's window, so the candidate list holds rows that belong to
+        // other probes. Each probe must reject them: matching a reading half an hour outside its
+        // own window drops a genuinely new reading from the write.
+        var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var later = Now.AddMinutes(30);
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([MakeSg(later, 120)]);
+
+        var results = await _sut.CheckDuplicatesAsync(new[]
+        {
+            new EntryDuplicateProbe("test-device", "sgv", 120, mills),
+            new EntryDuplicateProbe("test-device", "sgv", 120, mills + (30 * 60_000L)),
+        }, windowMinutes: 5);
+
+        results[0].Should().BeNull("the stored reading is 30 minutes outside this probe's window");
+        results[1].Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_EntriesJustUnderTheGap_DoNotWalkTheChunkOpen()
+    {
+        // Spacing an entry a millisecond under the limit is the shape that defeats a budget
+        // measured from the chunk's start: each entry pays for the next and the window grows
+        // without bound. The gap is measured against the neighbour instead.
+        var captured = CaptureCandidateWindows();
+        var justUnder = TimeSpan.FromHours(1) - TimeSpan.FromMilliseconds(1);
+
+        await _sut.CheckDuplicatesAsync(SpacedProbes(400, justUnder, "xdrip"));
+
+        captured.Max(w => w.To - w.From)
+            .Should().BeLessThanOrEqualTo(TimeSpan.FromDays(7) + TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_WindowHoldsMoreRowsThanTheCap_FallsBackToPerEntryProbes()
+    {
+        // The span and gap limits bound the chunk's window, not how many readings a tenant has
+        // inside it. Above the row cap the chunk must not hold them all in memory.
+        var flood = Enumerable.Range(0, 20_001).Select(i => MakeSg(Now.AddSeconds(-i), 100)).ToArray();
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(flood);
+        _sgRepo.Setup(r => r.FindStoredDuplicateAsync(
+                It.IsAny<string?>(), It.IsAny<double?>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SensorGlucose?)null);
+
+        var results = await _sut.CheckDuplicatesAsync(FiveMinutelyProbes(3, "xdrip"));
+
+        Assert.All(results, Assert.Null);
+        _sgRepo.Verify(r => r.FindStoredDuplicateAsync(
+            It.IsAny<string?>(), It.IsAny<double?>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(3));
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData("SGV")]
+    [InlineData("Sgv")]
+    [InlineData("sgv ")]
+    public async Task CheckDuplicatesAsync_TypeIsNotExactlySgv_NeverReachesTheBatchRead(string type)
+    {
+        // Which types reach the batch read is the correctness boundary of this change: the batch
+        // read is a superset of the per-entry probe's paged, device-filtered read, and for mbg
+        // that difference suppresses a real write. Only exactly "sgv" may take it.
+        var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var results = await _sut.CheckDuplicatesAsync(
+            [new EntryDuplicateProbe("xdrip", type, 120, mills)]);
+
+        Assert.Null(Assert.Single(results));
+        _sgRepo.Verify(r => r.FindStoredDuplicateCandidatesAsync(
+            It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_DeviceFilter_KeepsDevicesThatDifferOnlyByCase()
+    {
+        // Folding case here would filter the query to one spelling, miss the other's stored
+        // readings, and re-insert them on every upload cycle.
+        IReadOnlyCollection<string>? devices = null;
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, int, CancellationToken>(
+                (d, _, _, _, _) => devices = d)
+            .ReturnsAsync(Array.Empty<SensorGlucose>());
+
+        var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        await _sut.CheckDuplicatesAsync(new[]
+        {
+            new EntryDuplicateProbe("xdrip", "sgv", 120, mills),
+            new EntryDuplicateProbe("XDRIP", "sgv", 121, mills + 60_000),
+        });
+
+        devices.Should().BeEquivalentTo(new[] { "xdrip", "XDRIP" });
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_CancelledToken_StopsClassifying()
+    {
+        StubNoSgvCandidates();
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _sut.CheckDuplicatesAsync(FiveMinutelyProbes(5, "xdrip"), 5, cancelled.Token));
+    }
+
     private List<(DateTime From, DateTime To)> CaptureCandidateWindows()
     {
         var captured = new List<(DateTime From, DateTime To)>();
         _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
                 It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
-                (_, from, to, _) => captured.Add((from, to)))
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, int, CancellationToken>(
+                (_, from, to, _, _) => captured.Add((from, to)))
             .ReturnsAsync(Array.Empty<SensorGlucose>());
         return captured;
     }
@@ -613,7 +734,7 @@ public class EntryReadServiceTests
     private void StubNoSgvCandidates() =>
         _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
                 It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<SensorGlucose>());
 
     private static EntryDuplicateProbe[] FiveMinutelyProbes(int count, string? device)

--- a/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
@@ -501,6 +501,115 @@ public class EntryReadServiceTests
         Assert.Equal(stored.Mills, results[1]!.Mills);
     }
 
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_NoQueryReadsMoreThanTheChunkSpanCap()
+    {
+        // 400 entries half an hour apart span 8.3 days, and their per-entry budget (400 h) would
+        // allow all of it in one query. The absolute span cap is what stops that.
+        var captured = CaptureCandidateWindows();
+
+        await _sut.CheckDuplicatesAsync(SpacedProbes(400, TimeSpan.FromMinutes(30), "xdrip"));
+
+        captured.Should().HaveCountGreaterThan(1);
+        captured.Max(w => w.To - w.From)
+            .Should().BeLessThanOrEqualTo(TimeSpan.FromDays(7) + TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_EntriesSpacedAtTheBudget_DoNotWalkItUpwards()
+    {
+        // Entries spaced exactly the per-entry budget apart: a non-strict comparison lets each one
+        // pay for the next and the chunk widens without bound.
+        var captured = CaptureCandidateWindows();
+
+        await _sut.CheckDuplicatesAsync(SpacedProbes(200, TimeSpan.FromHours(1), "xdrip"));
+
+        captured.Max(w => w.To - w.From)
+            .Should().BeLessThanOrEqualTo(TimeSpan.FromMinutes(11));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_ChunkHoldsAtMostFiveHundredEntries()
+    {
+        // Rows per query must have a ceiling that does not depend on how densely the tenant's
+        // stored readings fill the span, so entry count is capped as well as span.
+        var captured = CaptureCandidateWindows();
+
+        await _sut.CheckDuplicatesAsync(SpacedProbes(1_000, TimeSpan.FromMinutes(5), "xdrip"));
+
+        captured.Should().HaveCount(2);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_SeveralDevices_FiltersToAllOfThem()
+    {
+        IReadOnlyCollection<string>? devices = null;
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
+                (d, _, _, _) => devices = d)
+            .ReturnsAsync(Array.Empty<SensorGlucose>());
+
+        var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        await _sut.CheckDuplicatesAsync(new[]
+        {
+            new EntryDuplicateProbe("xdrip", "sgv", 120, mills),
+            new EntryDuplicateProbe("Dexcom G6", "sgv", 121, mills + 60_000),
+            new EntryDuplicateProbe("xdrip", "sgv", 122, mills + 120_000),
+        });
+
+        devices.Should().BeEquivalentTo(new[] { "xdrip", "Dexcom G6" });
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_NonSgvTypes_KeepThePerEntryProbe()
+    {
+        _mgRepo.Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MeterGlucose>());
+
+        var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        await _sut.CheckDuplicatesAsync(new[]
+        {
+            new EntryDuplicateProbe("meter", "mbg", 150, mills),
+            new EntryDuplicateProbe("meter", "mbg", 151, mills + 60_000),
+        });
+
+        // The per-entry page is device-filtered and limited; a batch-wide read is a superset that
+        // would drop a reading the per-entry probe stores.
+        _mgRepo.Verify(r => r.GetAsync(
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), "meter", It.IsAny<string?>(),
+            100, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    private List<(DateTime From, DateTime To)> CaptureCandidateWindows()
+    {
+        var captured = new List<(DateTime From, DateTime To)>();
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
+                (_, from, to, _) => captured.Add((from, to)))
+            .ReturnsAsync(Array.Empty<SensorGlucose>());
+        return captured;
+    }
+
+    private static EntryDuplicateProbe[] SpacedProbes(int count, TimeSpan spacing, string? device)
+    {
+        var start = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var step = (long)spacing.TotalMilliseconds;
+        return Enumerable.Range(0, count)
+            .Select(i => new EntryDuplicateProbe(device, "sgv", 100 + (i % 50), start + (i * step)))
+            .ToArray();
+    }
+
     private void StubNoSgvCandidates() =>
         _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
                 It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),

--- a/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
@@ -355,6 +355,168 @@ public class EntryReadServiceTests
 
     #endregion
 
+    #region CheckDuplicatesAsync — one query per batch
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_ContiguousBatch_ProbesStorageOnce()
+    {
+        StubNoSgvCandidates();
+        var probes = FiveMinutelyProbes(200, "xdrip");
+
+        var results = await _sut.CheckDuplicatesAsync(probes);
+
+        Assert.Equal(200, results.Count);
+        Assert.All(results, Assert.Null);
+        _sgRepo.Verify(r => r.FindStoredDuplicateCandidatesAsync(
+            It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _sgRepo.Verify(r => r.FindStoredDuplicateAsync(
+            It.IsAny<string?>(), It.IsAny<double?>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_ProbesFarApart_QueriesEachClusterSeparately()
+    {
+        // Two entries a week apart must not make one query read a week of readings.
+        StubNoSgvCandidates();
+        var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var probes = new[]
+        {
+            new EntryDuplicateProbe("xdrip", "sgv", 120, mills),
+            new EntryDuplicateProbe("xdrip", "sgv", 130, mills + (long)TimeSpan.FromDays(7).TotalMilliseconds),
+        };
+
+        await _sut.CheckDuplicatesAsync(probes);
+
+        _sgRepo.Verify(r => r.FindStoredDuplicateCandidatesAsync(
+            It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_QueryWindowCoversEveryProbesOwnWindow()
+    {
+        var captured = new List<(DateTime From, DateTime To)>();
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
+                (_, from, to, _) => captured.Add((from, to)))
+            .ReturnsAsync(Array.Empty<SensorGlucose>());
+
+        var probes = FiveMinutelyProbes(10, "xdrip");
+
+        await _sut.CheckDuplicatesAsync(probes, windowMinutes: 5);
+
+        var window = TimeSpan.FromMinutes(5);
+        Assert.All(probes, probe =>
+        {
+            var at = DateTimeOffset.FromUnixTimeMilliseconds(probe.Mills).UtcDateTime;
+            Assert.Contains(captured, w => w.From <= at - window && w.To >= at + window);
+        });
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_AllProbesShareADevice_FiltersToThatDevice()
+    {
+        IReadOnlyCollection<string>? devices = null;
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
+                (d, _, _, _) => devices = d)
+            .ReturnsAsync(Array.Empty<SensorGlucose>());
+
+        await _sut.CheckDuplicatesAsync(FiveMinutelyProbes(5, "xdrip"));
+
+        Assert.NotNull(devices);
+        Assert.Equal(["xdrip"], devices);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_AnyProbeWithoutADevice_FetchesEveryDevice()
+    {
+        // A probe with no device matches a stored reading from any device, so the fetch cannot
+        // be narrowed to the devices the other probes named.
+        IReadOnlyCollection<string>? devices = new[] { "sentinel" };
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>?, DateTime, DateTime, CancellationToken>(
+                (d, _, _, _) => devices = d)
+            .ReturnsAsync(Array.Empty<SensorGlucose>());
+
+        var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        await _sut.CheckDuplicatesAsync(new[]
+        {
+            new EntryDuplicateProbe("xdrip", "sgv", 120, mills),
+            new EntryDuplicateProbe(null, "sgv", 130, mills + 300_000),
+        });
+
+        Assert.Null(devices);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_UnknownType_IsNeverADuplicateAndCostsNoQuery()
+    {
+        var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var results = await _sut.CheckDuplicatesAsync(
+            [new EntryDuplicateProbe("xdrip", "food", null, mills)]);
+
+        Assert.Null(Assert.Single(results));
+        _sgRepo.VerifyNoOtherCalls();
+        _mgRepo.VerifyNoOtherCalls();
+        _calRepo.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CheckDuplicatesAsync_ResultsAlignWithSubmissionOrder()
+    {
+        var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var stored = MakeSg(Now.AddMinutes(-30), 99);
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([stored]);
+
+        // Submitted newest-first, so the stored reading answers the *last* probe: chunking sorts
+        // by time internally and must not reorder the results.
+        var results = await _sut.CheckDuplicatesAsync(new[]
+        {
+            new EntryDuplicateProbe("test-device", "sgv", 120, mills),
+            new EntryDuplicateProbe("test-device", "sgv", 99, stored.Mills),
+        });
+
+        Assert.Null(results[0]);
+        Assert.NotNull(results[1]);
+        Assert.Equal(stored.Mills, results[1]!.Mills);
+    }
+
+    private void StubNoSgvCandidates() =>
+        _sgRepo.Setup(r => r.FindStoredDuplicateCandidatesAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SensorGlucose>());
+
+    private static EntryDuplicateProbe[] FiveMinutelyProbes(int count, string? device)
+    {
+        var start = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        return Enumerable.Range(0, count)
+            .Select(i => new EntryDuplicateProbe(device, "sgv", 100 + (i % 50), start + (i * 300_000L)))
+            .ToArray();
+    }
+
+    #endregion
+
     #region QueryAsync — demo mode filtering
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
@@ -193,4 +193,89 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
 
         match.Should().BeNull();
     }
+
+    [Fact]
+    public async Task FindStoredDuplicateCandidatesAsync_ReturnsWindowNewestFirst()
+    {
+        // The caller reproduces the single-entry probe by taking the first match in this order,
+        // so the ordering is the contract, not an incidental detail.
+        var now = DateTime.UtcNow;
+        SeedReading(now.AddMinutes(-10), 130, "Dexcom G7 DXCMRf");
+        SeedReading(now, 134, "Dexcom G7 DXCMRf");
+        SeedReading(now.AddMinutes(-5), 132, "Dexcom G7 DXCMRf");
+        SeedReading(now.AddMinutes(-40), 120, "Dexcom G7 DXCMRf");
+
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
+            ["Dexcom G7 DXCMRf"], now.AddMinutes(-15), now.AddMinutes(5));
+
+        candidates.Select(c => c.Mgdl).Should().Equal(134, 132, 130);
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateCandidatesAsync_FiltersToTheNamedDevices()
+    {
+        var now = DateTime.UtcNow;
+        SeedReading(now, 134, "Dexcom G7 DXCMRf");
+        SeedReading(now, 135, "xdrip");
+        SeedReading(now, 136, "dexcom-connector");
+
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
+            ["Dexcom G7 DXCMRf", "xdrip"], now.AddMinutes(-5), now.AddMinutes(5));
+
+        candidates.Select(c => c.Mgdl).Should().BeEquivalentTo(new[] { 134d, 135d });
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateCandidatesAsync_NoDevices_ReturnsEveryDevice()
+    {
+        var now = DateTime.UtcNow;
+        SeedReading(now, 134, "Dexcom G7 DXCMRf");
+        SeedReading(now, 135, "xdrip");
+
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
+            devices: null, now.AddMinutes(-5), now.AddMinutes(5));
+
+        candidates.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateCandidatesAsync_KeepsNonPrimaryCopiesAndDropsDeletedRows()
+    {
+        // Same raw-storage semantics as the single-entry probe: hidden duplicate copies count as
+        // stored, soft-deleted rows do not.
+        var now = DateTime.UtcNow;
+        var hiddenId = SeedReading(now, 134, "Dexcom G7 DXCMRf");
+        LinkNonPrimary(hiddenId, now);
+        var deletedId = SeedReading(now.AddMinutes(-1), 133, "Dexcom G7 DXCMRf");
+        var deleted = _context.SensorGlucose.IgnoreQueryFilters().Single(e => e.Id == deletedId);
+        deleted.DeletedAt = now;
+        _context.SaveChanges();
+
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
+            ["Dexcom G7 DXCMRf"], now.AddMinutes(-5), now.AddMinutes(5));
+
+        candidates.Select(c => c.Id).Should().Equal(hiddenId);
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateCandidatesAsync_OtherTenantsRows_AreExcluded()
+    {
+        var otherTenant = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var now = DateTime.UtcNow;
+        _context.Tenants.Add(new TenantEntity { Id = otherTenant, Slug = "other" });
+        _context.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = otherTenant,
+            Timestamp = now,
+            Mgdl = 134,
+            Device = "Dexcom G7 DXCMRf",
+        });
+        _context.SaveChanges();
+
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
+            ["Dexcom G7 DXCMRf"], now.AddMinutes(-5), now.AddMinutes(5));
+
+        candidates.Should().BeEmpty();
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
@@ -205,8 +205,7 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
         SeedReading(now.AddMinutes(-5), 132, "Dexcom G7 DXCMRf");
         SeedReading(now.AddMinutes(-40), 120, "Dexcom G7 DXCMRf");
 
-        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
-            ["Dexcom G7 DXCMRf"], now.AddMinutes(-15), now.AddMinutes(5));
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(["Dexcom G7 DXCMRf"], now.AddMinutes(-15), now.AddMinutes(5), limit: 1000);
 
         candidates.Select(c => c.Mgdl).Should().Equal(134, 132, 130);
     }
@@ -223,8 +222,7 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
         SeedReading(now, 134, "Dexcom G7 DXCMRf", higher);
         SeedReading(now, 134, "Dexcom G7 DXCMRf", lower);
 
-        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
-            ["Dexcom G7 DXCMRf"], now.AddMinutes(-5), now.AddMinutes(5));
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(["Dexcom G7 DXCMRf"], now.AddMinutes(-5), now.AddMinutes(5), limit: 1000);
 
         candidates.Select(c => c.Id).Should().Equal(higher, lower);
     }
@@ -237,8 +235,7 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
         SeedReading(now, 135, "xdrip");
         SeedReading(now, 136, "dexcom-connector");
 
-        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
-            ["Dexcom G7 DXCMRf", "xdrip"], now.AddMinutes(-5), now.AddMinutes(5));
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(["Dexcom G7 DXCMRf", "xdrip"], now.AddMinutes(-5), now.AddMinutes(5), limit: 1000);
 
         candidates.Select(c => c.Mgdl).Should().BeEquivalentTo(new[] { 134d, 135d });
     }
@@ -250,8 +247,7 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
         SeedReading(now, 134, "Dexcom G7 DXCMRf");
         SeedReading(now, 135, "xdrip");
 
-        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
-            devices: null, now.AddMinutes(-5), now.AddMinutes(5));
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(devices: null, now.AddMinutes(-5), now.AddMinutes(5), limit: 1000);
 
         candidates.Should().HaveCount(2);
     }
@@ -269,8 +265,7 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
         deleted.DeletedAt = now;
         _context.SaveChanges();
 
-        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
-            ["Dexcom G7 DXCMRf"], now.AddMinutes(-5), now.AddMinutes(5));
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(["Dexcom G7 DXCMRf"], now.AddMinutes(-5), now.AddMinutes(5), limit: 1000);
 
         candidates.Select(c => c.Id).Should().Equal(hiddenId);
     }
@@ -291,8 +286,7 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
         });
         _context.SaveChanges();
 
-        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
-            ["Dexcom G7 DXCMRf"], now.AddMinutes(-5), now.AddMinutes(5));
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(["Dexcom G7 DXCMRf"], now.AddMinutes(-5), now.AddMinutes(5), limit: 1000);
 
         candidates.Should().BeEmpty();
     }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
@@ -50,9 +50,9 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private Guid SeedReading(DateTime timestamp, double mgdl, string device)
+    private Guid SeedReading(DateTime timestamp, double mgdl, string device, Guid? forcedId = null)
     {
-        var id = Guid.NewGuid();
+        var id = forcedId ?? Guid.NewGuid();
         _context.SensorGlucose.Add(new SensorGlucoseEntity
         {
             Id = id,
@@ -209,6 +209,24 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
             ["Dexcom G7 DXCMRf"], now.AddMinutes(-15), now.AddMinutes(5));
 
         candidates.Select(c => c.Mgdl).Should().Equal(134, 132, 130);
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateCandidatesAsync_TiedTimestamps_ReturnTheHigherIdFirst()
+    {
+        // The batch caller takes the first match, so this ordering IS the tie-break the
+        // single-entry probe resolves by. Sorting the other way silently changes which stored
+        // reading an upload is told it already has.
+        var now = DateTime.UtcNow;
+        var lower = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var higher = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        SeedReading(now, 134, "Dexcom G7 DXCMRf", higher);
+        SeedReading(now, 134, "Dexcom G7 DXCMRf", lower);
+
+        var candidates = await _repo.FindStoredDuplicateCandidatesAsync(
+            ["Dexcom G7 DXCMRf"], now.AddMinutes(-5), now.AddMinutes(5));
+
+        candidates.Select(c => c.Id).Should().Equal(higher, lower);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1281.

`POST /api/v1/entries` checked every submitted entry for a stored duplicate one at a time —
`EntryService.CheckForDuplicateEntryAsync` per entry, each its own `DbContext` and pooled
connection (`set_config`, the probe, `DISCARD ALL`). One tenant's Loop uploader re-sends a
~7,000-reading backlog every 5-minute cycle in 1,000-entry POSTs, which made that probe the
most-executed statement in the hosted database: 95 M calls since 2026-07-14, 0.98 rows per call.

## The batch probe, for sgv only

`IEntryStore.CheckDuplicatesAsync` (and `IEntryService.CheckForDuplicateEntriesAsync`) take the
whole batch and return one result per submitted entry, in submission order. The `sgv` entries are
classified against stored readings loaded once per chunk; `mbg` and `cal` keep the per-entry probe.

That split is deliberate and it is the correctness boundary of this change. The per-entry `mbg`
probe reads a **device-filtered page of 100** rows from the entry's own ±5-minute window. A
batch-wide read is a strict superset of that, so it reports duplicates the per-entry probe does
not — and a suppressed write there is a lost fingerstick. Only `sgv` arrives in the volumes that
motivate batching (all 95 M calls are `sgv`), so the other types are left exactly as they were and
classification is identical for every type.

For `sgv`, parity rests on two things:

- `FindStoredDuplicateCandidatesAsync` returns candidates in the single-entry probe's own order
  (`timestamp DESC, id DESC`) and the in-memory match takes the **first** candidate that fits.
  Scanning a database-ordered list rather than re-sorting keeps Postgres's `uuid` tie-break, which
  a .NET `Guid` comparison would not reproduce.
- A probe with no device matches a reading from any device, so a batch containing one falls back to
  fetching every device rather than the devices the other entries named.

The per-entry echo semantics NightscoutKit depends on are untouched: `PartitionStoredEntriesAsync`
(now shared by the sync and async endpoints) still returns one response object per submitted entry,
the stored one for a duplicate. `V3 EntriesController.CreateEntry` is single-entry and keeps the
existing call, which is now the same query with a `LIMIT 1`.

## Bounding the query

One query per chunk is only safe if a batch cannot make that query read unbounded rows. Two
separate things have to be bounded, and only one of them is about the batch:

- **The chunk's window.** Probes are chunked by time: a chunk continues while each entry is within
  an hour of its *neighbour*, its whole span is within 7 days, and it holds fewer than 500 entries.
  The gap is measured against the neighbour rather than the chunk's start on purpose — a budget
  that grows with the entry count is walked open by entries spaced just under it, each paying for
  the next, which is how 169 entries could buy a single seven-day query.
- **The rows inside that window**, which is the tenant's ingest density and nothing the batch can
  constrain. So the candidate read is capped at 20,000 rows, and a chunk whose window holds more
  falls back to the per-entry probe — one row per entry. That fallback is the only bound here that
  holds whatever the density is.

A 1,000-entry 5-minutely backlog is 2 chunks and 2 queries; two entries a week apart are two
10-minute queries. The worst case is one chunk per entry — the per-entry probing this replaces — so
no batch is worse off than before.

Matching does not trust the chunking either: each probe re-checks that a candidate is inside its
own window. The binary search that finds the probe's slice is therefore an optimisation, not a
correctness dependency — without the re-check, an off-by-one there would report a reading outside
the window as a duplicate and drop a real one.

Matching is a binary search to each probe's slice of the (sorted) candidate list plus an early
`break`, not a full scan per probe, and the per-probe loop honours cancellation. The naive version
was quadratic in the batch and worst on the all-new-data path, i.e. the ordinary upload.

Note for whoever picks up Npgsql auto-prepare next: the multi-device filter is a new `= ANY($1)` on
the entries write path. It is custom-planned today because nothing configures auto-prepare, and the
generic plan for that shape has been measured at 19 s against 200 ms. There is a comment at the
query saying so.

## Making the loop visible

An upload of ≥100 entries that is ≥95 % already stored now logs one Information line with the two
counts and the request's `User-Agent` — truncated, with control, Unicode format and
line/paragraph-separator characters folded to spaces (logs are line-oriented at the console
exporter and shipped verbatim over OTLP, so a header value could otherwise forge a log line or
spoof how one reads), and no entry values. Nightscout's own `cgm-remote-monitor` answers such a batch the same way this does —
the stored records echoed back — and Loop accepts that, so the reason this client keeps retrying is
on the client side. The log line is what lets someone find the next tenant in this state from the
logs instead of from `pg_stat_statements`.

## Tests

- `EntryReadServiceBatchProbeParityTests` — real repositories over SQLite. A 288-entry re-upload of
  a stored day issues **one** `sensor_glucose` SELECT (counted by a `DbCommandInterceptor`); a
  12-entry mixed batch classifies **identically** to running `CheckDuplicateAsync` over the same
  entries one at a time; the window is inclusive at both ends and exclusive one millisecond
  further out; tied timestamps echo the row the per-entry probe echoes, and specifically the
  higher id; a device differing only by case is not a duplicate; an `mbg` window holding more than
  100 rows still agrees with the per-entry probe and costs no `sensor_glucose` query; a reading
  whose only copy is linked non-primary is still a duplicate.
- `EntryReadServiceTests` — one query for a contiguous batch and none of the old per-entry probe;
  separate queries for probes a week apart; every probe's own ±window covered by some query's
  window; no query wider than the span cap; entries spaced at the budget not walking it upwards;
  at most 500 entries per chunk; the single-device, multi-device and no-device filters; non-sgv
  types keeping the per-entry probe; an unknown type costing no query at all; results aligned with
  submission order when the batch arrives newest-first.
- `SensorGlucoseRepositoryDuplicateProbeTests` — the candidate query's ordering including the id
  tie-break under tied timestamps (the parity contract), device filtering in its one-device,
  multi-device and no-device forms, non-primary copies kept, soft-deleted rows and other tenants'
  rows excluded.
- `EntriesControllerTests` — the re-upload line fires once for a large all-stored batch and names
  the uploader, strips control characters from the User-Agent, and stays silent for a small batch
  and for a large batch that is half new.

Mutation-checked across two review rounds. Caught: the span cap, the neighbour gap, the entry cap,
the row cap and its fallback, the id tie-break direction, case-sensitivity of both the device match
and the device set, `sgv` routing (so `"SGV"` cannot reach the batch read), batching `mbg`, both
window ends, a reading outside a probe's own window, the User-Agent sanitiser and its length cap,
cancellation, the device and value predicates, the null-device fallback, the duplicate echo, and
the re-upload thresholds.

Two mutations survive individually and are equivalent mutants rather than gaps: breaking the binary
search's bound, and removing the per-probe window re-check. Either alone is harmless because the
other covers it; applied **together** they fail the suite, which is the data-loss scenario the pair
exists to prevent.

