### PR TITLE
fix(api): keep the static connector catalog out of every tenant's settings row

### DIFF
--- a/src/API/Nocturne.API/Services/Profiles/UISettingsService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/UISettingsService.cs
@@ -17,6 +17,9 @@ namespace Nocturne.API.Services.Profiles;
 /// assembled on read from the section rows rather than stored, and the alarm configuration lives
 /// only under <c>ui:settings:notifications:alarms</c> — the notifications row is written without its
 /// <see cref="NotificationSettings.AlarmConfiguration"/> so no second copy can go stale.
+/// Anything a read serves but no tenant owns gets no row at all, per
+/// <see cref="UISettingsSection.OmittedProperties"/>, so a client that sends it back cannot persist
+/// it.
 /// <c>ui:settings:complete</c>, written by earlier versions, is read-only: it is the fallback for a
 /// section that has no row of its own, which is how tenants whose settings predate this layout keep
 /// reading correctly.
@@ -323,9 +326,9 @@ public class UISettingsService : IUISettingsService
     }
 
     /// <summary>
-    /// Stages the row owning <paramref name="sectionSettings"/>. The notifications section splits in
-    /// two: its alarm configuration goes to the row that owns it, and the section row is written
-    /// without that property.
+    /// Stages the row owning <paramref name="sectionSettings"/>, minus whatever the section's
+    /// <see cref="UISettingsSection.OmittedProperties"/> keeps off it. The notifications section
+    /// splits in two, so its alarm configuration is additionally staged to the row that owns it.
     /// </summary>
     private async Task WriteSectionAsync(
         string sectionName,
@@ -333,8 +336,6 @@ public class UISettingsService : IUISettingsService
         CancellationToken cancellationToken
     )
     {
-        var notes = $"UI settings section: {sectionName}";
-
         if (sectionSettings is NotificationSettings notifications)
         {
             await UpsertAsync(
@@ -343,25 +344,37 @@ public class UISettingsService : IUISettingsService
                 AlarmConfigurationNotes,
                 cancellationToken
             );
-
-            var node = JsonSerializer.SerializeToNode(notifications, JsonOptions)!.AsObject();
-            node.Remove("alarmConfiguration");
-
-            await UpsertAsync(
-                GetSectionKey(sectionName),
-                node.ToJsonString(),
-                notes,
-                cancellationToken
-            );
-            return;
         }
 
         await UpsertAsync(
             GetSectionKey(sectionName),
-            JsonSerializer.Serialize(sectionSettings, JsonOptions),
-            notes,
+            SerializeForRow(sectionName, sectionSettings),
+            $"UI settings section: {sectionName}",
             cancellationToken
         );
+    }
+
+    /// <summary>
+    /// The JSON a section's row stores: the section as serialized, less the properties no row of
+    /// this section carries.
+    /// </summary>
+    private static string SerializeForRow(string sectionName, object sectionSettings)
+    {
+        var omitted = UISettingsSections.Find(sectionName)?.OmittedProperties ?? [];
+
+        if (omitted.Count == 0)
+        {
+            return JsonSerializer.Serialize(sectionSettings, JsonOptions);
+        }
+
+        var node = JsonSerializer.SerializeToNode(sectionSettings, JsonOptions)!.AsObject();
+
+        foreach (var property in omitted)
+        {
+            node.Remove(property);
+        }
+
+        return node.ToJsonString();
     }
 
     private async Task UpsertAsync(

--- a/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
@@ -637,6 +637,11 @@ public class ServicesSettings
     [JsonPropertyName("connectedServices")]
     public List<ConnectedService> ConnectedServices { get; set; } = new();
 
+    /// <summary>
+    /// The connector catalog, served from <c>ConnectorMetadataService</c> on every read. It is
+    /// build-time metadata rather than tenant state, so the services row omits it — see
+    /// <see cref="UISettingsSection.OmittedProperties"/>.
+    /// </summary>
     [JsonPropertyName("availableServices")]
     public List<AvailableService> AvailableServices { get; set; } = new();
 

--- a/src/Core/Nocturne.Core.Models/Configuration/UISettingsSections.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UISettingsSections.cs
@@ -10,7 +10,15 @@ public sealed record UISettingsSection(
     Type Type,
     Func<UISettingsConfiguration, object?> Get,
     Action<UISettingsConfiguration, object> Set
-);
+)
+{
+    /// <summary>
+    /// JSON property names the section's own row must not carry, either because another row owns
+    /// the value or because it is not tenant state at all. A client that sends one back cannot
+    /// make it stick.
+    /// </summary>
+    public IReadOnlyList<string> OmittedProperties { get; init; } = [];
+}
 
 /// <summary>
 /// The sections of <see cref="UISettingsConfiguration"/>. Routing, persistence and section lookup all
