### PR TITLE
fix(auth): refresh the sign-in-factor count after an OIDC unlink

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -427,6 +427,12 @@ public class OidcController : ControllerBase
     /// Factor-count enforcement is handled atomically inside <see cref="ISubjectService.TryRemoveOidcIdentityAsync"/>
     /// using a serializable transaction to prevent TOCTOU races between concurrent removals.
     /// Returns <see cref="FactorRemovalResult"/> to distinguish between not-found, last-factor, and success.
+    /// <para>
+    /// Dropping a primary factor also changes the factor count that
+    /// <see cref="PasskeyController.ListCredentials"/> reports, which is what the account page reads to
+    /// decide whether a Remove is offered at all. That read lives under another OpenAPI tag, so it is
+    /// named by its full operationId — a bare name resolves only within the declaring operation's own tag.
+    /// </para>
     /// </remarks>
     /// <response code="204">Identity unlinked successfully.</response>
     /// <response code="401">Not authenticated.</response>
@@ -434,7 +440,7 @@ public class OidcController : ControllerBase
     /// <response code="409">Cannot remove the last primary sign-in method.</response>
     [HttpDelete("link/identities/{identityId:guid}")]
     [DenyDemoSubject]
-    [RemoteCommand(Invalidates = ["GetLinkedIdentities"])]
+    [RemoteCommand(Invalidates = ["GetLinkedIdentities", "Passkey_ListCredentials"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/OidcInvalidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/OidcInvalidationTests.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using FluentAssertions;
+using Nocturne.API.Controllers.Authentication;
+using OpenApi.Remote.Attributes;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// Unlinking an OIDC identity drops a primary sign-in factor, and the count of those is reported by
+/// <see cref="PasskeyController.ListCredentials"/> — not by this controller's own read. The account
+/// page decides from that count whether a passkey's Remove is offered at all, so a refresh list
+/// naming only <see cref="OidcController.GetLinkedIdentities"/> leaves the count stale until the next
+/// full load and the page keeps offering a Remove the server answers 409 <c>last_factor</c>.
+/// </summary>
+[Trait("Category", "Unit")]
+public class OidcInvalidationTests
+{
+    [Theory]
+    [InlineData(nameof(OidcController.GetLinkedIdentities))]
+    [InlineData("Passkey_ListCredentials")]
+    public void UnlinkingAnIdentity_RefreshesTheReadsThatReportIt(string read)
+    {
+        Command(nameof(OidcController.UnlinkIdentity))
+            .Invalidates.Should()
+            .Contain(read);
+    }
+
+    /// <summary>
+    /// Only a query can be refreshed, and a read on another controller has to be named the way the
+    /// OpenAPI document names it — NSwag's <c>{controller}_{action}</c> operationId — because a bare
+    /// name resolves only within the declaring operation's own tag and is otherwise dropped in
+    /// silence. Resolving each entry back to a method proves the spelling still lands on something.
+    /// </summary>
+    [Fact]
+    public void EveryRefreshedRead_IsAQueryTheCommandCanName()
+    {
+        var reads = Command(nameof(OidcController.UnlinkIdentity)).Invalidates;
+
+        reads.Should().NotBeEmpty();
+
+        foreach (var read in reads)
+        {
+            Resolve(read).Should().NotBeNull($"'{read}' should name a method on a controller");
+            Resolve(read)!.GetCustomAttribute<RemoteQueryAttribute>().Should()
+                .NotBeNull($"'{read}' should name a query, since only a query can be refreshed");
+        }
+    }
+
+    /// <summary>
+    /// Resolves one <c>Invalidates</c> entry to the action it names: a bare name against the
+    /// declaring controller, a <c>{controller}_{action}</c> operationId against the controller that
+    /// prefix belongs to (<see cref="Nocturne.API.OpenApi.ControllerNameTagOperationProcessor"/>
+    /// derives both the tag and the prefix from the controller's type name).
+    /// </summary>
+    private static MethodInfo? Resolve(string read)
+    {
+        var separator = read.IndexOf('_');
+        if (separator < 0)
+        {
+            return typeof(OidcController).GetMethod(read);
+        }
+
+        var controller = typeof(OidcController).Assembly
+            .GetType($"{typeof(OidcController).Namespace}.{read[..separator]}Controller");
+
+        return controller?.GetMethod(read[(separator + 1)..]);
+    }
+
+    private static RemoteCommandAttribute Command(string write) =>
+        typeof(OidcController).GetMethod(write)!
+            .GetCustomAttribute<RemoteCommandAttribute>()!;
+}


### PR DESCRIPTION
Closes #1236.

## The bug

Unlinking an OIDC identity drops a primary sign-in factor, but the count of those factors is reported by `PasskeyController.ListCredentials`, not by the OIDC controller's own read. The account page gates every passkey Remove button on that count, and reads `hasSingleSignInMethod` off the same response. Because the unlink command declared `Invalidates = ["GetLinkedIdentities"]` only, the count stayed stale until the next full page load, so the page could keep offering a Remove that the server answers 409 `last_factor`.

Passkey removal and both TOTP commands already refresh `ListCredentials`; the OIDC unlink was the odd one out.

## The fix, and why the issue's suggestion would not have worked

#1236 proposes adding `"ListCredentials"`. That would have been a silent no-op.

`openapi-remote-codegen`'s `resolveInvalidationTarget` (`dist/utils/invalidation.js`) resolves a **bare** name only within the declaring operation's own OpenAPI tag, and `ControllerNameTagOperationProcessor` gives each controller a tag of its own. There is no `ListCredentials` query under the `Oidc` tag, so the entry would have resolved to nothing — and an unresolved target is dropped by a bare `if (!target) continue;`, with no error. A **qualified** name is matched against the full `operationId` and may name a query under any tag.

The target is therefore named `Passkey_ListCredentials`. Verified against the generated OpenAPI document, which contains `"operationId": "Passkey_ListCredentials"`. Note that `"operationId": "Totp_ListCredentials"` also exists, so a bare `ListCredentials` is genuinely ambiguous across tags — the qualified form is required, not merely preferred.

## Tests

`OidcInvalidationTests` pins both refresh targets, and asserts that every `Invalidates` entry on the unlink resolves to a method carrying `[RemoteQuery]` — only a query can be refreshed, so a name that lands on nothing or on a command is a defect. That second test generalises beyond this one fix.

## Notes for the reviewer

- This is the **first** use of the qualified cross-tag form in this repo; every other `Invalidates` entry is a bare same-tag name. The codegen supports it explicitly (its own docstring gives `Trackers_GetActiveInstances` as the example), but it is otherwise unexercised here.
- The tests assert the attribute and resolve names by reflection. They do **not** execute the generated client, so they prove the spelling maps to a real query but not that a refresh fires at runtime. The operationId check above is what closes that gap.
- Related and out of scope: `settings/members/+page.svelte` carries a comment that `GetMembers` "is on another controller so ApproveRequest's Invalidates cannot name it", and works around it with a manual `refresh()`. Given the above, that limitation no longer holds and the workaround could be removed. Left alone here.
