### PR TITLE
perf(alerts): evaluate once per canonical reading, not once per published batch

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
+using Nocturne.API.Services.Alerts;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.API.Helpers;
@@ -575,7 +576,7 @@ public class EntriesController : ControllerBase
             _logger.LogDebug("Created {Count} entries", createdArray.Length);
 
             // Evaluate alert rules against the latest created entry
-            await EvaluateAlertsAsync(createdArray, cancellationToken);
+            await _alertEvaluator.EvaluateForEntriesAsync(createdArray, cancellationToken);
 
             return StatusCode(201, responseEntries.ToV1Responses());
         }
@@ -1235,11 +1236,4 @@ public class EntriesController : ControllerBase
         }
     }
 
-    private async Task EvaluateAlertsAsync(Entry[] entries, CancellationToken ct)
-    {
-        // Alarms evaluate against the canonical stream, not the just-uploaded batch — a losing
-        // CGM's readings must not trigger or suppress an alarm.
-        if (entries.Any(e => e.Sgv is > 0))
-            await _alertEvaluator.EvaluateAsync(ct);
-    }
 }

--- a/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
@@ -1,3 +1,4 @@
+using Nocturne.API.Services.Alerts;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -256,7 +257,7 @@ public class EntriesController : BaseV3Controller<Entry>
 
             _logger.LogDebug("Successfully created V3 entry {Id}", createdEntry.Id);
 
-            await EvaluateAlertsAsync(new[] { createdEntry }, cancellationToken);
+            await _alertEvaluator.EvaluateForEntriesAsync([createdEntry], cancellationToken);
 
             // Location resolves to the 24-hex ObjectId that matches the response body identifier.
             return CreatedAtAction(
@@ -333,7 +334,7 @@ public class EntriesController : BaseV3Controller<Entry>
                 createdEntries.Count()
             );
 
-            await EvaluateAlertsAsync(createdEntries.ToArray(), cancellationToken);
+            await _alertEvaluator.EvaluateForEntriesAsync(createdEntries, cancellationToken);
 
             return StatusCode(201, createdEntries.ToV3Responses());
         }
@@ -625,14 +626,6 @@ public class EntriesController : BaseV3Controller<Entry>
         // Use the most recent entry's date as last modified
         var latestMills = entries.Max(e => e.Mills);
         return DateTimeOffset.FromUnixTimeMilliseconds(latestMills);
