### PR TITLE
fix(reports): include 31 December in the year overview heatmap

### DIFF
--- a/src/Web/packages/app/src/lib/components/reports/year-overview/YearHeatmap.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/YearHeatmap.svelte
@@ -8,13 +8,13 @@
   import { formatGlucoseValue, formatMonthLabel, formatWeekdayDate } from "$lib/utils/formatting";
   import type { GlucoseUnits } from "$lib/utils/formatting";
   import { getDataTypeLabel } from "$lib/utils/data-type-labels";
+  import { yearCalendarBounds } from "./year-bounds";
 
   let {
     year,
     yearIndex,
     loadingYears,
     yearData,
-    getYearBounds,
     transformYearData,
     getCellFill,
     getWeekColumns,
@@ -30,7 +30,6 @@
     yearIndex: number;
     loadingYears: Set<number>;
     yearData: Map<number, any[]>;
-    getYearBounds: (year: number) => { start: Date; end: Date };
     transformYearData: (days: any[]) => any[];
     getCellFill: (data: any) => string;
     getWeekColumns: (cells: any[]) => any[];
@@ -43,7 +42,7 @@
     sentinelElement?: HTMLDivElement;
   }>();
 
-  const bounds = $derived(getYearBounds(year));
+  const bounds = $derived(yearCalendarBounds(year));
   const days = $derived(yearData.get(year));
   const chartData = $derived(days ? transformYearData(days) : []);
   const isYearLoading = $derived(loadingYears.has(year) && !days);

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/year-bounds.test.ts
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/year-bounds.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { timeDays, timeMonths } from "d3-time";
+
+import { yearCalendarBounds } from "./year-bounds";
+
+/** `YYYY-MM-DD` in the local calendar, matching the cells' own day identity. */
+function localDay(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+/** The days layerchart's `Calendar` lays out for `year`. */
+function heatmapDays(year: number): string[] {
+  const { start, end } = yearCalendarBounds(year);
+  return timeDays(start, end).map(localDay);
+}
+
+describe("yearCalendarBounds", () => {
+  it("opens on 1 January and ends on the following 1 January", () => {
+    const { start, end } = yearCalendarBounds(2025);
+    expect(localDay(start)).toBe("2025-01-01");
+    expect(localDay(end)).toBe("2026-01-01");
+    expect(start.getHours()).toBe(0);
+    expect(end.getHours()).toBe(0);
+  });
+
+  it("covers 31 December", () => {
+    const days = heatmapDays(2025);
+    expect(days).toContain("2025-12-31");
+    expect(days.at(-1)).toBe("2025-12-31");
+    expect(days).toHaveLength(365);
+  });
+
+  it("covers 31 December of a leap year, and 29 February with it", () => {
+    const days = heatmapDays(2024);
+    expect(days).toContain("2024-02-29");
+    expect(days).toContain("2024-12-30");
+    expect(days).toContain("2024-12-31");
+    expect(days.at(-1)).toBe("2024-12-31");
+    expect(days).toHaveLength(366);
+  });
+
+  it("opens on 1 January and spills into no other year", () => {
+    const days = heatmapDays(2025);
+    expect(days[0]).toBe("2025-01-01");
+    expect(days.every((day) => day.startsWith("2025-"))).toBe(true);
+  });
+
+  it("still spans exactly the twelve months the labels are drawn from", () => {
+    const { start, end } = yearCalendarBounds(2025);
+    const months = timeMonths(start, end).map(localDay);
+    expect(months).toHaveLength(12);
+    expect(months[0]).toBe("2025-01-01");
+    expect(months.at(-1)).toBe("2025-12-01");
+  });
+
+  it("covers 31 December whichever weekday it falls on", () => {
+    // 2022 ends on a Saturday (last cell of a column), 2023 on a Sunday (first
+    // cell of a new one), 2024 on a Tuesday.
+    for (const year of [2022, 2023, 2024, 2025, 2026, 2027]) {
+      expect(heatmapDays(year).at(-1)).toBe(`${year}-12-31`);
+    }
+  });
+});

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/year-bounds.ts
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/year-bounds.ts
@@ -1,0 +1,13 @@
+/**
+ * The interval the year heatmap lays out.
+ *
+ * **Half-open**: local midnight opening 1 January, to local midnight opening
+ * the following 1 January. layerchart's `Calendar` builds its cells from
+ * `timeDays(start, end)`, and a d3 time range excludes its end, so an end of 31
+ * December leaves the last day of the year without a cell — while the December
+ * month path, which derives its own month end, still outlines the square where
+ * that cell should be.
+ */
+export function yearCalendarBounds(year: number): { start: Date; end: Date } {
+  return { start: new Date(year, 0, 1), end: new Date(year + 1, 0, 1) };
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
@@ -454,13 +454,6 @@
   // Helpers
   // =========================================================================
 
-  function getYearBounds(year: number): { start: Date; end: Date } {
-    return {
-      start: new Date(year, 0, 1),
-      end: new Date(year, 11, 31),
-    };
-  }
-
   function formatSelectedDate(dateStr: string): string {
     const [y, m, d] = dateStr.split("-").map(Number);
     const date = new Date(y, m - 1, d);
@@ -623,7 +616,6 @@
             {yearIndex}
             {loadingYears}
             {yearData}
-            {getYearBounds}
             {transformYearData}
             {getCellFill}
             {getWeekColumns}


### PR DESCRIPTION
Closes #1250.

## Mechanism

The heatmap asked layerchart's `Calendar` for the year as an **inclusive** interval:

```ts
function getYearBounds(year: number): { start: Date; end: Date } {
  return { start: new Date(year, 0, 1), end: new Date(year, 11, 31) };
}
```

`Calendar` lays out one cell per day of `timeDays(start, end)` (`Calendar.base.svelte`), and a d3 time range is **half-open** — it excludes its end. So an end of 31 December produced no cell for 31 December.

Measured directly against the installed `d3-time`:

```
2024 exclusive-Dec31 end -> 365 cells, last 2024-12-30
2024 next-Jan-1 end      -> 366 cells, last 2024-12-31
2025 exclusive-Dec31 end -> 364 cells, last 2025-12-30
2025 next-Jan-1 end      -> 365 cells, last 2025-12-31
```

**This is what rules out the other candidate causes**, and it is worth being explicit about because they predict different symptoms:

- Exactly **one** day is lost, in a leap year and a common year alike. A day-of-year loop bounded at 365 would drop two days in 2024 (30 and 31 December). The screenshot shows 2024 labelled "366 days with data" with a single square missing, so it is the bound, not a loop.
- It is **not** a UTC-vs-local truncation. Both bounds are built with the local-time `Date` constructor, `cells` derive their row from `date.getDay()` (local), and the day cells are keyed off `transformYearData`'s local-calendar dates. Nothing in the path reads a UTC component.
- Per the repo's own note, `setDate`-style date maths was **not** assumed to be DST-broken, and it is not implicated here — no arithmetic of that kind is involved, only a range bound. `new Date(year + 1, 0, 1)` is a calendar construction, not an offset from another date, so a DST transition cannot shift it.

The empty **outlined** square in the report (rather than a gap) is the corroborating detail: `MonthPath` computes its own `monthEnd = endOfInterval('month', date)`, independent of `yearDays`, so December's outline still traced the square where the missing cell belonged.

## What changed

`yearCalendarBounds` returns a half-open interval — 1 January to the **following** 1 January — and lives in a new `year-bounds.ts` beside `YearHeatmap.svelte`, the only component that consumes it. It was previously a function defined on the page and threaded down as a `getYearBounds` prop; a pure function of `year` has no reason to be a prop, and inside `+page.svelte` it had no test seam.

Nothing else changes. The month labels are drawn from `timeMonths(bounds.start, bounds.end)`, which yields the same twelve months either way (January through December) — there is a test pinning that. `cellSize` is passed explicitly as `24`, so layerchart's internal `yearWeeks`-derived sizing is unused and the wider week count cannot change the layout. The page's `getWeekColumns` labels each column from the first cell it sees in it, and 31 December is never the first day of a Sunday-started column unless it genuinely opens one, in which case a new column is correct.

## Blast radius

This is the only place with the truncation. `getYearBounds` had exactly one consumer, `Calendar` is imported in exactly one file repo-wide, and the only other d3 range call in `app/src` or `portal/src` is the `timeMonths` in the same component. No shared date-range helper is involved: `$lib/utils/date-range.ts` deals in inclusive `YYYY-MM-DD` day strings and is untouched, so no other report changes.

**The backend was already right.** `DataOverviewService.LocalYearBoundsUtc` builds a half-open `[1 January, following 1 January)` interval in the patient's zone for both `getDailySummary` and `getGriTimeline`, so the day was always in the response. The report's own header proved it: "365 days with data" for 2025 while the grid drew 364 cells. Consistent with the reporter seeing the day fine when navigating to it directly. No server or ingest change, and nothing that converts glucose units was touched.

## Verification

`year-bounds.test.ts`, 6 tests, node vitest:

```
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

The tests assert on `timeDays(start, end)` — the actual layerchart call — not just on the returned `Date`, so they exercise the mechanism rather than restating the fix. Covered: the bound itself; 31 December present and last for 2025 with 365 days; 31 December **and** 29 February present for the leap year 2024 with 366 days; no spill into a neighbouring year; the twelve month labels unchanged; and 31 December last for 2022 through 2027, which sweeps the weekdays it can fall on including a Saturday (last cell of a column) and a Sunday (first cell of a new one).

### Mutation proof

The file was copied outside the worktree, the bound reverted to `new Date(year, 11, 31)` with `sed`, the suite re-run, and the file restored from the copy — no `git checkout` or `git restore` against a tree holding uncommitted work; md5 confirmed identical after restore.

Against the unfixed bound, **4 of 6 tests fail**:

```
FAIL > opens on 1 January and ends on the following 1 January
  expected "2026-01-01", received "2025-12-31"
FAIL > covers 31 December
  expected [ '2025-01-01', '2025-01-02', ...(362) ] to include '2025-12-31'
FAIL > covers 31 December of a leap year, and 29 February with it
  expected [ '2024-01-01', '2024-01-02', ...(363) ] to include '2024-12-31'
FAIL > covers 31 December whichever weekday it falls on
  expected '2022-12-31', received '2022-12-30'

 Tests  4 failed | 2 passed (6)
```

The leap-year list holding 365 entries and the common-year list 364 is the off-by-one, reproduced. Restored, the suite is 6/6 again.

`svelte-check`: **76 errors** repo-wide, the same count this checkout reports for an unrelated branch off the same base, and **none in `year-bounds.ts`, `year-bounds.test.ts` or `YearHeatmap.svelte`**. The only finding that names a file this branch touches is `'reportsParams' is declared but its value is never read` in `+page.svelte`, which is pre-existing — `origin/main` has the same single assign-and-never-read occurrence, so it is not fallout from removing `getYearBounds`.

Lint: eslint is clean on both new files. The two modified files carry only pre-existing findings — `+page.svelte` reports the same 15 problems before and after (verified by piping `origin/main`'s content and the branch's content through the same `eslint --stdin` path), and `YearHeatmap.svelte` reports none. `year-bounds.ts` and `year-bounds.test.ts` are prettier-clean; `+page.svelte` was prettier-clean on `main` and still is; `YearHeatmap.svelte` was already prettier-unclean on `main` and is deliberately not reformatted, so the change is not buried in unrelated churn.

## Residual risk

- **`@nocturne/app`'s vitest suite runs in no CI job.** `tests.yml`'s `web-typecheck` runs vitest only for `@nocturne/bot` and `@nocturne/portal` and excludes `@nocturne/app` outright; the browser vitest project (`vitest.browser.config.ts`) is separate and also unrun. These 6 tests will not gate a regression until that changes.
- **The rendered grid was not run.** The reasoning about week columns, month paths and cell rows is read off `layerchart@2.2.0`'s `Calendar.base.svelte` and `MonthPath.svelte` and matched against the reporter's screenshot, but no browser test or screenshot of the fixed heatmap is attached. There is no existing component test for `YearHeatmap`, so nothing automated covers the rendered output either way.
  
  What makes this narrower than it sounds: the new cell is not a new code path. `cells` is rendered by an unconditional `{#each cells as cell}` with no date filter, and each cell's datum comes from the same `dataByDate.get(date)` lookup — keyed on a `Date` from `timeDays`, against datum dates that `transformYearData` builds as local midnight from the API's `YYYY-MM-DD`. The 364 cells the report already draws correctly prove that lookup works; 31 December's `Date` is constructed identically to its siblings, so it resolves the same way. The unverified part is the visual, not the data binding.
- The removal of the `getYearBounds` prop is only as safe as the grep that confirmed nothing else referenced it. `svelte-check` and the web build in CI are the backstop, and both are clean, but a dynamic reference would evade all three.
- If a tenant's data genuinely stops before 31 December, that day now renders as an empty cell where previously there was none — correct, and the same as any other dataless day, but it is a visible change on the last column for anyone whose year is incomplete.
- `layerchart` upgrades are the standing hazard: if a future `Calendar` switched to an inclusive end, this bound would add a spurious 1 January cell. The tests assert against `timeDays` rather than the component, so they would not catch that; the module doc names the dependency so a reviewer of such an upgrade has a chance of finding it.

https://claude.ai/code/session_01LwgLFFBvXjqe9QoJsq83mq

