### PR TITLE
fix(auth): let a Nocturne-minted access token authenticate on ?token=

### DIFF
--- a/src/API/Nocturne.API/Authorization/TokenFormat.cs
+++ b/src/API/Nocturne.API/Authorization/TokenFormat.cs
@@ -4,11 +4,17 @@ namespace Nocturne.API.Authorization;
 /// The shape of a presented credential, read before anything validates it.
 /// </summary>
 /// <remarks>
-/// The auth chain routes on this: a handler that recognises JWTs claims the credential and every
-/// later handler is skipped, so what counts as a JWT here decides which handler owns it.
+/// The auth chain routes on this: a handler that recognises a credential claims it and every later
+/// handler is skipped, so what counts as a given shape here decides which handler owns it.
 /// </remarks>
 public static class TokenFormat
 {
+    /// <summary>
+    /// Random bytes behind a Nocturne-minted access token, whose plaintext is those bytes
+    /// hex-encoded. Read by the generator too, so the mint and the shape cannot drift apart.
+    /// </summary>
+    internal const int AccessTokenBytes = 32;
+
     /// <summary>
     /// Whether <paramref name="token"/> is in the JWT compact serialization — three dot-separated
     /// segments. Nocturne's opaque credentials carry no dot at all: <c>noc_</c> direct grants are
@@ -17,4 +23,62 @@ public static class TokenFormat
     /// <param name="token">The presented credential, or null when none was presented.</param>
     public static bool IsJwt(string? token) =>
         !string.IsNullOrEmpty(token) && token.Count(c => c == '.') == 2;
+
+    /// <summary>
+    /// Whether <paramref name="token"/> could be an access token, and so worth a lookup.
+    /// </summary>
+    /// <remarks>
+    /// Two shapes reach the same credential. Nocturne mints a bare hex string of
+    /// <see cref="AccessTokenBytes"/> bytes and stores its SHA-256; a subject migrated from classic
+    /// Nightscout keeps that instance's <c>{name-abbrev}-{digest}</c> token, matched either by the
+    /// same SHA-256 or by <see cref="Services.Auth.LegacyNightscoutToken"/>'s digest-prefix rule.
+    /// Nothing here validates the token — it only decides whether a database lookup is worth doing,
+    /// so it is deliberately wider than either lookup.
+    /// <para>
+    /// A JWT is not hex and carries no dash-delimited suffix of its own, and a <c>noc_</c> direct
+    /// grant is neither hex nor dash-delimited before its secret, so both fall through to the
+    /// handlers that own them.
+    /// </para>
+    /// </remarks>
+    /// <param name="token">The presented credential, or null when none was presented.</param>
+    public static bool IsAccessToken(string? token) =>
+        !string.IsNullOrEmpty(token) && (IsMintedAccessToken(token) || IsNightscoutAccessToken(token));
+
+    /// <summary>
+    /// A token as <see cref="Services.Auth.SubjectService"/> mints it: hex, and nothing else.
+    /// </summary>
+    private static bool IsMintedAccessToken(string token)
+    {
+        if (token.Length != AccessTokenBytes * 2)
+        {
+            return false;
+        }
+
+        foreach (var c in token)
+        {
+            if (!Uri.IsHexDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// A classic Nightscout token: <c>{name-abbrev}-{digest}</c>, with the digest after the last
+    /// dash. The digest's own length and alphabet are left loose because a migrated subject carries
+    /// whatever its source instance issued, and the lookup that follows is what actually decides.
+    /// </summary>
+    private static bool IsNightscoutAccessToken(string token)
+    {
+        var dashIndex = token.LastIndexOf('-');
+        if (dashIndex <= 0 || dashIndex >= token.Length - 1)
+        {
+            return false;
+        }
+
+        var digest = token[(dashIndex + 1)..];
+        return digest.Length >= 8 && digest.All(char.IsLetterOrDigit);
+    }
 }

--- a/src/API/Nocturne.API/Middleware/Handlers/AccessTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/AccessTokenHandler.cs
@@ -1,3 +1,4 @@
+using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Models.Authorization;
@@ -5,9 +6,9 @@ using Nocturne.Core.Models.Authorization;
 namespace Nocturne.API.Middleware.Handlers;
 
 /// <summary>
-/// Authentication handler for Nightscout legacy access tokens.
-/// Access tokens use format: {name_abbrev}-{16_char_sha1_digest}
-/// Example: rhys-a1b2c3d4e5f6g7h8
+/// Authentication handler for subject access tokens, in either shape
+/// <see cref="TokenFormat.IsAccessToken"/> recognises: the bare hex string Nocturne mints, and the
+/// <c>{name_abbrev}-{digest}</c> token a subject migrated from classic Nightscout keeps.
 /// Tokens can be provided via:
 /// - Authorization header (Bearer token)
 /// - Query parameter: ?token=xxx
@@ -48,15 +49,13 @@ public class AccessTokenHandler : IAuthHandler
             return AuthResult.Skip();
         }
 
-        // Access tokens contain a dash separator: name-hash
         // JWTs have dots (.), so if we find dots it's not an access token
         if (accessToken.Contains('.'))
         {
             return AuthResult.Skip();
         }
 
-        // Validate format: should have a dash and alphanumeric chars
-        if (!IsValidAccessTokenFormat(accessToken))
+        if (!TokenFormat.IsAccessToken(accessToken))
         {
             _logger.LogDebug("Token doesn't match access token format, skipping");
             return AuthResult.Skip();
@@ -155,29 +154,5 @@ public class AccessTokenHandler : IAuthHandler
         // We skip body parsing here and expect middleware to have buffered if needed
 
         return null;
-    }
-
-    /// <summary>
-    /// Validate that the token matches the access token format
-    /// Format: {name_abbrev}-{hex_digest} where digest is typically 16 chars
-    /// </summary>
-    private static bool IsValidAccessTokenFormat(string token)
-    {
-        // Must have at least one dash
-        var dashIndex = token.LastIndexOf('-');
-        if (dashIndex <= 0 || dashIndex >= token.Length - 1)
-        {
-            return false;
-        }
-
-        // Characters after the dash should be alphanumeric (hex digest)
-        var digest = token[(dashIndex + 1)..];
-        if (digest.Length < 8) // Minimum reasonable digest length
-        {
-            return false;
-        }
-
-        // Allow alphanumeric characters in digest
-        return digest.All(c => char.IsLetterOrDigit(c));
     }
 }

--- a/src/API/Nocturne.API/Services/Auth/SubjectService.cs
+++ b/src/API/Nocturne.API/Services/Auth/SubjectService.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Authorization;
 using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
@@ -830,11 +831,12 @@ public class SubjectService : ISubjectService
     }
 
     /// <summary>
