### PR TITLE
fix(web): round insulin and carb amounts on entry timelines

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/RecentTreatmentsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/RecentTreatmentsCard.svelte
@@ -9,6 +9,7 @@
   } from "$lib/components/ui/card";
   import { Badge } from "$lib/components/ui/badge";
   import { time } from "$lib/utils/formatting";
+  import { entryDetails, entryLabel } from "$lib/utils/entry-summary";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { EntryEditDialog } from "$lib/components/entries";
 
@@ -42,39 +43,6 @@
     isDialogOpen = true;
   }
 
-  function getEntryLabel(entry: EntryRecord): string {
-    switch (entry.kind) {
-      case "bolus":
-        return entry.data.insulin ? `${entry.data.insulin}u insulin` : "Bolus";
-      case "carbs":
-        return entry.data.carbs ? `${entry.data.carbs}g carbs` : "Carbs";
-      case "bgCheck":
-        return entry.data.mgdl ? `${entry.data.mgdl} mg/dL` : "BG Check";
-      case "note":
-        return entry.data.text ?? "Note";
-      case "deviceEvent":
-        return entry.data.eventType ?? "Device Event";
-      case "basalInjection":
-        return entry.data.units ? `${entry.data.units}u basal` : "Long-acting injection";
-    }
-  }
-
-  function getEntryDetails(entry: EntryRecord): string {
-    switch (entry.kind) {
-      case "bolus":
-        return entry.data.bolusType ?? "";
-      case "carbs":
-        return "";
-      case "bgCheck":
-        return entry.data.glucoseType ?? "";
-      case "note":
-        return entry.data.isAnnouncement ? "Announcement" : "";
-      case "deviceEvent":
-        return entry.data.notes ?? "";
-      case "basalInjection":
-        return entry.data.insulinContext?.insulinName ?? "";
-    }
-  }
 </script>
 
 <Card class="@container">
@@ -116,9 +84,9 @@
                 </Badge>
                 <div>
                   <div class="font-medium">
