### PR TITLE
fix(web): the three UI faults in #573 — token toast, revoke toast, null toFixed

### DIFF
--- a/src/Web/packages/app/src/lib/api/fake-remote-query.svelte.ts
+++ b/src/Web/packages/app/src/lib/api/fake-remote-query.svelte.ts
@@ -1,0 +1,108 @@
+/**
+ * Stand-in for a generated remote `query()` export, for component tests.
+ *
+ * A real query proxy decides once, in its constructor, whether it was built in a
+ * tracking context, and refuses to be awaited when it was not — the failure the
+ * `nocturne/no-imperative-remote-query` lint rule exists to catch. Tests that
+ * hand a component a bare `Promise` cannot see that, so a component which awaits
+ * a query from an event handler passes its tests and fails in the browser.
+ *
+ * Tracking is probed here the same way SvelteKit probes it, so the double agrees
+ * with the runtime on the one thing it exists to model. That probe only carries
+ * information under the browser runner: Svelte's server build makes
+ * `$effect.pre` a no-op rather than a throw, so a Node test always reads as
+ * tracking and cannot exercise the rule at all.
+ *
+ * @see $lib/api/retain-query.svelte for the registration lifetime this implies.
+ */
+
+/** SvelteKit's own tracking probe: `$effect.pre` throws outside a reactive context. */
+function isTracking(): boolean {
+  try {
+    $effect.pre(() => {});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const NOT_REACTIVE =
+  "This query was not created in a reactive context and cannot be awaited. Use `.run()` to execute the query instead.";
+
+export interface FakeQuery<T> extends PromiseLike<T> {
+  readonly current: T | undefined;
+  readonly error: unknown;
+  readonly ready: boolean;
+  readonly loading: boolean;
+  refresh(): Promise<T>;
+}
+
+class FakeQueryState<T> {
+  raw = $state.raw<T | undefined>(undefined);
+  err = $state.raw<unknown>(undefined);
+  ready = $state(false);
+  loading = $state(false);
+  settled: Promise<T> | null = null;
+
+  constructor(private readonly load: () => Promise<T>) {}
+
+  run(): Promise<T> {
+    this.loading = true;
+
+    const pending = this.load().then(
+      (value) => {
+        this.raw = value;
+        this.err = undefined;
+        this.ready = true;
+        this.loading = false;
+        return value;
+      },
+      (e: unknown) => {
+        this.err = e;
+        this.loading = false;
+        throw e;
+      }
+    );
+
+    // A rejection reaches whoever awaits the query or its refresh; nothing else
+    // is expected to handle it.
+    pending.catch(() => {});
+    this.settled = pending;
+    return pending;
+  }
+}
+
+/**
+ * Builds a fake `query()` export over `load`. Every call shares one underlying
+ * result, as a real query memoized on its payload does.
+ */
+export function fakeRemoteQuery<T>(load: () => Promise<T>): () => FakeQuery<T> {
+  const state = new FakeQueryState(load);
+
+  return () => {
+    const tracking = isTracking();
+
+    if (tracking && state.settled === null) state.run();
+
+    return {
+      get current() {
+        return state.raw;
+      },
+      get error() {
+        return state.err;
+      },
+      get ready() {
+        return state.ready;
+      },
+      get loading() {
+        return state.loading;
+      },
+      refresh: () => state.run(),
+      get then() {
+        if (!tracking) throw new Error(NOT_REACTIVE);
+        const pending = state.settled ?? state.run();
+        return pending.then.bind(pending);
+      },
+    };
+  };
+}

--- a/src/Web/packages/app/src/lib/api/pills-processor.test.ts
+++ b/src/Web/packages/app/src/lib/api/pills-processor.test.ts
@@ -349,4 +349,38 @@ describe("processPillsData – legacy DeviceStatus fallback when no snapshots", 
 		expect(result.iob).not.toBeNull();
 		expect(result.iob!.iob).toBe(1.5);
 	});
+
+	// A device status is uploaded JSON, so an uploader writes an explicit null for
+	// a field it has no value for. The pill data types declare these `number |
+	// undefined`, and the components guard on absence before calling `.toFixed`,
+	// so a null that survives the lift crashes the dashboard's render.
+	it("drops a null OpenAPS basaliob rather than carrying it into pill data", () => {
+		const legacyStatus = [{
+			mills: NOW - 3 * MIN,
+			openaps: {
+				iob: { iob: 1.5, basaliob: null, activity: null }
+			}
+		}] as any[];
+		const result = processPillsData(legacyStatus, EMPTY, EMPTY, EMPTY, EMPTY, null, { now: NOW });
+		expect(result.iob).not.toBeNull();
+		expect(result.iob!.basalIob).toBeUndefined();
+		expect(result.iob!.activity).toBeUndefined();
+	});
+
+	it("drops a null legacy Loop iob and cob rather than carrying them into pill data", () => {
+		const legacyStatus = [{
+			mills: NOW - 3 * MIN,
+			loop: {
+				timestamp: new Date(NOW - 3 * MIN).toISOString(),
+				iob: { iob: null },
+				cob: { cob: null },
+				enacted: { timestamp: new Date(NOW - 3 * MIN).toISOString(), rate: null, duration: null }
+			}
+		}] as any[];
+		const result = processPillsData(legacyStatus, EMPTY, EMPTY, EMPTY, EMPTY, null, { now: NOW });
+		expect(result.loop).not.toBeNull();
+		expect(result.loop!.iob).toBeUndefined();
+		expect(result.loop!.cob).toBeUndefined();
+		expect(result.loop!.lastEnacted!.rate).toBeUndefined();
+	});
 });