-    /// Generate a secure access token
+    /// Generate a secure access token, in the shape <see cref="TokenFormat.IsAccessToken"/> routes
+    /// to <see cref="Middleware.Handlers.AccessTokenHandler"/>.
     /// </summary>
     private static string GenerateAccessToken()
     {
-        var bytes = RandomNumberGenerator.GetBytes(32);
+        var bytes = RandomNumberGenerator.GetBytes(TokenFormat.AccessTokenBytes);
         return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TokenFormatTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TokenFormatTests.cs
@@ -40,4 +40,51 @@ public class TokenFormatTests
     {
         TokenFormat.IsJwt("header.payload.signature.extra").Should().BeFalse();
     }
+
+    /// <summary>
+    /// Both shapes that reach a subject's access token: the bare hex string Nocturne mints, and the
+    /// <c>{name-abbrev}-{digest}</c> token a subject migrated from classic Nightscout keeps.
+    /// </summary>
+    [Theory]
+    [InlineData("2f0c9cf12ed3fb2eb59df4bb4157dbb08ea44121e2e2b5cbfd85d1c31d34e5b6")]
+    [InlineData("2F0C9CF12ED3FB2EB59DF4BB4157DBB08EA44121E2E2B5CBFD85D1C31D34E5B6")]
+    [InlineData("phone-318030bcdc470b9d")]
+    [InlineData("rhys-a1b2c3d4e5f6g7h8")]
+    public void Both_access_token_shapes_are_worth_a_lookup(string token)
+    {
+        TokenFormat.IsAccessToken(token).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A JWT and a dashless <c>noc_</c> direct grant keep falling through to the handlers that own
+    /// them. A Base64-URL grant secret that happens to contain a dash reads as the Nightscout shape
+    /// and always has, which costs nothing: <see cref="Nocturne.API.Middleware.Handlers.DirectGrantTokenHandler"/>
+    /// runs first, and a grant this handler then fails to find is skipped rather than refused.
+    /// </summary>
+    [Theory]
+    [InlineData("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2ln")]
+    [InlineData("noc_Zm9vYmFyYmF6cXV1eGNvcmdlZ3JhdWx0Z2FycGx5")]
+    public void A_credential_another_handler_owns_is_not_an_access_token(string token)
+    {
+        TokenFormat.IsAccessToken(token).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Hex alone is not enough — only the minted length is, so a random hex fragment does not buy a
+    /// database lookup. A dash-delimited digest keeps the looser rule migrated tokens need.
+    /// </summary>
+    [Theory]
+    [InlineData("2f0c9cf12ed3fb2e")]
+    [InlineData("2f0c9cf12ed3fb2eb59df4bb4157dbb08ea44121e2e2b5cbfd85d1c31d34e5b")]
+    [InlineData("2f0c9cf12ed3fb2eb59df4bb4157dbb08ea44121e2e2b5cbfd85d1c31d34e5b6a")]
+    [InlineData("notanaccesstoken")]
+    [InlineData("phone-short")]
+    [InlineData("-318030bcdc470b9d")]
+    [InlineData("phone-")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Anything_else_is_not_worth_a_lookup(string? token)
+    {
+        TokenFormat.IsAccessToken(token).Should().BeFalse();
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/AccessTokenHandlerMintedTokenTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/AccessTokenHandlerMintedTokenTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Authorization;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware.Handlers;
+
+/// <summary>
+/// A token this instance minted has to authenticate the way every Nightscout-compatible client
+/// presents one: <c>?token=</c> on the request, or an <c>Authorization: Bearer</c> header. The token
+/// is minted through the real <see cref="SubjectService"/> over an EF InMemory context rather than
+/// written out here, so what the handler accepts stays pinned to what the generator produces — a
+/// length copied into a test would not have caught the shape check rejecting every minted token.
+/// </summary>
+public class AccessTokenHandlerMintedTokenTests : IDisposable
+{
+    private readonly NocturneDbContext _db;
+    private readonly SubjectService _subjects;
+    private readonly AccessTokenHandler _handler;
+
+    public AccessTokenHandlerMintedTokenTests()
+    {
+        _db = TestDbContextFactory.CreateInMemoryContext();
+        _subjects = new SubjectService(
+            _db,
+            Mock.Of<IAuthAuditService>(),
+            Mock.Of<IRecoveryCodeService>(),
+            NullLogger<SubjectService>.Instance);
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider
+            .Setup(p => p.GetService(typeof(ISubjectService)))
+            .Returns(_subjects);
+
+        var scope = new Mock<IServiceScope>();
+        scope.Setup(s => s.ServiceProvider).Returns(serviceProvider.Object);
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+
+        _handler = new AccessTokenHandler(
+            scopeFactory.Object,
+            NullLogger<AccessTokenHandler>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<string> MintAsync()
+    {
+        var id = Guid.CreateVersion7();
+        _db.Subjects.Add(new SubjectEntity
+        {
+            Id = id,
+            Name = "Uploader",
+            AccessTokenHash = "overwritten-by-the-mint",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        var token = await _subjects.RegenerateAccessTokenAsync(id);
+        token.Should().NotBeNull();
+        return token!;
+    }
+
+    [Fact]
+    public async Task A_minted_token_authenticates_on_the_query_string()
+    {
+        var token = await MintAsync();
+
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?token={token}");
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.Succeeded.Should().BeTrue();
+        result.AuthContext!.SubjectName.Should().Be("Uploader");
+    }
+
+    [Fact]
+    public async Task A_minted_token_authenticates_as_a_bearer_credential()
+    {
+        var token = await MintAsync();
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Authorization = $"Bearer {token}";
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task The_shape_check_accepts_what_the_generator_mints()
+    {
+        var token = await MintAsync();
+
+        TokenFormat.IsAccessToken(token).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Closes #544.

## The bug

`SubjectService` mints an access token as 32 random bytes hex-encoded — 64 characters, no dash. `AccessTokenHandler`'s format pre-filter was written for classic Nightscout's `{name}-{hexdigest}` shape and required a dash, so every token this instance issues was skipped before the lookup and could not authenticate a normal API request by `?token=` or `Authorization: Bearer`.

The token was not inert: `/api/v2/authorization/request/<token>` and SignalR hub authorization both worked, because neither has a format gate. It just could not be used the way every Nightscout-compatible client actually uses a token.

## The fix

Both shapes now live in `TokenFormat` beside `IsJwt`, and `AccessTokenHandler` calls `TokenFormat.IsAccessToken`. `SubjectService`'s generator reads its length from `TokenFormat.AccessTokenBytes`, so the mint and the shape check cannot drift apart — which is the actual root cause here, two places independently deciding what a token looks like.

**Relaxing the check rather than changing generation** is deliberate: changing the minted shape would invalidate every token already issued. The Nightscout branch is carried over unchanged rather than narrowed to hex, because a migrated subject keeps whatever token its source instance issued.

The pre-filter is deliberately wider than either lookup — it only decides whether a database lookup is worth doing, and the lookup is what actually authenticates.

## Other token shapes still reach their own handlers

- **JWTs**: rejected by the existing dot check before the format test, and not hex.
- **`noc_` direct grants**: not hex, so the minted branch rejects them. Worth being precise about the other branch, since the issue calls this out specifically: `noc_` tokens are Base64-URL, and that alphabet *does* include `-`, so one can in principle satisfy the Nightscout dash rule. It still reaches its own handler, because a lookup miss returns `Skip()` rather than `Failure()` so the chain keeps trying later credentials. That behaviour is unchanged from before this PR — the dash rule is carried over verbatim.

## Tests

- `TokenFormatTests` covers both accepted shapes and the rejections, driven off `AccessTokenBytes` so it tracks the generator.
- `AccessTokenHandlerMintedTokenTests` mints a token through `SubjectService` and authenticates with it, which is the regression the issue asks for.