-                    {getEntryLabel(entry)}
-                    {#if getEntryDetails(entry)}
-                      <span class="text-muted-foreground"> - {getEntryDetails(entry)}</span>
+                    {entryLabel(entry)}
+                    {#if entryDetails(entry)}
+                      <span class="text-muted-foreground"> - {entryDetails(entry)}</span>
                     {/if}
                   </div>
                   <div class="text-sm text-muted-foreground">

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ChartTooltip.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ChartTooltip.svelte
@@ -3,7 +3,13 @@
   import { cn } from "$lib/utils";
   import { goto } from "$app/navigation";
   import { BasalDeliveryOrigin, ChartSpanKind } from "$lib/api";
-  import { bg, bgLabel, time } from "$lib/utils/formatting";
+  import {
+    bg,
+    bgLabel,
+    formatCarbDisplay,
+    formatInsulinDisplay,
+    time,
+  } from "$lib/utils/formatting";
   import { getGlucoseChartContext } from "./chart-context.svelte";
   import { isBasalAdjusted } from "./engine/basal-presentation";
   import type { GlucosePoint } from "./engine/chart-data-engine.svelte";
@@ -96,7 +102,7 @@
       {#if showBolus && nearbyBolus}
         <Tooltip.Item
           label="Bolus"
-          value={`${(nearbyBolus.insulin ?? 0).toFixed(1)}U`}
+          value={`${formatInsulinDisplay(nearbyBolus.insulin ?? 0)}U`}
           color="var(--insulin-bolus)"
           class="font-medium"
         />
@@ -104,7 +110,7 @@
       {#if showCarbs && nearbyCarbs}
         <Tooltip.Item
           label="Carbs"
-          value={`${nearbyCarbs.carbs ?? 0}g`}
+          value={`${formatCarbDisplay(nearbyCarbs.carbs ?? 0)}g`}
           color="var(--carbs)"
           class="font-medium"
         />

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentDisambiguationDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentDisambiguationDialog.svelte
@@ -5,6 +5,7 @@
   import { Button } from "$lib/components/ui/button";
   import * as Dialog from "$lib/components/ui/dialog";
   import { time } from "$lib/utils/formatting";
+  import { entrySummary } from "$lib/utils/entry-summary";
 
   interface Props {
     open: boolean;
@@ -14,29 +15,6 @@
   }
 
   let { open = $bindable(), entries, onSelect, onClose }: Props = $props();
-
-  function formatEntrySummary(entry: EntryRecord): string {
-    const parts: string[] = [];
-    switch (entry.kind) {
-      case "bolus":
-        if (entry.data.insulin) parts.push(`${entry.data.insulin}U`);
-        if (entry.data.bolusType) parts.push(entry.data.bolusType);
-        break;
-      case "carbs":
-        if (entry.data.carbs) parts.push(`${entry.data.carbs}g carbs`);
-        break;
-      case "bgCheck":
-        if (entry.data.mgdl) parts.push(`${entry.data.mgdl} mg/dL`);
-        break;
-      case "note":
-        if (entry.data.text) parts.push(entry.data.text.slice(0, 50));
-        break;
-      case "deviceEvent":
-        if (entry.data.eventType) parts.push(entry.data.eventType);
-        break;
-    }
-    return parts.join(" · ") || ENTRY_CATEGORIES[entry.kind].name;
-  }
 </script>
 
 <Dialog.Root bind:open>
@@ -57,7 +35,7 @@
         >
           <div class="flex-1">
             <div class="font-medium text-sm">
-              {formatEntrySummary(entry)}
+              {entrySummary(entry)}
             </div>
             <div class="text-xs text-muted-foreground">
               {entry.data.mills

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentInspectionDialog.svelte
@@ -2,8 +2,16 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import { Badge } from "$lib/components/ui/badge";
   import { Syringe } from "lucide-svelte";
-  import { bg, bgLabel, formatLocale, time } from "$lib/utils/formatting";
+  import {
+    bg,
+    bgLabel,
+    formatCarbDisplay,
+    formatInsulinDisplay,
+    formatLocale,
+    time,
+  } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
+  import { entrySummary } from "$lib/utils/entry-summary";
   import type { BolusCalculation } from "$lib/api";
   import { CalculationType } from "$lib/api";
   import type { EntryRecord } from "$lib/constants/entry-categories";
@@ -84,13 +92,13 @@
   const treatmentSummary = $derived.by(() => {
     const parts: string[] = [];
     if (bolusInsulin != null) {
-      let bolusText = `${bolusInsulin}U`;
+      let bolusText = `${formatInsulinDisplay(bolusInsulin)}U`;
       if (bolusType) bolusText += ` ${bolusType}`;
       else bolusText += " bolus";
       parts.push(bolusText);
     }
     if (carbGrams != null) {
-      let carbText = `${carbGrams}g carbs`;
+      let carbText = `${formatCarbDisplay(carbGrams)}g carbs`;
       if (carbLabel) carbText += ` (${carbLabel})`;
       parts.push(carbText);
     }
@@ -100,10 +108,11 @@
   // Build the chart center label
   const chartLabel = $derived.by(() => {
     if (bolusInsulin != null && carbGrams != null) {
-      return `${bolusInsulin}U + ${carbGrams}g`;
+      return `${formatInsulinDisplay(bolusInsulin)}U + ${formatCarbDisplay(carbGrams)}g`;
     }
-    if (bolusInsulin != null) return `${bolusInsulin}U bolus`;
-    if (carbGrams != null) return `${carbGrams}g carbs`;
+    if (bolusInsulin != null)
+      return `${formatInsulinDisplay(bolusInsulin)}U bolus`;
+    if (carbGrams != null) return `${formatCarbDisplay(carbGrams)}g carbs`;
     return undefined;
   });
 
@@ -122,29 +131,6 @@
     }
   });
 
-  // Format entry summary for correlated records (matches TreatmentDisambiguationDialog)
-  function formatEntrySummary(record: EntryRecord): string {
-    const parts: string[] = [];
-    switch (record.kind) {
-      case "bolus":
-        if (record.data.insulin) parts.push(`${record.data.insulin}U`);
-        if (record.data.bolusType) parts.push(record.data.bolusType);
-        break;
-      case "carbs":
-        if (record.data.carbs) parts.push(`${record.data.carbs}g carbs`);
-        break;
-      case "bgCheck":
-        if (record.data.mgdl) parts.push(`${record.data.mgdl} mg/dL`);
-        break;
-      case "note":
-        if (record.data.text) parts.push(record.data.text.slice(0, 50));
-        break;
-      case "deviceEvent":
-        if (record.data.eventType) parts.push(record.data.eventType);
-        break;
-    }
-    return parts.join(" · ") || ENTRY_CATEGORIES[record.kind].name;
-  }
 
   // Fetch the bolus calculation behind the treatment on open
   $effect(() => {
@@ -177,7 +163,7 @@
             class="{ENTRY_CATEGORIES.bolus.colorClass} {ENTRY_CATEGORIES.bolus.bgClass} {ENTRY_CATEGORIES.bolus.borderClass}"
           >
             <Syringe class="mr-1 h-3.5 w-3.5" />
-            {bolusInsulin}U{bolusType ? ` ${bolusType}` : ""}
+            {formatInsulinDisplay(bolusInsulin)}U{bolusType ? ` ${bolusType}` : ""}
           </Badge>
         {/if}
         {#if carbGrams != null}
@@ -185,7 +171,7 @@
             variant="outline"
             class="{ENTRY_CATEGORIES.carbs.colorClass} {ENTRY_CATEGORIES.carbs.bgClass} {ENTRY_CATEGORIES.carbs.borderClass}"
           >
-            {carbGrams}g{carbLabel ? ` ${carbLabel}` : " carbs"}
+            {formatCarbDisplay(carbGrams)}g{carbLabel ? ` ${carbLabel}` : " carbs"}
           </Badge>
         {/if}
       </Dialog.Title>
@@ -331,7 +317,7 @@
             >
               <div class="flex-1">
                 <div class="font-medium text-sm">
-                  {formatEntrySummary(record)}
+                  {entrySummary(record)}
                 </div>
                 <div class="text-xs text-muted-foreground">
                   {record.data.mills

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/point-inspection.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/point-inspection.svelte.ts
@@ -4,7 +4,12 @@ import type {
   SeriesPoint,
 } from "./chart-data-engine.svelte";
 import { type BasalPoint, BasalDeliveryOrigin } from "$lib/api";
-import { bg, bgLabel } from "$lib/utils/formatting";
+import {
+  bg,
+  bgLabel,
+  formatCarbDisplay,
+  formatInsulinDisplay,
+} from "$lib/utils/formatting";
 
 // ===== Types =====
 
@@ -108,10 +113,10 @@ export function createPointInspection(
     if (context.nearbyBolus || context.nearbyCarbs) {
       const parts: string[] = [];
       if (context.nearbyBolus?.insulin) {
-        parts.push(`${context.nearbyBolus.insulin.toFixed(1)}U`);
+        parts.push(`${formatInsulinDisplay(context.nearbyBolus.insulin)}U`);
       }
       if (context.nearbyCarbs?.carbs) {
-        parts.push(`${context.nearbyCarbs.carbs}g`);
+        parts.push(`${formatCarbDisplay(context.nearbyCarbs.carbs)}g`);
       }
       opts.push({
         type: "treatment",

--- a/src/Web/packages/app/src/lib/components/meals/MealBolusDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/meals/MealBolusDialog.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { formatClock, formatLocale } from "$lib/utils/formatting";
+  import {
+    formatClock,
+    formatInsulinDisplay,
+    formatLocale,
+  } from "$lib/utils/formatting";
   import type { MealEvent, Bolus, BolusType, PatientInsulin } from "$lib/api";
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
@@ -272,7 +276,7 @@
                     <span class="text-sm font-medium">
                       {formatBolusTime(bolus.mills)}
                     </span>
-                    <span class="text-sm">{bolus.insulin}U</span>
+                    <span class="text-sm">{formatInsulinDisplay(bolus.insulin)}U</span>
                     {#if bolus.bolusType}
                       <Badge variant="secondary" class="text-xs">
                         {bolus.bolusType}

--- a/src/Web/packages/app/src/lib/components/reports/TreatmentEvents.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/TreatmentEvents.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { formatLocale } from "$lib/utils/formatting";
+  import {
+    formatCarbDisplay,
+    formatInsulinDisplay,
+    formatLocale,
+  } from "$lib/utils/formatting";
   import type { TreatmentDataItem } from "./types";
 
   interface Props {
@@ -24,9 +28,9 @@
               minute: "2-digit",
             })}
             {#if treatment.insulin}
-              • {treatment.insulin}U{/if}
+              • {formatInsulinDisplay(treatment.insulin)}U{/if}
             {#if treatment.carbs}
-              • {treatment.carbs}g carbs{/if}
+              • {formatCarbDisplay(treatment.carbs)}g carbs{/if}
           </div>
         </div>
       {/each}

--- a/src/Web/packages/app/src/lib/components/status-pills/COBPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/COBPill.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatLocale } from "$lib/utils/formatting";
+  import { formatCarbDisplay, formatLocale } from "$lib/utils/formatting";
   import StatusPill from "./StatusPill.svelte";
   import type {
     COBPillData,
@@ -28,7 +28,7 @@
         hour: "2-digit",
         minute: "2-digit",
       });
-      const amount = `${data.lastCarbs.carbs}g`;
+      const amount = `${formatCarbDisplay(data.lastCarbs.carbs)}g`;
       items.push({ label: "Last Carbs", value: `${amount} @ ${timeStr}` });
 
       // Food description if available

--- a/src/Web/packages/app/src/lib/components/status-pills/IOBPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/IOBPill.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatLocale } from "$lib/utils/formatting";
+  import { formatInsulinDisplay, formatLocale } from "$lib/utils/formatting";
   import StatusPill from "./StatusPill.svelte";
   import type {
     IOBPillData,
@@ -29,7 +29,7 @@
           minute: "2-digit",
         }
       );
-      const amount = `${data.lastBolus.insulin.toFixed(2)}U`;
+      const amount = `${formatInsulinDisplay(data.lastBolus.insulin)}U`;
       items.push({ label: "Last Bolus", value: `${amount} @ ${when}` });
 
       if (data.lastBolus.notes) {

--- a/src/Web/packages/app/src/lib/utils/entry-summary.test.ts
+++ b/src/Web/packages/app/src/lib/utils/entry-summary.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from "vitest";
+
+import type {
+  BGCheck,
+  BasalInjection,
+  Bolus,
+  BolusType,
+  CarbIntake,
+  DeviceEvent,
+  DeviceEventType,
+  GlucoseType,
+  Note,
+} from "$lib/api";
+import type { EntryRecord } from "$lib/constants/entry-categories";
+
+// `entry-summary.ts` reaches `formatting.ts`, which imports the appearance store
+// and the Svelte runtime behind it. Stub the store so Vite never resolves it;
+// none of the amount formatters read a preference.
+vi.mock("$app/environment", () => ({ browser: false }));
+vi.mock("mode-watcher", () => ({}));
+vi.mock("$lib/stores/appearance-store.svelte", () => ({
+  glucoseUnits: { current: "mg/dl" },
+  timeFormat: { current: "12" },
+  regionFormat: { current: "" },
+  preferredLanguage: { current: "en" },
+}));
+
+// Dynamic import so the mocks are established first
+const { entryDetails, entryLabel, entrySummary } =
+  await import("./entry-summary");
+
+const bolus = (data: Bolus): EntryRecord => ({ kind: "bolus", data });
+const carbs = (data: CarbIntake): EntryRecord => ({ kind: "carbs", data });
+const bgCheck = (data: BGCheck): EntryRecord => ({ kind: "bgCheck", data });
+const note = (data: Note): EntryRecord => ({ kind: "note", data });
+const deviceEvent = (data: DeviceEvent): EntryRecord => ({
+  kind: "deviceEvent",
+  data,
+});
+const basalInjection = (data: BasalInjection): EntryRecord => ({
+  kind: "basalInjection",
+  data,
+});
+
+// String enums from the generated client, spelled out rather than imported by
+// value, so the `$lib/api` import stays type-only and this suite runs before the
+// NSwag client has been generated.
+const enums = {
+  normalBolus: "Normal",
+  fingerStick: "Finger",
+  siteChange: "SiteChange",
+} as unknown as {
+  normalBolus: BolusType;
+  fingerStick: GlucoseType;
+  siteChange: DeviceEventType;
+};
+
+// Computed rather than written as literals: both artifacts are longer than a
+// double round-trips, which `no-loss-of-precision` rejects in source.
+const INEXACT_BOLUS = 0.1 + 0.2;
+const INEXACT_CARBS = 45 + 0.1 + 0.2 - 0.3;
+
+describe("entry-summary fixtures", () => {
+  it("holds the exact doubles a stored total can carry", () => {
+    expect(INEXACT_BOLUS.toString()).toBe("0.30000000000000004");
+    expect(INEXACT_CARBS.toString()).toBe("45.00000000000001");
+  });
+});
+
+describe("entryLabel", () => {
+  it("prints a binary-inexact bolus at the insulin convention's two places", () => {
+    expect(entryLabel(bolus({ insulin: INEXACT_BOLUS }))).toBe("0.30u insulin");
+  });
+
+  it("keeps the finest real pump increment distinguishable", () => {
+    expect(entryLabel(bolus({ insulin: 0.05 }))).toBe("0.05u insulin");
+    expect(entryLabel(bolus({ insulin: 0.1 }))).toBe("0.10u insulin");
+    expect(entryLabel(bolus({ insulin: 1.15 }))).toBe("1.15u insulin");
+  });
+
+  it("rounds, rather than truncates, below the second place", () => {
+    expect(entryLabel(bolus({ insulin: 12.345 }))).toBe("12.35u insulin");
+    expect(entryLabel(bolus({ insulin: 12.344 }))).toBe("12.34u insulin");
+  });
+
+  it("names the category when a bolus carries no amount", () => {
+    expect(entryLabel(bolus({}))).toBe("Bolus");
+    expect(entryLabel(bolus({ insulin: 0 }))).toBe("Bolus");
+  });
+
+  it("prints carbs as whole grams", () => {
+    expect(entryLabel(carbs({ carbs: INEXACT_CARBS }))).toBe("45g carbs");
+    expect(entryLabel(carbs({ carbs: 30 }))).toBe("30g carbs");
+    expect(entryLabel(carbs({}))).toBe("Carbs");
+  });
+
+  it("prints a long-acting injection at the same insulin precision", () => {
+    expect(entryLabel(basalInjection({ units: INEXACT_BOLUS }))).toBe(
+      "0.30u basal"
+    );
+    expect(entryLabel(basalInjection({ units: 24 }))).toBe("24.00u basal");
+    expect(entryLabel(basalInjection({}))).toBe("Long-acting injection");
+  });
+
+  it("passes glucose, note and device text through untouched", () => {
+    expect(entryLabel(bgCheck({ mgdl: 112 }))).toBe("112 mg/dL");
+    expect(entryLabel(note({ text: "felt low" }))).toBe("felt low");
+    expect(entryLabel(deviceEvent({ eventType: enums.siteChange }))).toBe(
+      "SiteChange"
+    );
+  });
+});
+
+describe("entryDetails", () => {
+  it("gives the qualifier behind the amount", () => {
+    expect(entryDetails(bolus({ bolusType: enums.normalBolus }))).toBe(
+      "Normal"
+    );
+    expect(entryDetails(bgCheck({ glucoseType: enums.fingerStick }))).toBe(
+      "Finger"
+    );
+    expect(entryDetails(note({ isAnnouncement: true }))).toBe("Announcement");
+    expect(entryDetails(deviceEvent({ notes: "reservoir low" }))).toBe(
+      "reservoir low"
+    );
+    expect(
+      entryDetails(
+        basalInjection({ insulinContext: { insulinName: "Tresiba" } })
+      )
+    ).toBe("Tresiba");
+  });
+
+  it("is empty where a record has no qualifier", () => {
+    expect(entryDetails(bolus({}))).toBe("");
+    expect(entryDetails(carbs({ carbs: 30 }))).toBe("");
+    expect(entryDetails(note({}))).toBe("");
+    expect(entryDetails(basalInjection({}))).toBe("");
+  });
+});
+
+describe("entrySummary", () => {
+  it("prints a binary-inexact bolus at two places", () => {
+    expect(entrySummary(bolus({ insulin: INEXACT_BOLUS }))).toBe("0.30U");
+    expect(
+      entrySummary(
+        bolus({ insulin: INEXACT_BOLUS, bolusType: enums.normalBolus })
+      )
+    ).toBe("0.30U · Normal");
+  });
+
+  it("prints carbs as whole grams", () => {
+    expect(entrySummary(carbs({ carbs: INEXACT_CARBS }))).toBe("45g carbs");
+  });
+
+  it("prints a long-acting injection's units", () => {
+    expect(entrySummary(basalInjection({ units: 24 }))).toBe("24.00U");
+  });
+
+  it("truncates a long note to a preview", () => {
+    expect(entrySummary(note({ text: "a".repeat(80) }))).toBe("a".repeat(50));
+  });
+
+  it("falls back to the category name when nothing is quantified", () => {
+    expect(entrySummary(bolus({}))).toBe("Insulin");
+    expect(entrySummary(carbs({}))).toBe("Carbs");
+    expect(entrySummary(deviceEvent({}))).toBe("Device Events");
+    expect(entrySummary(basalInjection({}))).toBe("Long-acting injection");
+  });
+});

--- a/src/Web/packages/app/src/lib/utils/entry-summary.ts
+++ b/src/Web/packages/app/src/lib/utils/entry-summary.ts
@@ -1,0 +1,95 @@
+/**
+ * Text for a v4 entry record wherever a timeline row, tooltip or picker has to
+ * name one in a single line.
+ *
+ * Amounts go through {@link formatInsulinDisplay} and {@link formatCarbDisplay}
+ * so a stored value keeps its exact magnitude but is never printed at the full
+ * width of a double: a bolus summed from 0.1 + 0.2 is held as
+ * 0.30000000000000004 and has to read as 0.30.
+ */
+
+import type { EntryRecord } from "$lib/constants/entry-categories";
+import { ENTRY_CATEGORIES } from "$lib/constants/entry-categories";
+import { formatCarbDisplay, formatInsulinDisplay } from "$lib/utils/formatting";
+
+/**
+ * The headline line for an entry row — the amount with its unit, or the
+ * category's own name when the record carries no amount to show.
+ */
+export function entryLabel(entry: EntryRecord): string {
+  switch (entry.kind) {
+    case "bolus":
+      return entry.data.insulin
+        ? `${formatInsulinDisplay(entry.data.insulin)}u insulin`
+        : "Bolus";
+    case "carbs":
+      return entry.data.carbs
+        ? `${formatCarbDisplay(entry.data.carbs)}g carbs`
+        : "Carbs";
+    case "bgCheck":
+      return entry.data.mgdl ? `${entry.data.mgdl} mg/dL` : "BG Check";
+    case "note":
+      return entry.data.text ?? "Note";
+    case "deviceEvent":
+      return entry.data.eventType ?? "Device Event";
+    case "basalInjection":
+      return entry.data.units
+        ? `${formatInsulinDisplay(entry.data.units)}u basal`
+        : "Long-acting injection";
+  }
+}
+
+/** The secondary line for an entry row: the qualifier behind the amount. */
+export function entryDetails(entry: EntryRecord): string {
+  switch (entry.kind) {
+    case "bolus":
+      return entry.data.bolusType ?? "";
+    case "carbs":
+      return "";
+    case "bgCheck":
+      return entry.data.glucoseType ?? "";
+    case "note":
+      return entry.data.isAnnouncement ? "Announcement" : "";
+    case "deviceEvent":
+      return entry.data.notes ?? "";
+    case "basalInjection":
+      return entry.data.insulinContext?.insulinName ?? "";
+  }
+}
+
+/** Longest note prefix a one-line summary carries. */
+const NOTE_PREVIEW_LENGTH = 50;
+
+/**
+ * Amount and qualifier on one line, for the compact rows a dialog uses to let
+ * the reader tell several entries at the same minute apart.
+ */
+export function entrySummary(entry: EntryRecord): string {
+  const parts: string[] = [];
+  switch (entry.kind) {
+    case "bolus":
+      if (entry.data.insulin)
+        parts.push(`${formatInsulinDisplay(entry.data.insulin)}U`);
+      if (entry.data.bolusType) parts.push(entry.data.bolusType);
+      break;
+    case "carbs":
+      if (entry.data.carbs)
+        parts.push(`${formatCarbDisplay(entry.data.carbs)}g carbs`);
+      break;
+    case "bgCheck":
+      if (entry.data.mgdl) parts.push(`${entry.data.mgdl} mg/dL`);
+      break;
+    case "note":
+      if (entry.data.text)
+        parts.push(entry.data.text.slice(0, NOTE_PREVIEW_LENGTH));
+      break;
+    case "deviceEvent":
+      if (entry.data.eventType) parts.push(entry.data.eventType);
+      break;
+    case "basalInjection":
+      if (entry.data.units)
+        parts.push(`${formatInsulinDisplay(entry.data.units)}U`);
+      break;
+  }
+  return parts.join(" · ") || ENTRY_CATEGORIES[entry.kind].name;
+}


### PR DESCRIPTION
Closes #1251.

## Mechanism

The recent-entries card built each row's label by string-interpolating the stored amount:

```svelte
return entry.data.insulin ? `${entry.data.insulin}u insulin` : "Bolus";
```

There was no formatter in the path at all. A bolus whose stored value is a binary-inexact sum (`0.1 + 0.2` is exactly `0.30000000000000004`) therefore reached the reader at the full width of a double.

Two things in the report were red herrings worth recording:

- **The decimal comma.** The issue text says `0,30000000000000004`, which suggests a locale formatter mangling a Dutch reader's separator. The screenshot shows a **dot** — `0.30000000000000004u insulin`. Nothing locale-aware is involved; the comma was the reporter's own typing. Separators are left exactly as they are, which keeps this consistent with every other amount in the app.
- **"round to 3 decimals."** See below — the app already has a convention, and it is two.

## What changed

Amounts now go through the two formatters that already exist in `$lib/utils/formatting`, `formatInsulinDisplay` and `formatCarbDisplay`. Nothing on the server or at ingest is touched; the stored value stays exact and this is a display change only.

The row-label and one-line-summary derivations move into a new shared `$lib/utils/entry-summary` module:

- `formatEntrySummary` was **duplicated verbatim** between `TreatmentDisambiguationDialog` and `TreatmentInspectionDialog` (the second copy carried a comment saying so). Both now call `entrySummary`.
- `getEntryLabel` / `getEntryDetails` lived inside `RecentTreatmentsCard.svelte`, where the reported bug had no test seam. They are now `entryLabel` / `entryDetails`.

Surfaces that interpolated a raw amount, or reached for their own `.toFixed()`, now call the shared formatters instead: the glucose-chart tooltip and point inspection (`.toFixed(1)`), the treatment inspection dialog's subtitle, chart label and badges, the IOB and COB pills (`.toFixed(2)` and raw), the treatment-events report, and the meal bolus dialog.

## Precision, and why not the reporter's 3

Insulin renders at **two** decimal places and carbs at **whole grams** — matching `formatInsulinDisplay` / `formatCarbDisplay`, which the daily-insulin, period-averages, treatment-summary, linked-records and treatments-report surfaces already use. Consistency with the established convention beat the issue's suggestion of three.

Two places is also the correct floor on the safety argument: the finest increment a real pump doses in is 0.05 U, which two places represents exactly. **One place would render 0.05 U as 0.1 U and hide a real dose difference**, so the precision could not be reduced further. Three places would only ever add a trailing zero to a real dose while still not being enough to make a float artifact legible.

The visible cost is that an amount now always carries both places: `0.4u insulin` becomes `0.40u insulin`. That is the same reading the report screens have always given.

One behaviour change falls out of unifying the two dialog copies: neither had a `basalInjection` case, so a long-acting injection showed only its category name. A shared function has to handle every member of the union, so it now shows its units.

## Verification

`entry-summary.test.ts`, 15 tests, node vitest:

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Full `src/lib/utils` suite, to check nothing else regressed: `16 passed (16)` files, `249 passed (249)` tests.

Covered: the exact value from the report; 0.05 vs 0.10 staying distinguishable; rounding rather than truncating at the second place (`12.345` -> `12.35`, `12.344` -> `12.34`); the no-amount fallbacks; and the same artifact on a carb total and on a long-acting injection. The artifacts are computed rather than written as literals, because eslint's `no-loss-of-precision` rejects a literal a double cannot round-trip — a fixture assertion pins `(0.1 + 0.2).toString()` to `"0.30000000000000004"` so the suite provably uses the reported value.

`svelte-check`: 76 errors repo-wide, all pre-existing, **none in any file this branch touches**. The run before the last fixup showed 80, the extra 4 being enum-typed fixture fields in the new test, now resolved.

Lint: the five modified `.svelte`/`.ts` files were already prettier-unclean and already carried eslint errors on `main` (verified by piping each file's `origin/main` content through `prettier --check`), so they are deliberately not reformatted — that would bury the change in unrelated churn. The new test file is prettier-clean and its only eslint finding is one `as unknown as` type assertion, the same convention the neighbouring `formatting.test.ts` uses 30 times.

## Residual risk

- **`@nocturne/app`'s vitest suite runs in no CI job.** `tests.yml`'s `web-typecheck` runs vitest only for `@nocturne/bot` and `@nocturne/portal`, and `@nocturne/app` is excluded from that job entirely. These 15 tests will not gate a future regression until that changes; they only ran locally here.
- The rendered output of ten surfaces changes, all by gaining trailing zeros or losing float noise. No component test asserts on those strings, so nothing catches an unintended wording change automatically — the strings were transcribed unchanged and reviewed by eye.
- `formatInsulinDisplay` returns `"N/A"` for `undefined`. Every call site added here sits behind an existing truthiness or `!= null` guard, so that branch is unreachable from them; the chart tooltip's `?? 0` fallbacks were left as they were and now read `0.00`/`0` rather than `0.0`/`0`.
- Food-nutrition surfaces (the food search combobox, food entry details, meal suggestion rows, meal-match review) still interpolate raw carb values and are **not** in this change. Their numbers are per-serving nutrition scaled by portion, which can be a genuine half-gram, and `formatCarbDisplay`'s whole-gram rounding would hide it. That needs its own precision decision rather than being swept in here.
- The year-overview report keeps its own local `formatUnits` at one decimal place for daily insulin totals. It is a duplicate of the same idea at a different precision, but it formats aggregates rather than a dose, so changing it was out of scope.

https://claude.ai/code/session_01LwgLFFBvXjqe9QoJsq83mq