-    }
-
-    private async Task EvaluateAlertsAsync(Entry[] entries, CancellationToken ct)
-    {
-        // Alarms evaluate against the canonical stream, not the just-uploaded batch — a losing
-        // CGM's readings must not trigger or suppress an alarm.
-        if (entries.Any(e => e.Sgv is > 0))
-            await _alertEvaluator.EvaluateAsync(ct);
     }
 
     #endregion

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -1,3 +1,4 @@
+using Nocturne.API.Services.Alerts;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
@@ -163,8 +164,7 @@ public class SensorGlucoseController(
     /// </remarks>
     protected override async Task<SensorGlucose[]> OnAfterBulkCreateAsync(SensorGlucose[] written, CancellationToken ct)
     {
-        if (written.Any(r => r.Mgdl > 0))
-            await alertEvaluator.EvaluateAsync(ct);
+        await alertEvaluator.EvaluateForReadingsAsync(written, ct);
 
         return written;
     }
@@ -187,8 +187,7 @@ public class SensorGlucoseController(
 
     protected override async Task<SensorGlucose> OnAfterCreateAsync(SensorGlucose created, CancellationToken ct)
     {
-        if (created.Mgdl > 0)
-            await alertEvaluator.EvaluateAsync(ct);
+        await alertEvaluator.EvaluateForReadingsAsync([created], ct);
 
         return created;
     }

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -602,6 +602,7 @@ public static class ServiceRegistrationExtensions
         // Canonical glucose stream (single-stream view for v1/v3, alarms, unfiltered analytics)
         services.AddScoped<ICanonicalGlucoseService, CanonicalGlucoseService>();
         services.AddScoped<ICanonicalAlertEvaluator, CanonicalAlertEvaluator>();
+        services.AddSingleton<AlertEvaluationWatermark>();
 
         // Coach marks
         services.AddScoped<ICoachMarkService, CoachMarkService>();

--- a/src/API/Nocturne.API/Services/Alerts/AlertEvaluationWatermark.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertEvaluationWatermark.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Services.Alerts;
+
+/// <summary>
+/// Remembers, per tenant, the canonical reading the last completed alert evaluation ran against,
+/// so a write that did not move the canonical stream does not repeat the pass.
+/// </summary>
+/// <remarks>
+/// A single sync publishes glucose in chunks — a page per fetch, a batch per page — and an
+/// uploader that re-posts already-stored readings publishes on every request; each of those calls
+/// the evaluator, and each evaluation re-decides against the same latest canonical reading.
+/// Singleton because <see cref="ICanonicalAlertEvaluator"/> is scoped and those chunks span
+/// scopes. Keyed by tenant, so the entry count is bounded by tenant count.
+/// <para>
+/// The reading is recorded only after a pass completes, so an evaluation that threw is retried by
+/// the next write instead of being skipped as already done.
+/// </para>
+/// </remarks>
+/// <seealso cref="CanonicalAlertEvaluator"/>
+internal sealed class AlertEvaluationWatermark
+{
+    private readonly ConcurrentDictionary<Guid, EvaluatedReading> _lastEvaluated = new();
+
+    /// <summary>
+    /// True when the last completed pass for this tenant already evaluated exactly this reading.
+    /// Compares the three fields that make up the evaluated <c>SensorContext</c> rather than the
+    /// row's identity: a corrected value or trend at an unchanged timestamp is a different
+    /// decision and must be evaluated, and a same-valued replacement row is not.
+    /// </summary>
+    public bool AlreadyEvaluated(Guid tenantId, SensorGlucose reading) =>
+        _lastEvaluated.TryGetValue(tenantId, out var previous) && previous == Snapshot(reading);
+
+    /// <summary>
+    /// Records the reading a completed pass evaluated, replacing any earlier one for the tenant.
+    /// </summary>
+    public void Record(Guid tenantId, SensorGlucose reading) =>
+        _lastEvaluated[tenantId] = Snapshot(reading);
+
+    private static EvaluatedReading Snapshot(SensorGlucose reading) =>
+        new(reading.Timestamp, reading.Mgdl, reading.TrendRate);
+
+    private readonly record struct EvaluatedReading(DateTime Timestamp, double Mgdl, double? TrendRate);
+}

--- a/src/API/Nocturne.API/Services/Alerts/AlertEvaluationWatermark.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertEvaluationWatermark.cs
@@ -15,32 +15,55 @@ namespace Nocturne.API.Services.Alerts;
 /// Singleton because <see cref="ICanonicalAlertEvaluator"/> is scoped and those chunks span
 /// scopes. Keyed by tenant, so the entry count is bounded by tenant count.
 /// <para>
-/// The reading is recorded only after a pass completes, so an evaluation that threw is retried by
-/// the next write instead of being skipped as already done.
+/// The skip expires after <see cref="MaxSkipWindow"/>. A rule can turn true on elapsed time alone
+/// while the reading stands still — <c>alert_state</c> with <c>forMinutes</c>, the documented way
+/// to express delayed escalation, is the sharpest case, and nothing in <see cref="AlertSweepService"/>
+/// opens an excursion for it — so the reading is a reason to skip a repeat, never a reason to stop
+/// evaluating. The window also bounds a rule the user has just created or edited, and a pass the
+/// orchestrator completed with some rule's exception swallowed internally.
 /// </para>
 /// </remarks>
 /// <seealso cref="CanonicalAlertEvaluator"/>
-internal sealed class AlertEvaluationWatermark
+internal sealed class AlertEvaluationWatermark(TimeProvider timeProvider)
 {
-    private readonly ConcurrentDictionary<Guid, EvaluatedReading> _lastEvaluated = new();
+    /// <summary>
+    /// Longest a repeat pass may be skipped. Comparable to the interval between the repeats it
+    /// replaces (the measured ~8 publishes per reading), so a clock-driven rule is at most this
+    /// late rather than indefinitely frozen.
+    /// </summary>
+    internal static readonly TimeSpan MaxSkipWindow = TimeSpan.FromSeconds(60);
+
+    private readonly ConcurrentDictionary<Guid, Pass> _lastPass = new();
 
     /// <summary>
-    /// True when the last completed pass for this tenant already evaluated exactly this reading.
-    /// Compares the three fields that make up the evaluated <c>SensorContext</c> rather than the
-    /// row's identity: a corrected value or trend at an unchanged timestamp is a different
-    /// decision and must be evaluated, and a same-valued replacement row is not.
+    /// True when a pass inside the last <see cref="MaxSkipWindow"/> already evaluated exactly this
+    /// reading. Compares the three fields that make up the evaluated <c>SensorContext</c> rather
+    /// than the row's identity: a corrected value or trend at an unchanged timestamp is a
+    /// different decision and must be evaluated, and a same-valued replacement row is not.
     /// </summary>
     public bool AlreadyEvaluated(Guid tenantId, SensorGlucose reading) =>
-        _lastEvaluated.TryGetValue(tenantId, out var previous) && previous == Snapshot(reading);
+        _lastPass.TryGetValue(tenantId, out var previous)
+        && previous.Reading == Key(reading)
+        && timeProvider.GetUtcNow() - previous.At < MaxSkipWindow;
 
     /// <summary>
     /// Records the reading a completed pass evaluated, replacing any earlier one for the tenant.
     /// </summary>
-    public void Record(Guid tenantId, SensorGlucose reading) =>
-        _lastEvaluated[tenantId] = Snapshot(reading);
+    /// <remarks>
+    /// <see cref="Guid.Empty"/> means no tenant was in scope, and the orchestrator returns before
+    /// its first read in that case; nothing was evaluated, so nothing is remembered. Refusing the
+    /// write here is what keeps <see cref="AlreadyEvaluated"/> from ever matching on that key.
+    /// </remarks>
+    public void Record(Guid tenantId, SensorGlucose reading)
+    {
+        if (tenantId == Guid.Empty) return;
+        _lastPass[tenantId] = new Pass(Key(reading), timeProvider.GetUtcNow());
+    }
 
-    private static EvaluatedReading Snapshot(SensorGlucose reading) =>
+    private static ReadingKey Key(SensorGlucose reading) =>
         new(reading.Timestamp, reading.Mgdl, reading.TrendRate);
 
-    private readonly record struct EvaluatedReading(DateTime Timestamp, double Mgdl, double? TrendRate);
+    private readonly record struct ReadingKey(DateTime Timestamp, double Mgdl, double? TrendRate);
+
+    private readonly record struct Pass(ReadingKey Reading, DateTimeOffset At);
 }

--- a/src/API/Nocturne.API/Services/Alerts/AlertEvaluationWatermark.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertEvaluationWatermark.cs
@@ -33,6 +33,14 @@ internal sealed class AlertEvaluationWatermark(TimeProvider timeProvider)
     /// </summary>
     internal static readonly TimeSpan MaxSkipWindow = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    /// Measured with <see cref="TimeProvider.GetTimestamp"/> rather than a wall clock: an NTP
+    /// correction that steps the clock backwards would make the age of a recorded pass negative,
+    /// which reads as "well inside the window" and reinstates the unbounded skip this window
+    /// exists to prevent, for as long as the step.
+    /// </summary>
+    private readonly TimeProvider _timeProvider = timeProvider;
+
     private readonly ConcurrentDictionary<Guid, Pass> _lastPass = new();
 
     /// <summary>
@@ -44,7 +52,7 @@ internal sealed class AlertEvaluationWatermark(TimeProvider timeProvider)
     public bool AlreadyEvaluated(Guid tenantId, SensorGlucose reading) =>
         _lastPass.TryGetValue(tenantId, out var previous)
         && previous.Reading == Key(reading)
-        && timeProvider.GetUtcNow() - previous.At < MaxSkipWindow;
+        && _timeProvider.GetElapsedTime(previous.At) < MaxSkipWindow;
 
     /// <summary>
     /// Records the reading a completed pass evaluated, replacing any earlier one for the tenant.
@@ -57,7 +65,7 @@ internal sealed class AlertEvaluationWatermark(TimeProvider timeProvider)
     public void Record(Guid tenantId, SensorGlucose reading)
     {
         if (tenantId == Guid.Empty) return;
-        _lastPass[tenantId] = new Pass(Key(reading), timeProvider.GetUtcNow());
+        _lastPass[tenantId] = new Pass(Key(reading), _timeProvider.GetTimestamp());
     }
 
     private static ReadingKey Key(SensorGlucose reading) =>
@@ -65,5 +73,5 @@ internal sealed class AlertEvaluationWatermark(TimeProvider timeProvider)
 
     private readonly record struct ReadingKey(DateTime Timestamp, double Mgdl, double? TrendRate);
 
-    private readonly record struct Pass(ReadingKey Reading, DateTimeOffset At);
+    private readonly record struct Pass(ReadingKey Reading, long At);
 }

--- a/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
+++ b/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
 
 namespace Nocturne.API.Services.Alerts;
@@ -9,19 +10,32 @@ namespace Nocturne.API.Services.Alerts;
 /// <see cref="ICanonicalGlucoseService"/> and hands a <see cref="SensorContext"/> to the
 /// <see cref="IAlertOrchestrator"/>.
 /// </summary>
+/// <remarks>
+/// Callers publish in chunks and re-publish readings they have already stored, so the same
+/// canonical reading arrives here many times over; <see cref="AlertEvaluationWatermark"/> keeps
+/// the orchestrator pass to once per reading. Rules that turn on elapsed time rather than on a
+/// new reading — signal loss, hysteresis closure, snooze expiry, auto-resolve, tracker age — are
+/// owned by <see cref="AlertSweepService"/>'s own timer and are unaffected by that skip.
+/// </remarks>
 internal sealed class CanonicalAlertEvaluator : ICanonicalAlertEvaluator
 {
     private readonly ICanonicalGlucoseService _canonicalGlucose;
     private readonly IAlertOrchestrator _alertOrchestrator;
+    private readonly ITenantAccessor _tenantAccessor;
+    private readonly AlertEvaluationWatermark _watermark;
     private readonly ILogger<CanonicalAlertEvaluator> _logger;
 
     public CanonicalAlertEvaluator(
         ICanonicalGlucoseService canonicalGlucose,
         IAlertOrchestrator alertOrchestrator,
+        ITenantAccessor tenantAccessor,
+        AlertEvaluationWatermark watermark,
         ILogger<CanonicalAlertEvaluator> logger)
     {
         _canonicalGlucose = canonicalGlucose ?? throw new ArgumentNullException(nameof(canonicalGlucose));
         _alertOrchestrator = alertOrchestrator ?? throw new ArgumentNullException(nameof(alertOrchestrator));
+        _tenantAccessor = tenantAccessor ?? throw new ArgumentNullException(nameof(tenantAccessor));
+        _watermark = watermark ?? throw new ArgumentNullException(nameof(watermark));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -33,6 +47,12 @@ internal sealed class CanonicalAlertEvaluator : ICanonicalAlertEvaluator
             var latest = await _canonicalGlucose.GetLatestAsync(ct);
             if (latest is null || latest.Mgdl <= 0) return;
 
+            // Guid.Empty means no tenant is in scope; the orchestrator returns before its first
+            // read in that case, so there is nothing for the watermark to save.
+            var tenantId = _tenantAccessor.TenantId;
+            if (tenantId != Guid.Empty && _watermark.AlreadyEvaluated(tenantId, latest))
+                return;
+
             var context = new SensorContext
             {
                 LatestValue = (decimal)latest.Mgdl,
@@ -42,6 +62,9 @@ internal sealed class CanonicalAlertEvaluator : ICanonicalAlertEvaluator
             };
 
             await _alertOrchestrator.EvaluateAsync(context, ct);
+
+            if (tenantId != Guid.Empty)
+                _watermark.Record(tenantId, latest);
         }
         catch (OperationCanceledException) { throw; }
         catch (InvalidOperationException ex)

--- a/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
+++ b/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
@@ -50,7 +50,12 @@ internal sealed class CanonicalAlertEvaluator : ICanonicalAlertEvaluator
 
             var tenantId = _tenantAccessor.TenantId;
             if (_watermark.AlreadyEvaluated(tenantId, latest))
+            {
+                _logger.LogTrace(
+                    "Alert evaluation skipped for tenant {TenantId}: reading at {ReadingTimestamp} was already evaluated",
+                    tenantId, latest.Timestamp);
                 return;
+            }
 
             var context = new SensorContext
             {

--- a/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
+++ b/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
@@ -12,10 +12,11 @@ namespace Nocturne.API.Services.Alerts;
 /// </summary>
 /// <remarks>
 /// Callers publish in chunks and re-publish readings they have already stored, so the same
-/// canonical reading arrives here many times over; <see cref="AlertEvaluationWatermark"/> keeps
-/// the orchestrator pass to once per reading. Rules that turn on elapsed time rather than on a
-/// new reading — signal loss, hysteresis closure, snooze expiry, auto-resolve, tracker age — are
-/// owned by <see cref="AlertSweepService"/>'s own timer and are unaffected by that skip.
+/// canonical reading arrives here many times over; <see cref="AlertEvaluationWatermark"/> collapses
+/// those repeats to one pass per reading per
+/// <see cref="AlertEvaluationWatermark.MaxSkipWindow"/>. Signal loss, hysteresis closure, snooze
+/// expiry, auto-resolve and tracker age are owned by <see cref="AlertSweepService"/>'s own timer;
+/// every other clock-driven rule is covered by the skip window rather than by the sweep.
 /// </remarks>
 internal sealed class CanonicalAlertEvaluator : ICanonicalAlertEvaluator
 {
@@ -47,10 +48,8 @@ internal sealed class CanonicalAlertEvaluator : ICanonicalAlertEvaluator
             var latest = await _canonicalGlucose.GetLatestAsync(ct);
             if (latest is null || latest.Mgdl <= 0) return;
 
-            // Guid.Empty means no tenant is in scope; the orchestrator returns before its first
-            // read in that case, so there is nothing for the watermark to save.
             var tenantId = _tenantAccessor.TenantId;
-            if (tenantId != Guid.Empty && _watermark.AlreadyEvaluated(tenantId, latest))
+            if (_watermark.AlreadyEvaluated(tenantId, latest))
                 return;
 
             var context = new SensorContext
@@ -63,8 +62,7 @@ internal sealed class CanonicalAlertEvaluator : ICanonicalAlertEvaluator
 
             await _alertOrchestrator.EvaluateAsync(context, ct);
 
-            if (tenantId != Guid.Empty)
-                _watermark.Record(tenantId, latest);
+            _watermark.Record(tenantId, latest);
         }
         catch (OperationCanceledException) { throw; }
         catch (InvalidOperationException ex)

--- a/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluatorExtensions.cs
+++ b/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluatorExtensions.cs
@@ -1,0 +1,27 @@
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Models;
+
+namespace Nocturne.API.Services.Alerts;
+
+/// <summary>
+/// The gate every glucose write shares before it asks for an alert pass: a CGM reading is the
+/// trigger each glucose alert condition is written against, so a batch carrying no positive
+/// sensor value — an empty publish, or one holding only fingersticks, calibrations or
+/// sensor-error sentinels — is not a trigger and must not spend an evaluation.
+/// </summary>
+/// <seealso cref="ICanonicalAlertEvaluator"/>
+internal static class CanonicalAlertEvaluatorExtensions
+{
+    /// <summary>
+    /// Evaluates alert rules when <paramref name="entries"/> carries at least one CGM reading.
+    /// </summary>
+    /// <remarks>
+    /// Evaluation reads the canonical latest from storage rather than these entries, so which
+    /// reading is newest does not matter here — only whether a CGM reading landed at all.
+    /// </remarks>
+    public static Task EvaluateForEntriesAsync(
+        this ICanonicalAlertEvaluator evaluator,
+        IEnumerable<Entry> entries,
+        CancellationToken ct) =>
+        entries.Any(e => e.Sgv is > 0) ? evaluator.EvaluateAsync(ct) : Task.CompletedTask;
+}

--- a/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluatorExtensions.cs
+++ b/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluatorExtensions.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Services.Alerts;
 
@@ -24,4 +25,11 @@ internal static class CanonicalAlertEvaluatorExtensions
         IEnumerable<Entry> entries,
         CancellationToken ct) =>
         entries.Any(e => e.Sgv is > 0) ? evaluator.EvaluateAsync(ct) : Task.CompletedTask;
+
+    /// <inheritdoc cref="EvaluateForEntriesAsync"/>
+    public static Task EvaluateForReadingsAsync(
+        this ICanonicalAlertEvaluator evaluator,
+        IEnumerable<SensorGlucose> readings,
+        CancellationToken ct) =>
+        readings.Any(r => r.Mgdl > 0) ? evaluator.EvaluateAsync(ct) : Task.CompletedTask;
 }

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/ConnectorPublisherBase.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/ConnectorPublisherBase.cs
@@ -33,7 +33,7 @@ internal abstract class ConnectorPublisherBase
     /// <paramref name="beforeWrite"/> runs inside the system audit scope: a preparation step that
     /// writes (an auto-created insulin, a reconcile of the source's window) is attributed to the sync,
     /// and a user-attributed delete would permanently block re-import. <paramref name="afterWrite"/>
-    /// runs after a successful write, outside the scope.
+    /// runs after a successful write, outside the scope, over the same materialised list.
     /// </summary>
     protected async Task<bool> PublishAsync<TRecord>(
         IEnumerable<TRecord> records,
@@ -42,7 +42,7 @@ internal abstract class ConnectorPublisherBase
         WriteOrigin origin,
         CancellationToken ct,
         Func<List<TRecord>, Task>? beforeWrite = null,
-        Func<Task>? afterWrite = null)
+        Func<List<TRecord>, Task>? afterWrite = null)
     {
         var recordType = typeof(TRecord).Name;
         try
@@ -59,7 +59,7 @@ internal abstract class ConnectorPublisherBase
             }
 
             if (afterWrite is not null)