@@ -51,13 +59,19 @@ public static class UISettingsSections
             typeof(NotificationSettings),
             s => s.Notifications,
             (s, v) => s.Notifications = (NotificationSettings)v
-        ),
+        )
+        {
+            OmittedProperties = ["alarmConfiguration"],
+        },
         new(
             "services",
             typeof(ServicesSettings),
             s => s.Services,
             (s, v) => s.Services = (ServicesSettings)v
-        ),
+        )
+        {
+            OmittedProperties = ["availableServices"],
+        },
         new(
             "dataQuality",
             typeof(DataQualitySettings),

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerConnectorCatalogTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerConnectorCatalogTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+using static Nocturne.API.Tests.Controllers.V4.Profiles.UISettingsControllerHarness;
+
+namespace Nocturne.API.Tests.Controllers.V4.Profiles;
+
+/// <summary>
+/// Coverage for the connector catalog <see cref="UISettingsController"/> serves on every read. It is
+/// build-time metadata, so no tenant may store a snapshot of it — including the tenant whose client
+/// reads the whole document and saves it straight back.
+/// </summary>
+[Trait("Category", "Unit")]
+public class UISettingsControllerConnectorCatalogTests
+{
+    [Fact]
+    public async Task SaveUISettings_doesNotPersistTheCatalogTheReadInjected()
+    {
+        var database = NewDatabase();
+        var controller = NewController(database);
+
+        var served = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
+        served.Services.AvailableServices.Add(
+            new AvailableService { Id = "dexcom-connector", Name = "Dexcom Share" }
+        );
+
+        await controller.SaveUISettings(served);
+
+        var rows = StoredValues(database);
+        rows.Should().NotBeEmpty();
+        rows.Where(v => v.Contains("availableServices", StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
+        rows.Where(v => v.Contains("dexcom-connector", StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetUISettings_servesTheCatalogFromTheRegistryNotTheStoredSection()
+    {
+        var database = NewDatabase();
+        var controller = NewController(database);
+        var settings = new UISettingsConfiguration();
+        settings.Services.AvailableServices.Add(
+            new AvailableService { Id = "retired-connector", Name = "Retired" }
+        );
+        settings.Services.SyncSettings.AutoSync = false;
+        await controller.SaveUISettings(settings);
+
+        var served = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
+
+        served
+            .Services.AvailableServices.Should()
+            .BeEquivalentTo(ConnectorMetadataService.GetAvailableServices());
+        served.Services.AvailableServices.Should().NotContain(s => s.Id == "retired-connector");
+        served.Services.SyncSettings.AutoSync.Should().BeFalse();
+    }
+
+    private static List<string> StoredValues(NocturneDbContext database)
+    {
+        return database
+            .Settings.AsNoTracking()
+            .Where(s => s.Value != null)
+            .Select(s => s.Value!)
+            .ToList();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -22,6 +24,7 @@ public class UISettingsServiceTests
     private const string LegacyAggregateKey = "ui:settings:complete";
     private const string NotificationsKey = "ui:settings:notifications";
     private const string AlarmsKey = "ui:settings:notifications:alarms";
+    private const string ServicesKey = "ui:settings:services";
 
     private static readonly Guid TenantId = Guid.Parse("33333333-3333-3333-3333-333333333333");
 
@@ -356,7 +359,105 @@ public class UISettingsServiceTests
         stored.Should().BeEquivalentTo(new UISettingsConfiguration());
     }
 
+    [Fact]
+    public async Task SaveSettingsAsync_doesNotStoreTheConnectorCatalog()
+    {
+        var context = NewContext();
+        var service = NewService(context);
+
+        await service.SaveSettingsAsync(
+            new UISettingsConfiguration
+            {
+                Services = new ServicesSettings
+                {
+                    AvailableServices = [Catalogued("dexcom-connector")],
+                    SyncSettings = new SyncSettings { AutoSync = false },
+                },
+            }
+        );
+
+        StoredRows(context).Select(r => r.Key).Should().Contain(ServicesKey);
+        StoredRows(context)
+            .Where(r => r.Value!.Contains("availableServices", StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
+        StoredRows(context)
+            .Where(r => r.Value!.Contains("dexcom-connector", StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
+
+        var stored = await service.GetSettingsAsync();
+        stored.Services.AvailableServices.Should().BeEmpty();
+        stored.Services.SyncSettings.AutoSync.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SaveSectionAsync_doesNotStoreTheConnectorCatalog()
+    {
+        var context = NewContext();
+        var service = NewService(context);
+
+        await service.SaveSectionAsync(
+            "services",
+            new ServicesSettings { AvailableServices = [Catalogued("dexcom-connector")] }
+        );
+
+        StoredRows(context).Select(r => r.Key).Should().Contain(ServicesKey);
+        StoredRows(context)
+            .Where(r => r.Value!.Contains("availableServices", StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public async Task SaveSettingsAsync_dropsACatalogSnapshotAnEarlierVersionStored()
+    {
+        var context = NewContext();
+        Seed(
+            context,
+            ServicesKey,
+            new ServicesSettings { AvailableServices = [Catalogued("retired-connector")] }
+        );
+        await context.SaveChangesAsync();
+
+        var service = NewService(context);
+        await service.SaveSettingsAsync(await service.GetSettingsAsync());
+
+        StoredRows(context)
+            .Where(r => r.Value!.Contains("retired-connector", StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public void OmittedProperties_nameJsonPropertiesTheirSectionDeclares()
+    {
+        foreach (var section in UISettingsSections.All)
+        {
+            var declared = section
+                .Type.GetProperties()
+                .Select(p => p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name)
+                .Where(name => name != null)
+                .ToList();
+
+            section
+                .OmittedProperties.Should()
+                .BeSubsetOf(declared!, $"section {section.Name} can only omit what it declares");
+        }
+    }
+
     // ----- helpers -----
+
+    private static AvailableService Catalogued(string id)
+    {
+        return new AvailableService
+        {
+            Id = id,
+            Name = id,
+            Type = "cgm",
+            Icon = id,
+        };
+    }
 
     /// <summary>
     /// The alarm configuration as returned by every public read path, so a copy that goes stale


### PR DESCRIPTION
Closes #880. Item 4 was the only item still live on `main`. Items 1, 2, 3 and 5 landed in #893 (plus #920 and #1034); I re-verified each against `main` before touching anything and did not invent work for them.

## Item 4 - the static connector catalog is persisted per tenant (premise HELD, fixed)

`GET /api/v4/ui-settings` injects `ConnectorMetadataService.GetAvailableServices()` into `settings.Services.AvailableServices`. That catalog is build-time metadata, scanned off the `ConnectorRegistration` attributes of the loaded connector assemblies - not tenant state. But the web app reads the whole document and saves it straight back, so every settings save wrote a snapshot of the catalog into the tenant's `ui:settings:services` row, where it goes stale as connectors are added, renamed or retired.

Two independent client paths do it, which is why this needed fixing server-side:

- `saveUiSettingsSection` (`src/Web/.../lib/api/ui-settings.remote.ts`) spreads the GET response into the PUT body.
- `SettingsStore.save()` (`src/Web/.../lib/stores/settings-store.svelte.ts`) sends `this.services`, a shallow copy of the GET response's services.

**Fixed on the server, not the client.** A client fix would leave the rows already written, and would not stop the other path - or any other client - re-persisting them. `UISettingsSection` now declares `OmittedProperties`, the JSON property names a section's own row must not carry, and `UISettingsService.WriteSectionAsync` strips them before the upsert. Two entries use it:

- `services` omits `availableServices` - not tenant state at all.
- `notifications` omits `alarmConfiguration`, which was already being stripped by a hand-rolled branch. That branch's `node.Remove("alarmConfiguration")` is gone; the registry now owns both exclusions, so the notifications special case is reduced to the one thing genuinely special about it - the extra write to the row that *does* own the alarm configuration.

Nothing reads `AvailableServices` back out of persistence (repo sweep: the only reads are the two injection sites and the demo service's own generator), so no consumer changes behaviour.

### No data migration needed

Snapshots already stored are invisible over the API - `GET /api/v4/ui-settings`, and `GET /api/v4/ui-settings/{section}` which delegates to it, both overwrite `availableServices` from the live catalog on every read. And the rows self-heal: `SaveSettingsAsync` rewrites every section row, so the tenant's next settings save drops the snapshot. The only residue is dead bytes in a `settings` row nothing reads. I have not written a migration and do not think one is warranted; if a maintainer wants the rows scrubbed eagerly it is a JSON key removal over `settings` where `key = 'ui:settings:services'` - happy to file that separately rather than smuggle it in here.

## Items already fixed - re-verified, no work done

**1. `GET /{section}` cannot serve `dataQuality` or `security`** - premise no longer holds. #893 replaced the five-case switch with `UISettingsSections.Find` (the controller now has zero `case "devices"` / `switch (section)` occurrences), so `dataQuality` is served and `UISettingsControllerSectionTests` already covers it. The `security` half is *moot* rather than fixed: #1034 removed site lockdown and with it `SecuritySettings` and its registry entry, so there is no security section left to route. Deliberately not reintroduced.

**2. The four built-in alarm profiles are unreachable** - decided in #893, and I agree with the decision, so nothing changed. Restating it explicitly because it is an alarm path:

> **A virgin tenant gets an empty `UserAlarmConfiguration`, not the four built-ins.**

Rationale: seeding profiles nobody configured would fire alarms nobody asked for, at thresholds (55/70/180/250 mg/dL) that were only ever chosen as demo fixture values, not for any particular person - and a user who believes alarms are off while thresholds are live is worse off than one who sees an obviously empty list. The three `?? GenerateDefaultAlarmConfiguration()` arms were never a virgin-tenant path at all: `GetAlarmConfigurationAsync` returns null only when the read *throws*, so on the profile POST/DELETE routes substituting defaults would have written the four built-ins over the tenant's real profiles. They are now `AlarmConfigurationUnavailable()` (500). The generator survives as `GenerateDemoAlarmConfiguration`, reachable only from the demo-mode branch of `GET notifications/alarms`.

Flagging for maintainer confirmation: if the intent was ever that a new tenant *should* arrive with sensible low/high alarms configured, that is a product decision this PR does not make, and it should be seeded explicitly at tenant creation rather than fabricated on a failed read.

**3. A third, drifted copy of the defaults in demo mode** - premise no longer holds. #893 collapsed `GenerateDefaultSettings` / `GenerateDefaultFeatureSettings` / `GenerateDefaultNotificationSettings` / `GenerateDefaultServicesSettings` onto the model initialisers (zero occurrences remain), and `UISettingsControllerSectionTests` asserts demo mode inherits every section it does not fixture. The widget-list drift went with them. Widget ownership (#1209) untouched.

**5. Unused constructor dependency** - premise no longer holds; `IConfiguration` was dropped from `UISettingsService` in #893 and from the controller in #920. Zero occurrences in either file.

## Tests

Six new tests, all in `tests/Unit/Nocturne.API.Tests` - a CI-covered project (`.github/workflows/tests.yml` runs `tests/Unit/*/`). Nothing landed in the API integration project.

| Test | What it pins |
| --- | --- |
| `SaveSettingsAsync_doesNotStoreTheConnectorCatalog` | Whole-document save: the services row exists but carries neither `availableServices` nor the entry's id, and the round-trip still keeps the section's real state |
| `SaveSectionAsync_doesNotStoreTheConnectorCatalog` | The typed section write path |
| `SaveSettingsAsync_dropsACatalogSnapshotAnEarlierVersionStored` | Seeds a pre-fix row and pins the self-heal claim above |
| `SaveUISettings_doesNotPersistTheCatalogTheReadInjected` | The controller reproducing the client's read-modify-write end to end |
| `GetUISettings_servesTheCatalogFromTheRegistryNotTheStoredSection` | The read still answers from the registry; a stale stored id cannot surface |
| `OmittedProperties_nameJsonPropertiesTheirSectionDeclares` | Registry invariant, so an omission naming a property its section does not declare cannot silently do nothing |

## Verification

Baseline on `origin/main` before any change, same filter: **51 passed, 0 failed**.
After the change: **57 passed, 0 failed** (51 + 6).

Mutation-proved, one mutation at a time, reverting by copying the file back from outside the worktree:

- **Drop `OmittedProperties = ["availableServices"]`** -> 4 failed / 53 passed. Exactly the four regression tests: `SaveSettingsAsync_doesNotStoreTheConnectorCatalog`, `SaveSectionAsync_doesNotStoreTheConnectorCatalog`, `SaveSettingsAsync_dropsACatalogSnapshotAnEarlierVersionStored`, `SaveUISettings_doesNotPersistTheCatalogTheReadInjected`.
- **Typo it to `["availableService"]`** -> 5 failed / 52 passed. Those four plus `OmittedProperties_nameJsonPropertiesTheirSectionDeclares`, which is that test's own attribution.
- **Drop `OmittedProperties = ["alarmConfiguration"]` from notifications** -> 1 failed / 56 passed: the pre-existing `SaveSettingsAsync_storesTheAlarmConfigurationInOneRowOnly`. This is the proof that moving the notifications exclusion onto the registry did not quietly drop it.

## Weakest claim

`GetUISettings_servesTheCatalogFromTheRegistryNotTheStoredSection` is a **guard, not a regression test** - it passes on the unfixed code too, because the read always overwrote `availableServices`. It is there to keep the read authoritative, and it is the reason no migration is needed; it is not evidence for the fix. It also asserts against `ConnectorMetadataService.GetAvailableServices()` rather than a literal list, because that scan walks *loaded* assemblies and caches process-wide, so its contents are not deterministic inside a unit-test run. That makes the assertion self-consistent but weaker than a fixed expectation.

## Behavioural deltas

- Persisted `ui:settings:services` rows no longer carry `availableServices`. **No API response changes** - the read injects the live catalog either way, and the property stays on the DTO, so no client or generated-client change is needed.
- A tenant whose row already holds a snapshot keeps it until their next settings save, and never sees it.