--- a/src/Web/packages/app/src/lib/api/pills-processor.ts
+++ b/src/Web/packages/app/src/lib/api/pills-processor.ts
@@ -91,6 +91,19 @@ interface LoopEnactedData {
 }
 
 /**
+ * A device-status number, or `undefined` when absent.
+ *
+ * Device statuses are uploaded JSON that these interfaces only assert a shape
+ * over, and an uploader writes an explicit `null` for a field it has no value
+ * for. Declaring such a field `number | undefined` does not make it one, so
+ * every lift out of a device status goes through here — a `null` that reaches
+ * pill data survives the `!= null` guards downstream as far as `.toFixed`.
+ */
+function statusNumber(value: number | null | undefined): number | undefined {
+	return value ?? undefined;
+}
+
+/**
  * Helper to safely access OpenAPS IOB data which can be an array or single object
  */
 function getOpenApsIob(iob: unknown): OpenApsIobEntry | null {
@@ -393,8 +406,8 @@ export function processIOB(
 						: status.mills ?? now;
 				iobFromDevice = {
 					iob: iobData.iob,
-					basalIob: iobData.basaliob,
-					activity: iobData.activity,
+					basalIob: statusNumber(iobData.basaliob),
+					activity: statusNumber(iobData.activity),
 					source: 'OpenAPS',
 					device: status.device,
 					display: `${iobData.iob.toFixed(2)}U`,
@@ -924,15 +937,15 @@ export function processLoop(
 		// Get predicted values - extract eventual BG
 		const predictedValues = loopData.predicted?.values;
 		if (predictedValues && predictedValues.length > 0) {
-			result.eventualBG = predictedValues[predictedValues.length - 1];
+			result.eventualBG = statusNumber(predictedValues[predictedValues.length - 1]);
 		}
 
 		// Get COB/IOB from loop
 		if (loopData.cob) {
-			result.cob = loopData.cob.cob;
+			result.cob = statusNumber(loopData.cob.cob);
 		}
 		if (loopData.iob) {
-			result.iob = loopData.iob.iob;
+			result.iob = statusNumber(loopData.iob.iob);
 		}
 
 		// Get enacted/recommended
@@ -943,9 +956,9 @@ export function processLoop(
 			result.lastEnacted = {
 				time: enactedTime,
 				type: enacted.bolusVolume ? 'bolus' : enacted.rate === 0 ? 'cancel' : 'temp_basal',
-				rate: enacted.rate,
-				duration: enacted.duration,
-				bolusVolume: enacted.bolusVolume,
+				rate: statusNumber(enacted.rate),
+				duration: statusNumber(enacted.duration),
+				bolusVolume: statusNumber(enacted.bolusVolume),
 				reason: enacted.reason
 			};
 
@@ -975,12 +988,12 @@ export function processLoop(
 			result.loopName = result.loopName ?? 'OpenAPS';
 
 			// Get IOB/COB
-			if (suggested.COB !== undefined) {
+			if (suggested.COB != null) {
 				result.cob = suggested.COB;
 			}
 
 			// Get eventual BG
-			if (suggested.eventualBG !== undefined) {
+			if (suggested.eventualBG != null) {
 				result.eventualBG = suggested.eventualBG;
 			}
 		}
@@ -991,8 +1004,8 @@ export function processLoop(
 			result.lastEnacted = {
 				time: enactedTime,
 				type: enacted.rate === 0 ? 'cancel' : 'temp_basal',
-				rate: enacted.rate,
-				duration: enacted.duration,
+				rate: statusNumber(enacted.rate),
+				duration: statusNumber(enacted.duration),
 				reason: enacted.reason
 			};
 
@@ -1007,7 +1020,7 @@ export function processLoop(
 		const iobData = openapsData.iob;
 		if (iobData) {
 			const iob = Array.isArray(iobData) ? iobData[0] : iobData;
-			if (iob?.iob !== undefined) {
+			if (iob?.iob != null) {
 				result.iob = iob.iob;
 			}
 		}

--- a/src/Web/packages/app/src/lib/components/connectors/UploaderSetupDialog.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/UploaderSetupDialog.svelte.test.ts
@@ -3,11 +3,12 @@ import { page } from "vitest/browser";
 import { describe, it, expect, beforeEach } from "vitest";
 import { vi } from "vitest";
 import { UploaderPlatform, type UploaderApp } from "$api-clients";
+import { fakeRemoteQuery } from "$lib/api/fake-remote-query.svelte";
 
 let createImpl: () => Promise<{ token?: string }>;
 
 vi.mock("$lib/api/generated/directGrants.generated.remote", () => ({
-  list: () => Promise.resolve([]),
+  list: fakeRemoteQuery(() => Promise.resolve([])),
   create: () => createImpl(),
   revoke: () => Promise.resolve(),
 }));

--- a/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { Button } from "$lib/components/ui/button";
   import * as Card from "$lib/components/ui/card";
   import * as Dialog from "$lib/components/ui/dialog";
@@ -24,6 +23,7 @@
     revoke as revokeGrant,
   } from "$lib/api/generated/directGrants.generated.remote";
   import { describeSubmitError } from "$lib/forms/submit-error";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import type { DirectGrantDto } from "$api";
   import { copyToClipboard } from "$lib/utils";
 
@@ -47,10 +47,23 @@
   // State
   // ============================================================================
 
-  let grants = $state<DirectGrantDto[]>([]);
-  let isLoading = $state(true);
-  let errorMessage = $state<string | null>(null);
+  // Built here, in the component's own tracking context, so its client-side
+  // registration lasts as long as the component and the commands' declared
+  // invalidation has an instance to apply to. A proxy built inside an event
+  // handler cannot be awaited at all.
+  const grantsQuery = listGrants();
+
+  const grants = $derived<DirectGrantDto[]>(grantsQuery.current ?? []);
+  const isLoading = $derived(!grantsQuery.ready && grantsQuery.error === undefined);
+  const loadError = $derived(
+    grantsQuery.error === undefined
+      ? null
+      : remoteErrorMessage(grantsQuery.error, "Failed to load API tokens.")
+  );
+
+  let mutationError = $state<string | null>(null);
   let successMessage = $state<string | null>(null);
+  const errorMessage = $derived(mutationError ?? loadError);
 
   // Create token flow
   let showCreateDialog = $state(false);
@@ -78,23 +91,6 @@
   });
 
   // ============================================================================
-  // Data fetching
-  // ============================================================================
-
-  async function loadGrants() {
-    try {
-      grants = await listGrants();
-    } catch (err) {
-      errorMessage = "Failed to load API tokens.";
-    }
-  }
-
-  onMount(async () => {
-    await loadGrants();
-    isLoading = false;
-  });
-
-  // ============================================================================
   // Create token
   // ============================================================================
 
@@ -108,7 +104,7 @@
 
   async function handleCreateToken() {
     isCreating = true;
-    errorMessage = null;
+    mutationError = null;
 
     try {
       const data = await createGrant({
@@ -116,9 +112,9 @@
         scopes: newTokenScopes,
       });
       createdToken = data.token ?? null;
-      await loadGrants();
+      await grantsQuery.refresh();
     } catch (err) {
-      errorMessage = describeSubmitError(err, "Failed to create token.");
+      mutationError = describeSubmitError(err, "Failed to create token.");
       closeCreateDialog();
     } finally {
       isCreating = false;
@@ -128,7 +124,7 @@
   async function copyToken() {
     if (createdToken) {
       if (!(await copyToClipboard(createdToken))) {
-        errorMessage = "Couldn't copy the token to the clipboard. Copy it manually instead.";
+        mutationError = "Couldn't copy the token to the clipboard. Copy it manually instead.";
         return;
       }
       copiedToken = true;
@@ -160,16 +156,16 @@
   async function handleRevokeGrant() {
     if (!revokeTarget) return;
     isRevoking = revokeTarget.id ?? null;
-    errorMessage = null;
+    mutationError = null;
     showRevokeDialog = false;
 
     try {
       await revokeGrant(revokeTarget.id!);
-      await loadGrants();
+      await grantsQuery.refresh();
       successMessage = "API token revoked.";
       clearMessages();
     } catch (err) {
-      errorMessage = "Failed to revoke token.";
+      mutationError = describeSubmitError(err, "Failed to revoke token.");
     } finally {
       isRevoking = null;
       revokeTarget = null;
@@ -179,7 +175,7 @@
   function clearMessages() {
     setTimeout(() => {
       successMessage = null;
-      errorMessage = null;
+      mutationError = null;
     }, 3000);
   }
 </script>
@@ -235,7 +231,12 @@
       </div>
     </Card.Header>
     <Card.Content class="space-y-3">
-      {#if grants.length === 0}
+      {#if loadError}
+        <p class="text-sm text-muted-foreground">
+          Your tokens couldn't be loaded, so this list may be incomplete.
+          Refresh the page to try again.
+        </p>
+      {:else if grants.length === 0}
         <div
           class="flex flex-col items-center justify-center py-8 text-center"
         >

--- a/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte.test.ts
@@ -1,14 +1,48 @@
 import { render } from "vitest-browser-svelte";
 import { page, userEvent } from "vitest/browser";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { DirectGrantDto } from "$api";
+import {
+  fakeRemoteQuery,
+  type FakeQuery,
+} from "$lib/api/fake-remote-query.svelte";
+
+/**
+ * A remote `query()` can only be awaited when its proxy was built in a tracking
+ * context, so a component that reloads its list from a click handler gets a
+ * rejection instead of data — the create still succeeds on the server, and the
+ * failed reload is what reaches the user. {@link fakeRemoteQuery} reproduces
+ * that rule; a bare `Promise` stand-in cannot.
+ */
+
+let grants: DirectGrantDto[];
+let listQuery: () => FakeQuery<DirectGrantDto[]>;
+let createImpl: () => Promise<{ token?: string }>;
+let revokeImpl: () => Promise<unknown>;
 
 vi.mock("$lib/api/generated/directGrants.generated.remote", () => ({
-  list: () => Promise.resolve([]),
-  create: () => Promise.resolve({}),
-  revoke: () => Promise.resolve(),
+  list: () => listQuery(),
+  create: () => createImpl(),
+  revoke: () => revokeImpl(),
 }));
 
 import ApiTokens from "./ApiTokens.svelte";
+
+const LOAD_FAILURE = "Failed to load API tokens.";
+
+const grant = (id: string, label: string): DirectGrantDto => ({
+  id,
+  label,
+  scopes: ["glucose.read"],
+  isLegacy: false,
+});
+
+beforeEach(() => {
+  grants = [];
+  createImpl = () => Promise.resolve({ token: "noc_created" });
+  revokeImpl = () => Promise.resolve({ success: true });
+  listQuery = fakeRemoteQuery(() => Promise.resolve(grants));
+});
 
 async function openCreateDialog() {
   const onCreateClose = vi.fn();
@@ -39,5 +73,126 @@ describe("ApiTokens", () => {
       .element(page.getByText("Create API token"))
       .not.toBeInTheDocument();
     expect(onCreateClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ApiTokens create", () => {
+  it("reports no load failure when the token was created", async () => {
+    render(ApiTokens, {
+      createOpen: true,
+      prefillLabel: "Home Assistant",
+      prefillScopes: ["glucose.read"],
+    });
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Create token" })
+      .click();
+
+    await expect.element(page.getByText("Token created")).toBeVisible();
+    await expect.element(page.getByText(LOAD_FAILURE)).not.toBeInTheDocument();
+  });
+
+  it("lists the new token without a page reload", async () => {
+    createImpl = () => {
+      grants = [grant("g-new", "Home Assistant")];
+      return Promise.resolve({ token: "noc_created" });
+    };
+
+    render(ApiTokens, {
+      createOpen: true,
+      prefillLabel: "Home Assistant",
+      prefillScopes: ["glucose.read"],
+    });
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Create token" })
+      .click();
+    await page.getByRole("button", { name: "Done" }).click();
+
+    await expect.element(page.getByText("Home Assistant")).toBeVisible();
+  });
+
+  it("still surfaces a real create failure", async () => {
+    createImpl = () =>
+      Promise.reject({ status: 400, body: { message: "Label already used." } });
+
+    render(ApiTokens, {
+      createOpen: true,
+      prefillLabel: "Home Assistant",
+      prefillScopes: ["glucose.read"],
+    });
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Create token" })
+      .click();
+
+    await expect.element(page.getByText("Label already used.")).toBeVisible();
+  });
+});
+
+describe("ApiTokens revoke", () => {
+  beforeEach(() => {
+    grants = [grant("g-1", "Old uploader key")];
+  });
+
+  it("reports success without also reporting a load failure", async () => {
+    render(ApiTokens);
+
+    await expect.element(page.getByText("Old uploader key")).toBeVisible();
+
+    // The revoke control is icon-only; it follows the card's "Create token".
+    await page.getByRole("button").nth(1).click();
+    await page.getByRole("button", { name: "Revoke" }).click();
+
+    await expect.element(page.getByText("API token revoked.")).toBeVisible();
+    await expect.element(page.getByText(LOAD_FAILURE)).not.toBeInTheDocument();
+  });
+
+  it("drops the token from the list without a page reload", async () => {
+    revokeImpl = () => {
+      grants = [];
+      return Promise.resolve({ success: true });
+    };
+
+    render(ApiTokens);
+    await expect.element(page.getByText("Old uploader key")).toBeVisible();
+
+    await page.getByRole("button").nth(1).click();
+    await page.getByRole("button", { name: "Revoke" }).click();
+
+    await expect
+      .element(page.getByText("Old uploader key"))
+      .not.toBeInTheDocument();
+  });
+
+  it("keeps the reason when the revoke itself fails", async () => {
+    revokeImpl = () =>
+      Promise.reject({ status: 409, body: { message: "Already revoked." } });
+
+    render(ApiTokens);
+    await expect.element(page.getByText("Old uploader key")).toBeVisible();
+
+    await page.getByRole("button").nth(1).click();
+    await page.getByRole("button", { name: "Revoke" }).click();
+
+    await expect.element(page.getByText("Already revoked.")).toBeVisible();
+  });
+});
+
+describe("ApiTokens load failure", () => {
+  it("does not claim there are no tokens when the list could not be loaded", async () => {
+    listQuery = fakeRemoteQuery(() =>
+      Promise.reject({ status: 500, body: { message: "boom" } })
+    );
+
+    render(ApiTokens);
+
+    await expect.element(page.getByText(LOAD_FAILURE)).toBeVisible();
+    await expect
+      .element(page.getByText("No API tokens.", { exact: false }))
+      .not.toBeInTheDocument();
   });
 });

--- a/src/Web/packages/app/src/lib/components/status-pills/IOBPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/IOBPill.svelte
@@ -38,12 +38,12 @@
     }
 
     // Basal IOB
-    if (data.basalIob !== undefined) {
+    if (data.basalIob != null) {
       items.push({ label: "Basal IOB", value: `${data.basalIob.toFixed(2)}U` });
     }
 
     // Activity (insulin impact on BG)
-    if (data.activity !== undefined && data.activity !== 0) {
+    if (data.activity != null && data.activity !== 0) {
       const activityDisplay = data.activity.toFixed(4);
       items.push({
         label: "Activity",

--- a/src/Web/packages/app/src/lib/components/status-pills/IOBPill.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/status-pills/IOBPill.svelte.test.ts
@@ -1,0 +1,69 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect } from "vitest";
+import type { IOBPillData } from "$lib/types/status-pills";
+import IOBPill from "./IOBPill.svelte";
+
+/**
+ * A device status carries an explicit `null` for a number the uploader had no
+ * value for, and the pill data types declare those fields `number | undefined`
+ * without anything enforcing it. The popover rows are built eagerly — StatusPill
+ * reads `info.length` on every render — so a `null` reaching a `.toFixed` throws
+ * during the dashboard's own render, and the authenticated layout's boundary
+ * replaces the whole page with "Something went wrong".
+ */
+/** What a device status can actually produce, which the declared type forbids. */
+type DeviceReported = Omit<IOBPillData, "basalIob" | "activity"> & {
+  basalIob?: number | null;
+  activity?: number | null;
+};
+
+const asPillData = (data: DeviceReported): IOBPillData =>
+  // The null is the point: this asserts past the very lie the fix is about.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  data as IOBPillData;
+
+const withNulls = (extra: Partial<DeviceReported>): IOBPillData =>
+  asPillData({
+    iob: 1.25,
+    display: "1.25U",
+    label: "IOB",
+    info: [],
+    level: "none",
+    ...extra,
+  });
+
+describe("IOBPill absent device-status numbers", () => {
+  it("still renders when basal IOB came through as null", async () => {
+    render(IOBPill, {
+      data: withNulls({ basalIob: null }),
+    });
+
+    await expect.element(page.getByText("1.25U")).toBeVisible();
+  });
+
+  it("still renders when insulin activity came through as null", async () => {
+    render(IOBPill, {
+      data: withNulls({ activity: null }),
+    });
+
+    await expect.element(page.getByText("1.25U")).toBeVisible();
+  });
+
+  it("omits the basal IOB row rather than inventing a value", async () => {
+    const { container } = render(IOBPill, {
+      data: withNulls({ basalIob: null }),
+    });
+
+    expect(container.textContent).not.toContain("Basal IOB");
+    expect(container.textContent).not.toContain("0.00");
+  });
+
+  it("keeps the basal IOB row when the device did report one", async () => {
+    render(IOBPill, { data: withNulls({ basalIob: 0.42 }) });
+
+    await page.getByRole("button").first().click();
+    await expect.element(page.getByText("Basal IOB")).toBeVisible();
+    await expect.element(page.getByText("0.42U")).toBeVisible();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/status-pills/LoopPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/LoopPill.svelte
@@ -47,7 +47,7 @@
         }
       } else if (data.lastEnacted.type === "cancel") {
         actionText = "<b>Temp Basal Canceled</b>";
-      } else if (data.lastEnacted.rate !== undefined) {
+      } else if (data.lastEnacted.rate != null) {
         actionText = `<b>Temp Basal Started</b> ${data.lastEnacted.rate.toFixed(2)}U/hour for ${data.lastEnacted.duration}m`;
       }
 
@@ -56,15 +56,15 @@
       }
 
       // Add IOB/COB info from loop
-      if (data.iob !== undefined) {
+      if (data.iob != null) {
         actionText += `, IOB: ${data.iob.toFixed(2)}U`;
       }
-      if (data.cob !== undefined) {
+      if (data.cob != null) {
         actionText += `, COB: ${Math.round(data.cob)}g`;
       }
 
       // Add eventual BG
-      if (data.eventualBG !== undefined) {
+      if (data.eventualBG != null) {
         actionText += `, Eventual BG: ${bg(data.eventualBG)}`;
       }
 
@@ -122,7 +122,7 @@
       }
     );
 
-    if (data.eventualBG !== undefined) {
+    if (data.eventualBG != null) {
       return `${time} ↝ ${bg(data.eventualBG)}`;
     }
 

--- a/src/Web/packages/app/tools/eslint/no-imperative-remote-query.js
+++ b/src/Web/packages/app/tools/eslint/no-imperative-remote-query.js
@@ -78,10 +78,14 @@ const rule = {
         const source = String(node.source.value ?? "");
         if (!source.includes("remote")) return;
         for (const spec of node.specifiers) {
-          if (
-            spec.type === "ImportSpecifier" &&
-            QUERY_NAMES.has(spec.local.name)
-          ) {
+          if (spec.type !== "ImportSpecifier") continue;
+          // The exported name is what the scan collected; the local name is what
+          // the call sites use. `import { list as listGrants }` differs in both.
+          const exported =
+            spec.imported.type === "Identifier"
+              ? spec.imported.name
+              : String(spec.imported.value);
+          if (QUERY_NAMES.has(exported)) {
             remoteQueryImports.add(spec.local.name);
           }
         }


### PR DESCRIPTION
Closes #573.

Three reported symptoms, two causes. Neither is where the report points.

## (a) and (b) — one cause, not two

Creating a token showed "Failed to load API tokens."; revoking one showed an error too. Both mutations actually succeeded, and the list only caught up on a page reload.

The mutation was never the problem — the **reload after it** was. `ApiTokens.svelte` did `grants = await listGrants()` inside `loadGrants()`, and called it from the create and revoke click handlers. A SvelteKit remote query proxy decides *in its constructor* whether it was built in a tracking context (`QueryProxy` sets `#tracking = is_in_effect()`, kit 2.59.1 `client/remote-functions/query.svelte.js`). Built in a DOM event handler it was not, so `#get_cached_query()` throws `"This query was not created in a reactive context and cannot be awaited"` — before any request leaves the browser.

`loadGrants()` swallowed that into its own message, which explains both screenshots:

- create: the token dialog shows "Token created" *and* the red banner, because `createdToken` was already set and `loadGrants()` did not rethrow;
- revoke: the reporter's screenshot shows the red "Failed to load API tokens." **above** the green "API token revoked." — reachable only if the reload threw and was caught inside `loadGrants` while `revokeGrant` resolved. Revoke's own `"Failed to revoke token."` was unreachable dead code.

Reporter theories that were wrong, for the record:

- **The stray leading "A" is not a message-composition artefact.** It is the `AlertTriangle` lucide icon next to the text, transcribed from the screenshot. The string is a hardcoded constant with no interpolation at all.
- **`HttpError` having no `.message` is not involved**, nor is ProblemDetails `detail`: nothing on that path read a field off the error.
- It is not an authorization or `Invalidates` naming problem, and not a race against the create's transaction. No request was made.

**Fix.** The list is built once at component init — a tracking context whose registration lives as long as the component — and read through `.current`, with the handlers refreshing that instance. `list` already declares its invalidation from both `create` and `revoke`, and the payloads match (`list(undefined)` vs a no-arg `listGrants()`), so the explicit `refresh()` is belt-and-braces against the client-side registration failure mode that #1013 turned out to be. This is the pattern `GuestLinksSection` and 11 other call sites already use.

Two smaller faults fixed while there: a failed load no longer renders the "No API tokens." empty state (it said there were none when we could not tell), and a failed revoke keeps the server's reason instead of discarding it.

## (c) — a different cause

A device status is uploaded JSON, and an uploader writes an explicit `null` for a number it has no value for. The **legacy** `DeviceStatus` processors lifted those straight into pill data (`basalIob: iobData.basaliob`, `result.iob = loopData.iob.iob`, `rate: enacted.rate`), whose types declare them `number | undefined` with nothing enforcing it — `getOpenApsIob` casts from `unknown`, so TypeScript never sees the lie. The pill components then tested `!== undefined` before calling `.toFixed`, which a `null` passes.

Two things make this take out the whole page rather than one pill: `StatusPill` reads `info.length` on **every render**, so those popover rows are built eagerly and not lazily on open; and the throw lands in the `(authenticated)/+layout.svelte` `<svelte:boundary>`, which is what renders the reported "Something went wrong / Cannot read properties of null (reading 'toFixed')" card.

The "after a period of inactivity" framing is the tell: the **snapshot** processors already coalesce (`latest.basalIob ?? undefined`) and only the legacy `DeviceStatus` ones did not, and which of the two runs turns on recency windows that lapse while a tab sits idle.

**Fix.** Every lift out of a device status goes through one `statusNumber` helper, making the declared types true; the component guards read `!= null` so a future raw assignment cannot blank the dashboard again. An absent value keeps the behaviour the guards already intended — **the row is omitted**, not filled with a `0` that would read as a real insulin figure on a diabetes dashboard.

## Two things outside the three symptoms

A reviewer will reasonably ask why these are here.

- **`tools/eslint/no-imperative-remote-query.js`.** This rule exists to catch precisely bug (a)/(b) and its message describes the failure verbatim — it just never fired, because it matched imported names against `spec.local` instead of `spec.imported`. The aliased `list as listGrants` therefore never entered its watch set, which is why this shipped. One-line class of fix; it now guards every component, not just this one.
- **`src/lib/api/fake-remote-query.svelte.ts`.** The existing test double was `list: () => Promise.resolve([])`. A bare `Promise` cannot express the rule that broke here, so the old tests passed against the broken component. The double probes tracking the same way SvelteKit does, so it agrees with the runtime on the one thing it models.

## Verification

- `vitest run --config vitest.config.ts` (Node): **101 files, 1132 passed, 1 skipped, exit 0.**
- `pnpm check`: **76 errors / 11 warnings, byte-identical to the pre-change baseline**, none in any file touched.
- Mutation proof, boundary fix: reverting only the `statusNumber` calls (file copied outside the worktree and restored by copy) fails both new tests with `expected null to be undefined` — the exact null that reaches `.toFixed`. Restored, 37/37 pass.
- Mutation proof, lint rule: with the rule fixed, linting the **pre-change** `ApiTokens.svelte` reports `Remote query 'listGrants' is called imperatively` at line 86 — the `await listGrants()` this PR removes. The post-change file does not report it.
- Lint over changed files: 37 problems vs **36 on the same files before**. The delta is −1 warning and −2 errors in `ApiTokens.svelte`, +4 in `pills-processor.test.ts` from the `as any[]` fixture idiom the 14 existing tests in that file already use (`loop.iob.iob` is typed `number`, so injecting a null needs it).

## Residual risk, stated plainly

- **The browser component tests in this PR have never been executed.** The `vitest-browser-svelte` runner fails to connect to a chromium session on my machine — reproduced with a pre-existing, untouched test (`ReservoirPill`) in both a worktree and a clean checkout, so it is environmental, not this change. The Node suite above is fully green. `@nocturne/app` vitest also runs in **no CI job** (`tests.yml` is .NET-only), so nothing will run these on merge either. `ApiTokens.svelte.test.ts` and `IOBPill.svelte.test.ts` should be treated as unverified until someone with a working browser runner confirms them; the executed guards for (a)/(b) are the lint rule and the reasoning above, not those tests. This is the weakest claim in the PR.
- The `.toFixed`-on-a-JSON-null class is **wider than the status pills**. The report pages hold many `.toFixed` calls on optional generated-DTO numbers, which NSwag assigns raw JSON nulls into. I fixed the dashboard members of the class, because that is where the report puts it and because a throw there blanks the page a user opens to see their glucose. The rest is not touched and wants its own sweep.
- `processBasal` still guards `enacted.rate !== undefined && enacted.duration !== undefined` (lines 828/849) when building `tempBasal`. `BasalPill`'s only `.toFixed` there is on `scheduledBasal`, which is computed rather than lifted, so it is not a live crash — but it is the same idiom and would become one if a lifted field were rendered.
- Relying on the declared invalidation *plus* an explicit `refresh()` costs one extra GET on create/revoke. I judged a guaranteed-correct list worth more than the round trip on a rare action, given #1013.