-                await afterWrite();
+                await afterWrite(recordList);
 
             Logger.LogDebug(
                 "Published {Count} {RecordType} records for {Source}", recordList.Count, recordType, source);

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -73,9 +73,9 @@ internal sealed class GlucosePublisher : ConnectorPublisherBase, IGlucosePublish
     }
 
     /// <remarks>
-    /// Alert evaluation after the write is this publisher's one addition to the shared shape: a CGM
-    /// reading is the trigger every glucose alert condition is written against.
+    /// Alert evaluation after the write is this publisher's one addition to the shared shape.
     /// </remarks>
+    /// <seealso cref="CanonicalAlertEvaluatorExtensions.EvaluateForReadingsAsync"/>
     public Task<bool> PublishSensorGlucoseAsync(
         IEnumerable<SensorGlucose> records,
         string source,
@@ -84,7 +84,7 @@ internal sealed class GlucosePublisher : ConnectorPublisherBase, IGlucosePublish
             records, _sensorGlucoseRepository, source, origin, cancellationToken,
             beforeWrite: recordList => _patientDeviceStamper.StampAsync(
                 recordList, DeviceAttributionCategories.SensorGlucose, source, cancellationToken),
-            afterWrite: () => _alertEvaluator.EvaluateAsync(cancellationToken));
+            afterWrite: recordList => _alertEvaluator.EvaluateForReadingsAsync(recordList, cancellationToken));
 
     /// <inheritdoc cref="ConnectorPublisherBase.LatestTimestampAsync" />
     /// <remarks>

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Services.Alerts;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
@@ -44,6 +45,11 @@ internal sealed class GlucosePublisher : ConnectorPublisherBase, IGlucosePublish
         _alertEvaluator = alertEvaluator ?? throw new ArgumentNullException(nameof(alertEvaluator));
     }
 
+    /// <remarks>
+    /// Empty batches skip the write for the reason <see cref="ConnectorPublisherBase.PublishAsync"/>
+    /// does: a connector sync that found nothing new still calls its publishers, and a write of no
+    /// records has nothing for the entry service or for an alert pass to decide against.
+    /// </remarks>
     public async Task<bool> PublishEntriesAsync(
         IEnumerable<Entry> entries,
         string source,
@@ -52,8 +58,10 @@ internal sealed class GlucosePublisher : ConnectorPublisherBase, IGlucosePublish
         try
         {
             var entryList = entries.ToList();
+            if (entryList.Count == 0) return true;
+
             await _entryService.CreateEntriesAsync(entryList, origin, cancellationToken);
-            await _alertEvaluator.EvaluateAsync(cancellationToken);
+            await _alertEvaluator.EvaluateForEntriesAsync(entryList, cancellationToken);
             return true;
         }
         catch (OperationCanceledException) { throw; }

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/CanonicalAlertEvaluatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/CanonicalAlertEvaluatorTests.cs
@@ -1,0 +1,208 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Alerts;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Alerts;
+
+/// <summary>
+/// The watermark contract: a canonical reading is evaluated once, and the pass that was skipped
+/// is the repeat, never the reading.
+/// </summary>
+[Trait("Category", "Unit")]
+public class CanonicalAlertEvaluatorTests
+{
+    private static readonly Guid Tenant = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly DateTime Reading = new(2026, 9, 9, 7, 15, 0, DateTimeKind.Utc);
+
+    private readonly Mock<ICanonicalGlucoseService> _canonical = new();
+    private readonly Mock<IAlertOrchestrator> _orchestrator = new();
+    private readonly AlertEvaluationWatermark _watermark = new();
+
+    private static SensorGlucose Latest(DateTime timestamp, double mgdl = 120, double? trendRate = 0.5) =>
+        new() { Timestamp = timestamp, Mgdl = mgdl, TrendRate = trendRate };
+
+    private CanonicalAlertEvaluator Evaluator(Guid tenantId) =>
+        new(_canonical.Object,
+            _orchestrator.Object,
+            Mock.Of<ITenantAccessor>(a => a.TenantId == tenantId),
+            _watermark,
+            NullLogger<CanonicalAlertEvaluator>.Instance);
+
+    private void LatestIs(params SensorGlucose?[] readings)
+    {
+        var queue = new Queue<SensorGlucose?>(readings);
+        _canonical
+            .Setup(c => c.GetLatestAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => queue.Count > 1 ? queue.Dequeue() : queue.Peek());
+    }
+
+    private void VerifyPasses(int times) =>
+        _orchestrator.Verify(
+            o => o.EvaluateAsync(It.IsAny<SensorContext>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(times));
+
+    [Fact]
+    public async Task EvaluateAsync_EvaluatesTheFirstTimeAReadingIsSeen()
+    {
+        LatestIs(Latest(Reading));
+
+        await Evaluator(Tenant).EvaluateAsync();
+
+        VerifyPasses(1);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SkipsARepeatOfTheSameReading()
+    {
+        // A sync publishes in chunks and an uploader re-posts stored readings, so the same
+        // canonical reading arrives here many times over.
+        LatestIs(Latest(Reading));
+        var evaluator = Evaluator(Tenant);
+
+        await evaluator.EvaluateAsync();
+        await evaluator.EvaluateAsync();
+        await evaluator.EvaluateAsync();
+
+        VerifyPasses(1);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SkipsARepeatAcrossScopes()
+    {
+        // The evaluator is scoped and a connector's chunks span scopes, so the watermark has to
+        // outlive the instance that recorded it.
+        LatestIs(Latest(Reading));
+
+        await Evaluator(Tenant).EvaluateAsync();
+        await Evaluator(Tenant).EvaluateAsync();
+
+        VerifyPasses(1);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_EvaluatesAgainWhenTheStreamAdvances()
+    {
+        LatestIs(Latest(Reading), Latest(Reading.AddMinutes(5)));
+        var evaluator = Evaluator(Tenant);
+
+        await evaluator.EvaluateAsync();
+        await evaluator.EvaluateAsync();
+
+        VerifyPasses(2);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_EvaluatesAgainWhenTheValueIsCorrectedAtTheSameTimestamp()
+    {
+        LatestIs(Latest(Reading, mgdl: 120), Latest(Reading, mgdl: 250));
+        var evaluator = Evaluator(Tenant);
+
+        await evaluator.EvaluateAsync();
+        await evaluator.EvaluateAsync();
+
+        VerifyPasses(2);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_EvaluatesAgainWhenOnlyTheTrendRateChanges()
+    {
+        LatestIs(Latest(Reading, trendRate: 0.5), Latest(Reading, trendRate: -3.5));
+        var evaluator = Evaluator(Tenant);
+
+        await evaluator.EvaluateAsync();
+        await evaluator.EvaluateAsync();
+
+        VerifyPasses(2);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_EvaluatesAgainWhenAnEarlierReadingBecomesLatest()
+    {
+        // A delete of the newest row moves the canonical latest backwards; that is a different
+        // decision, not a repeat of one already made.
+        LatestIs(Latest(Reading), Latest(Reading.AddMinutes(-5)));
+        var evaluator = Evaluator(Tenant);
+
+        await evaluator.EvaluateAsync();
+        await evaluator.EvaluateAsync();
+
+        VerifyPasses(2);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_RetriesAReadingWhosePassFailed()
+    {
+        LatestIs(Latest(Reading));
+        _orchestrator
+            .SetupSequence(o => o.EvaluateAsync(It.IsAny<SensorContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("engine unavailable"))
+            .Returns(Task.CompletedTask);
+        var evaluator = Evaluator(Tenant);
+
+        await evaluator.EvaluateAsync();
+        await evaluator.EvaluateAsync();
+
+        VerifyPasses(2);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_KeepsAWatermarkPerTenant()
+    {
+        var other = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        LatestIs(Latest(Reading));
+
+        await Evaluator(Tenant).EvaluateAsync();
+        await Evaluator(other).EvaluateAsync();
+
+        VerifyPasses(2);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_DoesNotSkipWhenNoTenantIsInScope()
+    {
+        // With no tenant the orchestrator returns before its first read, so there is nothing to
+        // remember and nothing a shared watermark could correctly stand for.
+        LatestIs(Latest(Reading));
+
+        await Evaluator(Guid.Empty).EvaluateAsync();
+        await Evaluator(Guid.Empty).EvaluateAsync();
+
+        VerifyPasses(2);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_DoesNotEvaluateWithoutAPositiveReading()
+    {
+        LatestIs(Latest(Reading, mgdl: 0));
+
+        await Evaluator(Tenant).EvaluateAsync();
+
+        VerifyPasses(0);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_PassesTheCanonicalReadingIntoTheContext()
+    {
+        LatestIs(Latest(Reading, mgdl: 187, trendRate: -1.5));
+        SensorContext? seen = null;
+        _orchestrator
+            .Setup(o => o.EvaluateAsync(It.IsAny<SensorContext>(), It.IsAny<CancellationToken>()))
+            .Callback<SensorContext, CancellationToken>((c, _) => seen = c)
+            .Returns(Task.CompletedTask);
+
+        await Evaluator(Tenant).EvaluateAsync();
+
+        seen.Should().NotBeNull();
+        seen!.LatestValue.Should().Be(187m);
+        seen.LatestTimestamp.Should().Be(Reading);
+        seen.TrendRate.Should().Be(-1.5m);
+        seen.LastReadingAt.Should().Be(Reading);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/CanonicalAlertEvaluatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/CanonicalAlertEvaluatorTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Nocturne.API.Services.Alerts;
 using Nocturne.Core.Contracts.Alerts;
@@ -23,7 +24,10 @@ public class CanonicalAlertEvaluatorTests
 
     private readonly Mock<ICanonicalGlucoseService> _canonical = new();
     private readonly Mock<IAlertOrchestrator> _orchestrator = new();
-    private readonly AlertEvaluationWatermark _watermark = new();
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(Reading, TimeSpan.Zero));
+    private readonly AlertEvaluationWatermark _watermark;
+
+    public CanonicalAlertEvaluatorTests() => _watermark = new AlertEvaluationWatermark(_clock);
 
     private static SensorGlucose Latest(DateTime timestamp, double mgdl = 120, double? trendRate = 0.5) =>
         new() { Timestamp = timestamp, Mgdl = mgdl, TrendRate = trendRate };
@@ -165,10 +169,50 @@ public class CanonicalAlertEvaluatorTests
     }
 
     [Fact]
+    public async Task EvaluateAsync_EvaluatesTheSameReadingAgainOnceTheSkipWindowExpires()
+    {
+        // A rule can turn true on elapsed time alone while the reading stands still: alert_state
+        // with forMinutes is the documented way to express delayed escalation, and no sweep path
+        // opens an excursion for it. The reading is a reason to skip a repeat, not to stop.
+        LatestIs(Latest(Reading));
+        var evaluator = Evaluator(Tenant);
+
+        await evaluator.EvaluateAsync();
+        _clock.Advance(AlertEvaluationWatermark.MaxSkipWindow - TimeSpan.FromMilliseconds(1));
+        await evaluator.EvaluateAsync();
+        VerifyPasses(1);
+
+        _clock.Advance(TimeSpan.FromMilliseconds(1));
+        await evaluator.EvaluateAsync();
+
+        VerifyPasses(2);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_RestartsTheSkipWindowFromTheLatestPass()
+    {
+        // The window measures staleness of the last pass, not of the first sighting, so a stream
+        // of repeats cannot walk the tenant past it without ever evaluating.
+        LatestIs(Latest(Reading));
+        var evaluator = Evaluator(Tenant);
+
+        await evaluator.EvaluateAsync();
+        _clock.Advance(AlertEvaluationWatermark.MaxSkipWindow);
+        await evaluator.EvaluateAsync();
+        VerifyPasses(2);
+
+        _clock.Advance(AlertEvaluationWatermark.MaxSkipWindow - TimeSpan.FromSeconds(1));
+        await evaluator.EvaluateAsync();
+
+        VerifyPasses(2);
+    }
+
+    [Fact]
     public async Task EvaluateAsync_DoesNotSkipWhenNoTenantIsInScope()
     {
-        // With no tenant the orchestrator returns before its first read, so there is nothing to
-        // remember and nothing a shared watermark could correctly stand for.
+        // With no tenant the orchestrator returns before its first read, so nothing was evaluated
+        // and nothing is remembered; refusing that write is what keeps every tenantless caller
+        // from sharing one key.
         LatestIs(Latest(Reading));
 
         await Evaluator(Guid.Empty).EvaluateAsync();

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/CanonicalAlertEvaluatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/CanonicalAlertEvaluatorTests.cs
@@ -169,6 +169,14 @@ public class CanonicalAlertEvaluatorTests
     }
 
     [Fact]
+    public void MaxSkipWindow_IsOneMinute()
+    {
+        // The bound on how late a clock-driven escalation can be. The window tests below are
+        // written against the symbol, so without this the value itself is free to drift.
+        AlertEvaluationWatermark.MaxSkipWindow.Should().Be(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
     public async Task EvaluateAsync_EvaluatesTheSameReadingAgainOnceTheSkipWindowExpires()
     {
         // A rule can turn true on elapsed time alone while the reading stands still: alert_state

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -25,6 +25,7 @@ public class GlucosePublisherTests
     private readonly Mock<ISensorGlucoseRepository> _mockSensorGlucoseRepository;
     private readonly Mock<IMeterGlucoseRepository> _mockMeterGlucoseRepository;
     private readonly Mock<IPatientDeviceStamper> _mockPatientDeviceStamper;
+    private readonly Mock<ICanonicalAlertEvaluator> _mockAlertEvaluator;
     private readonly GlucosePublisher _publisher;
 
     public GlucosePublisherTests()
@@ -33,13 +34,14 @@ public class GlucosePublisherTests
         _mockSensorGlucoseRepository = new Mock<ISensorGlucoseRepository>();
         _mockMeterGlucoseRepository = new Mock<IMeterGlucoseRepository>();
         _mockPatientDeviceStamper = new Mock<IPatientDeviceStamper>();
+        _mockAlertEvaluator = new Mock<ICanonicalAlertEvaluator>();
 
         _publisher = new GlucosePublisher(
             _mockEntryService.Object,
             _mockSensorGlucoseRepository.Object,
             _mockMeterGlucoseRepository.Object,
             _mockPatientDeviceStamper.Object,
-            Mock.Of<ICanonicalAlertEvaluator>(),
+            _mockAlertEvaluator.Object,
             Mock.Of<IAuditContext>(),
             NullLogger<GlucosePublisher>.Instance
         );
@@ -87,9 +89,56 @@ public class GlucosePublisherTests
             .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("test error"));
 
-        var result = await _publisher.PublishEntriesAsync(new List<Entry>(), "test-source", WriteOrigin.Live);
+        var result = await _publisher.PublishEntriesAsync(
+            new List<Entry> { new() { Id = "1", Sgv = 120 } }, "test-source", WriteOrigin.Live);
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PublishEntriesAsync_WritesNothing_ForAnEmptyBatch()
+    {
+        // A connector sync that found nothing new still calls its publishers; the sibling
+        // PublishAsync has always skipped that, this path did not.
+        var result = await _publisher.PublishEntriesAsync([], "test-source", WriteOrigin.Live);
+
+        result.Should().BeTrue();
+        _mockEntryService.Verify(
+            s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockAlertEvaluator.Verify(e => e.EvaluateAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PublishEntriesAsync_EvaluatesAlerts_ForACgmReading()
+    {
+        var entries = new List<Entry> { new() { Id = "1", Sgv = 120 } };
+        _mockEntryService
+            .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entries);
+
+        await _publisher.PublishEntriesAsync(entries, "test-source", WriteOrigin.Live);
+
+        _mockAlertEvaluator.Verify(e => e.EvaluateAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishEntriesAsync_DoesNotEvaluateAlerts_ForABatchWithNoCgmReading()
+    {
+        // Fingersticks, calibrations and sensor-error sentinels are written but are not the
+        // trigger any glucose alert condition is written against.
+        var entries = new List<Entry> { new() { Id = "1", Mbg = 96 }, new() { Id = "2", Sgv = 0 } };
+        _mockEntryService
+            .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entries);
+
+        var result = await _publisher.PublishEntriesAsync(entries, "test-source", WriteOrigin.Live);
+
+        result.Should().BeTrue();
+        _mockEntryService.Verify(
+            s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockAlertEvaluator.Verify(e => e.EvaluateAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -169,6 +169,67 @@ public class GlucosePublisherTests
     }
 
     [Fact]
+    public async Task PublishSensorGlucoseAsync_EvaluatesAlerts_ForACgmReading()
+    {
+        // This is the alarm trigger for every v4 connector -- Dexcom, Libre, CareLink, Glooko,
+        // Tandem, twiist, Eversense, Tidepool, MyLife -- and nothing asserted on it.
+        var records = new List<SensorGlucose>
+        {
+            new() { Mgdl = 0, Timestamp = DateTime.UtcNow.AddMinutes(-5), DataSource = DataSources.DexcomConnector },
+            new() { Mgdl = 130, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
+        };
+        _mockSensorGlucoseRepository
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(records);
+
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
+
+        result.Should().BeTrue();
+        _mockAlertEvaluator.Verify(e => e.EvaluateAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishSensorGlucoseAsync_DoesNotEvaluateAlerts_ForSensorErrorSentinelsAlone()
+    {
+        // A batch of non-positive readings cannot move the canonical latest, so the pass could
+        // only re-decide a reading that was already evaluated when it landed.
+        var records = new List<SensorGlucose>
+        {
+            new() { Mgdl = 0, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
+        };
+        _mockSensorGlucoseRepository
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(records);
+
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
+
+        result.Should().BeTrue();
+        _mockSensorGlucoseRepository.Verify(
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockAlertEvaluator.Verify(e => e.EvaluateAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PublishSensorGlucoseAsync_EvaluatesAlerts_EvenWhenDedupDropsEveryWrittenRow()
+    {
+        // The gate reads the records the publisher was handed, not the rows BulkCreateAsync
+        // returned. Fail-safe by design: over-evaluating costs a watermark-suppressed pass,
+        // whereas gating on an empty dedup result would drop the alarm for a real reading.
+        var records = new List<SensorGlucose>
+        {
+            new() { Mgdl = 130, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
+        };
+        _mockSensorGlucoseRepository
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
+
+        _mockAlertEvaluator.Verify(e => e.EvaluateAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task PublishSensorGlucoseAsync_StampsRecordsAsCgm_BeforeWriting()
     {
         var records = new List<SensorGlucose>


### PR DESCRIPTION
Closes #1285.

Alert evaluation ran once per *publish call*, not once per new reading. A connector sync
publishes a page per fetch and a batch per page, and an uploader that re-posts already-stored
readings publishes on every request — each of those calls `ICanonicalAlertEvaluator.EvaluateAsync`,
and each re-decides against the same latest canonical reading, which cannot have changed between
chunks of one sync.

## Measured before (hosted instance, `pg_stat_statements` windowed diff, 361 s, 07:18:48–07:24:48Z)

Total 88,261 statements (244/s), 0.043 cores of execution, ceremony (`set_config` + `DISCARD ALL`)
56,348 = 63.8 %.

The per-pass signature is unmistakable — five distinct single-row shapes at **exactly 840 calls each**:

| read | calls / 361 s |
|---|---|
| `in_app_notifications` | 840 |
| `alert_instances` join | 840 |
| `alert_excursions` (`hysteresis_started_at`) | 840 |
| `alert_rules` (rule set) | 840 |
| `alert_rules` (`condition_params` by type) | 840 |
| `alert_tracker_state` / per-rule detail / update | 540 / 270 / 135 |
| **`INSERT INTO sensor_glucose`, same window** | **102** |

840 passes in 361 s = **140 per minute**, against a stream that produces roughly one reading per
tenant per five minutes — about 8 passes per reading. Execution time is not the problem (the whole
window executes in 0.043 cores); statement count and planning are, as #1278 describes.

## Fix

**A per-tenant watermark on the evaluation, with a bounded skip window.**
`AlertEvaluationWatermark` (singleton, keyed by tenant, bounded by tenant count) remembers the
canonical reading the last *completed* pass evaluated and when. `CanonicalAlertEvaluator` returns
before the orchestrator's reads when the reading it just resolved is that same one **and** the
recorded pass is younger than `MaxSkipWindow` (60 s), measured on `TimeProvider`'s **monotonic**
timestamp.

- The reading is compared on `(Timestamp, Mgdl, TrendRate)` — the three fields that make up the
  `SensorContext`. A corrected value or trend at an unchanged timestamp is a different decision and
  is still evaluated; a same-valued replacement row is not. A canonical latest that moves
  *backwards* (a delete of the newest row) is also evaluated — the check is "is this the same
  reading", not "has it advanced".
- Singleton because the evaluator is scoped and a connector's chunks span scopes. This also covers
  the multipliers a hoist out of `PublishGlucoseDataInBatchesAsync` would not: `CrawlAndPublishAsync`
  publishes per *page* as well as per batch, and a re-posting uploader publishes per *request*.
- **Why the window, and why 60 s.** An unbounded skip is not "one reading interval late", it is
  indefinite: nothing invalidates the entry. `alert_state` with `forMinutes` is the documented way
  to express delayed escalation (`AlertOrchestrator`'s own remarks), it is purely clock-driven
  against the parent excursion's `triggered_at` (`AlertStateEvaluator.cs:70-77`), and **no
  `AlertSweepService` path opens an excursion for it**. Urgent low fires; the sensor then drops out;
  the connector keeps re-publishing its overlapping window. Before this change each of those
  republish passes re-evaluated the escalation rule and it opened at `forMinutes`. With an unbounded
  skip it would never open. 60 s is comparable to the interval between the ~8 repeats per reading it
  replaces, so a clock-driven rule is at most a minute late rather than frozen. It costs roughly one
  extra pass per tenant per minute — an order of magnitude below the 840.
- **Why monotonic.** With `GetUtcNow()`, an NTP correction that steps the clock backwards makes the
  age of a recorded pass negative, which reads as "well inside the window" and reinstates the
  indefinite freeze for as long as the step. `Record` stamps `GetTimestamp()` and `AlreadyEvaluated`
  uses `GetElapsedTime`, so the hazard is gone by construction rather than guarded against.

**The gate that was copied four times, now shared.** The v1 and v3 entries controllers each carried
an identical private `EvaluateAlertsAsync`; the v4 `SensorGlucose` create and bulk-create paths
carried two more copies of the same idea over a different type; `PublishEntriesAsync` and
`PublishSensorGlucoseAsync` had none. All six call sites now go through
`EvaluateForEntriesAsync` / `EvaluateForReadingsAsync`, and `ConnectorPublisherBase.PublishAsync`
hands `afterWrite` the materialised list to make that possible, mirroring `beforeWrite`.

**The empty-batch guard on `PublishEntriesAsync`** (issue item 1) is consistency with its sibling
`ConnectorPublisherBase.PublishAsync`, **not** a measured multiplier — see the corrections below.

## Behavioural deltas, declared

1. **Clock-driven rules are re-evaluated at most every 60 s per tenant** instead of on every
   publish. Signal loss, hysteresis closure, snooze expiry, auto-resolve and tracker age are owned
   by `AlertSweepService`'s 30 s timer and are unaffected; every other clock-driven root
   (`alert_state`, `staleness`, `site_age`, `sensor_age`, `loop_stale`, `time_of_day`,
   `time_since_last_bolus`, `sustained`, ...) is covered by the skip window. Both mechanisms still
   require *something* to publish, exactly as before.
2. **`ConfirmationReadings` regains its literal meaning.** `ExcursionTracker.ProcessEvaluationAsync`
   increments `ConfirmationCount` once per *pass*, so at ~8 passes per reading a rule with
   `ConfirmationReadings = 3` previously confirmed inside a single sync against a single reading;
   it now needs three distinct readings. That matches the field's name and the tracker's own
   comment, and is latent today — nothing in the codebase sets it above the model default of 1 —
   but it is a real change to alarm timing and is called out rather than discovered later.
3. **A batch of only fingersticks, calibrations or sensor-error sentinels no longer spends a pass.**
   Those cannot move the canonical latest (`CanonicalGlucoseService.GetLatestAsync` reads only
   `ISensorGlucoseRepository`) and no condition type consumes meter glucose, so the pass could only
   ever have re-decided an already-evaluated reading — which the skip window now governs anyway.
   This is a new delta on `PublishSensorGlucoseAsync`, which previously had no gate at all.
4. **`PublishEntriesAsync` returns `true` without writing for an empty list.** Its only caller chain
   (`PublishGlucoseDataInBatchesAsync` from `NightscoutConnectorService`) already returns early on an
   empty array, and `EntryService.CreateEntriesAsync` returns before any I/O, so no caller can
   observe the difference.

## Corrections to #1285 and to the first revision of this description

- **The issue's "second multiplier" is unreachable in production.** #1285 presents
  `PublishEntriesAsync`'s missing empty-batch guard as an observed load multiplier. It is not:
  `PublishGlucoseDataInBatchesAsync` returns `true` on an empty array before ever calling it, every
  non-Nightscout connector uses `PublishSensorGlucoseAsync` (whose base has always had the guard),
  and `EntryService.CreateEntriesAsync` short-circuits an empty list. The guard is worth having for
  shape consistency; it contributes zero to the measured 840.
- **The first revision claimed "all four now go through `EvaluateForEntriesAsync`".** That was
  wrong — the v4 controller was not in the diff and still had two copies. It is now, via the
  `SensorGlucose` overload.
- **The skip is now observable.** A suppressed evaluation used to return silently, which is a poor
  property for a safety-critical path; it logs at `Trace`.
- **"Recorded only after the pass completes, so a failed pass is retried" holds only for exceptions
  that escape the orchestrator.** `AlertOrchestrator` catches and logs every *per-rule* exception
  and returns normally, so a pass in which one rule's evaluation or dispatch threw is still recorded
  as complete. The skip window is what bounds that, to 60 s.
- **The parity corpus cannot see this change.** `AlertEngineCorpusTests` drives
  `IAlertEvaluationEngine` directly, below the evaluator, with explicit ticks — it neither confirms
  nor denies a de-duplication above the seam. It stays green (managed; rust skipped, no native lib
  locally), which is the correct null result. The semantics argument rests on reading the sweep, not
  on the corpus.

## Tests

`CanonicalAlertEvaluatorTests` (new, 15 cases): `MaxSkipWindow` is 60 s; first sighting evaluates; repeats skip, including
across evaluator instances; an advanced timestamp, a corrected value, a changed trend rate and a
backwards-moving latest each evaluate; the same reading evaluates again once `MaxSkipWindow`
expires, and the window restarts from the latest pass rather than the first sighting; a pass that
threw is retried; watermarks are per tenant; `Guid.Empty` never skips; a non-positive reading never
evaluates; the context carries the canonical reading's fields.

`GlucosePublisherTests` gains six cases: the entries empty-batch, sgv and no-sgv paths, and three on
`PublishSensorGlucoseAsync` — the alarm trigger for every v4 connector, which had no assertion
anywhere in the repo. One of them pins the deliberate asymmetry with the v4 controller: the
publisher's gate reads the records it was handed, not the rows `BulkCreateAsync` returned, because
gating on an empty dedup result would drop the alarm for a real reading.
`PublishEntriesAsync_ReturnsFalse_OnException` passed an empty list and relied on the write throwing
— it now passes a reading, since an empty batch is no longer a write.

**Mutation matrix** — 24 mutations across three revisions, every survivor now killed. Round 1 left
two alive (removing either of the then-redundant `Guid.Empty` guards); the single-guard restructure
kills both. Round 2 left four alive (`MaxSkipWindow` at 600 s and at 6 s, handing `afterWrite` an
empty list, and removing the `EvaluateForReadingsAsync` gate); the window assertion and the three
`PublishSensorGlucoseAsync` tests kill all four. Also killed: dropping `TrendRate` from the key;
dropping `Timestamp`; comparing timestamp only; recording before the orchestrator call; removing the
empty-batch guard; `Any()` instead of `Any(sgv > 0)`; `>= 0` instead of `> 0`; `<=` instead of `<`
on the window boundary; a tenant-blind watermark key; and replacing the monotonic elapsed time with
a wall-clock difference.

One survivor is an equivalent mutant, not a coverage gap: making the reading key ignore `Mgdl`'s
sign cannot be observed, because `CanonicalAlertEvaluator` returns on `Mgdl <= 0` before the
watermark is consulted, so the key never sees a non-positive value.

`dotnet test tests/Unit/Nocturne.API.Tests --filter "Category!=Integration&Category!=Performance&Category!=E2E"`:
**6,767 passed, 5 skipped, 0 failed**, rebased onto `aed38197d` (#1284).

## After

The before-window is above. The after-window will be measured on the same instance once this
deploys, comparing the 840-call families and `INSERT INTO sensor_glucose` over an equivalent window,
and posted here.

https://claude.ai/code/session_0117tEAEX1NBKcNkNiVKuCWV
