### PR TITLE
fix(v1): echo every submitted entry, including the ones we refuse

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -530,10 +530,31 @@ public class EntriesController : ControllerBase
                 );
             }
 
-            // Validate entries have meaningful data
-            var validEntries = entriesToCreate.Where(HasMeaningfulData).ToList();
+            // Fill in derived fields for every submitted entry, not just the ones that will be
+            // written: a refused entry is still echoed, and the echo has to be a well-formed v1
+            // object. Doing this before the refusal check cannot change which entries are refused
+            // — NormalizeEntry only defaults an empty type to "sgv", which HasMeaningfulData
+            // treats the same as empty, and only fills dateString when mills > 0, which already
+            // made the entry meaningful.
+            foreach (var entry in entriesToCreate)
+            {
+                NormalizeEntry(entry);
+            }
 
-            if (validEntries.Count == 0)
+            // Entries carrying no usable data are refused rather than written, but a refused entry
+            // still occupies its position in the response: v1 uploaders require one response object
+            // per submitted entry and treat a shorter array as a failed upload, which wedges the
+            // client on that batch forever (see PartitionStoredEntriesAsync).
+            var acceptedIndices = new List<int>(entriesToCreate.Count);
+            for (var i = 0; i < entriesToCreate.Count; i++)
+            {
+                if (HasMeaningfulData(entriesToCreate[i]))
+                {
+                    acceptedIndices.Add(i);
+                }
+            }
+
+            if (acceptedIndices.Count == 0)
             {
                 return BadRequest(
                     new
@@ -545,11 +566,9 @@ public class EntriesController : ControllerBase
                 );
             }
 
-            // Validate and prepare entries
-            foreach (var entry in validEntries)
-            {
-                NormalizeEntry(entry);
-            }
+            LogRefusedEntries(entriesToCreate.Count, entriesToCreate.Count - acceptedIndices.Count);
+
+            var validEntries = acceptedIndices.ConvertAll(i => entriesToCreate[i]);
 
             // Process entries for sanitization and timestamp conversion
             var processedEntries = _documentProcessingService.ProcessDocuments(validEntries);
@@ -578,7 +597,9 @@ public class EntriesController : ControllerBase
             // Evaluate alert rules against the latest created entry
             await _alertEvaluator.EvaluateForEntriesAsync(createdArray, cancellationToken);
 
-            return StatusCode(201, responseEntries.ToV1Responses());
+            var echo = BuildSubmittedOrderEcho(entriesToCreate, acceptedIndices, responseEntries);
+
+            return StatusCode(201, echo.ToV1Responses());
         }
         catch (JsonException ex)
         {
@@ -593,6 +614,54 @@ public class EntriesController : ControllerBase
                 }
             );
         }
+    }
+
+    /// <summary>
+    /// Rebuilds the response in submitted order: the processed entry for every entry that was
+    /// accepted, and the submitted entry unchanged for every one that was refused. The result has
+    /// exactly one element per submitted entry, which is the contract v1 uploaders depend on —
+    /// see <see cref="PartitionStoredEntriesAsync"/>.
+    /// </summary>
+    private static Entry[] BuildSubmittedOrderEcho(
+        List<Entry> submitted,
+        List<int> acceptedIndices,
+        List<Entry> acceptedResponses
+    )
+    {
+        if (acceptedResponses.Count != acceptedIndices.Count)
+        {
+            throw new InvalidOperationException(
+                $"Echo has {acceptedResponses.Count} entries for {acceptedIndices.Count} accepted entries");
+        }
+
+        // Refused entries are already in place; accepted ones are replaced by what the write path
+        // resolved them to (the submitted entry, or the stored row it duplicated).
+        var echo = submitted.ToArray();
+        for (var i = 0; i < acceptedIndices.Count; i++)
+        {
+            echo[acceptedIndices[i]] = acceptedResponses[i];
+        }
+
+        return echo;
+    }
+
+    /// <summary>
+    /// Records one line when a batch carried entries with no usable data. A refusal is invisible in
+    /// the response by design — the entry is echoed so the uploader's batch is not rejected — so
+    /// this is the only signal that a client is sending readings we will never store.
+    /// </summary>
+    private void LogRefusedEntries(int submitted, int refused)
+    {
+        if (refused == 0)
+            return;
+
+        _logger.LogInformation(
+            "Refused {Refused} of {Submitted} submitted entries carrying no glucose value, "
+                + "timestamp or non-sgv type; they are echoed but not stored. Client {UserAgent}",
+            refused,
+            submitted,
+            SanitizeForLog(Request?.Headers.UserAgent.ToString())
+        );
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
@@ -176,6 +176,7 @@ public class EntriesControllerTests
         {
             new Entry { Sgv = 120 }, // Valid
             new Entry { Type = "cal" }, // Valid - non-sgv type
+            new Entry(), // Invalid - sgv type with no value and no timestamp
         };
 
         // Track what gets passed to ProcessDocuments
@@ -485,6 +486,164 @@ public class EntriesControllerTests
         // Only the two non-duplicates are written
         createInput.Should().NotBeNull();
         createInput!.Select(e => e.Mills).Should().Equal(1000, 3000);
+    }
+
+    [Fact]
+    public async Task CreateEntries_RefusedEntry_StillEchoesOneResponsePerSubmittedEntry()
+    {
+        // A batch carrying one unusable reading — a CGM sentinel with no value and no timestamp —
+        // must still be echoed in full. A short array reads as a failed upload to NightscoutKit,
+        // which re-queues the batch and never uploads anything newer, so the tenant's CGM data
+        // stops arriving entirely.
+        var submitted = new[]
+        {
+            new Entry { Sgv = 120, Mills = 1000, Device = "Dexcom G7" },
+            new Entry(), // no value, no timestamp, type defaults to sgv
+            new Entry { Sgv = 140, Mills = 3000, Device = "Dexcom G7" },
+        };
+
+        _mockDocumentProcessingService
+            .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
+            .Returns<IEnumerable<Entry>>(entries => entries);
+
+        StubNothingStored();
+
+        List<Entry>? createInput = null;
+        _mockEntryService
+            .Setup(x =>
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
+            )
+            .Callback<IEnumerable<Entry>, WriteOrigin, CancellationToken>((entries, _, _) => createInput = entries.ToList())
+            .ReturnsAsync((IEnumerable<Entry> entries, WriteOrigin _, CancellationToken _) => entries.ToList());
+
+        // Act
+        var result = await _controller.CreateEntries(submitted);
+
+        // Assert
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(201);
+
+        var body = objectResult
+            .Value.Should()
+            .BeAssignableTo<IEnumerable<object>>()
+            .Subject.Cast<EntryV1Response>()
+            .ToList();
+
+        // One object per submitted entry, each in its submitted position.
+        body.Should().HaveCount(3);
+        body[0].Mills.Should().Be(1000);
+        body[2].Mills.Should().Be(3000);
+
+        // The refused entry is echoed as a well-formed v1 object — it carries an _id even though
+        // nothing was stored, so the uploader can decode the array.
+        body[1].Mills.Should().Be(0);
+        body[1].Id.Should().NotBeNullOrEmpty();
+
+        // ...but it is not written.
+        createInput.Should().NotBeNull();
+        createInput!.Select(e => e.Mills).Should().Equal(1000, 3000);
+    }
+
+    [Fact]
+    public async Task CreateEntries_RefusedAndDuplicate_KeepsEverySubmittedPosition()
+    {
+        // The two reasons an entry is not written — refused, and already stored — in one batch.
+        // Both still occupy their slot in the response.
+        var submitted = new[]
+        {
+            new Entry(), // refused
+            new Entry { Sgv = 130, Mills = 2000, Device = "Dexcom G7" }, // already stored
+            new Entry { Sgv = 140, Mills = 3000, Device = "Dexcom G7" }, // written
+        };
+        var storedDuplicate = new Entry { Id = "stored-dup", Sgv = 130, Mills = 2000, Device = "Dexcom G7", Type = "sgv" };
+
+        _mockDocumentProcessingService
+            .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
+            .Returns<IEnumerable<Entry>>(entries => entries);
+
+        StubStoredAt((2000L, storedDuplicate));
+
+        List<Entry>? createInput = null;
+        _mockEntryService
+            .Setup(x =>
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
+            )
+            .Callback<IEnumerable<Entry>, WriteOrigin, CancellationToken>((entries, _, _) => createInput = entries.ToList())
+            .ReturnsAsync((IEnumerable<Entry> entries, WriteOrigin _, CancellationToken _) => entries.ToList());
+
+        // Act
+        var result = await _controller.CreateEntries(submitted);
+
+        // Assert
+        var body = result
+            .Result.Should()
+            .BeOfType<ObjectResult>()
+            .Subject.Value.Should()
+            .BeAssignableTo<IEnumerable<object>>()
+            .Subject.Cast<EntryV1Response>()
+            .ToList();
+
+        body.Should().HaveCount(3);
+        body[0].Mills.Should().Be(0); // refused, echoed
+        body[1].Id.Should().Be("stored-dup"); // duplicate, echoed as the stored row
+        body[2].Mills.Should().Be(3000); // written
+
+        createInput.Should().NotBeNull();
+        createInput!.Select(e => e.Mills).Should().Equal(3000);
+    }
+
+    [Fact]
+    public async Task CreateEntries_EveryEntryRefused_StillReturnsBadRequest()
+    {
+        // Echoing refusals does not turn a wholly unusable batch into a success.
+        var result = await _controller.CreateEntries(new[] { new Entry(), new Entry() });
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _mockEntryService.Verify(
+            x => x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task CreateEntries_RefusedEntry_ReportsTheRefusalAndTheClient()
+    {
+        // A refusal is invisible in the response by design, so the log line is the only way to
+        // find a client sending readings that will never be stored.
+        _mockDocumentProcessingService
+            .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
+            .Returns<IEnumerable<Entry>>(entries => entries);
+        StubNothingStored();
+        _controller.ControllerContext.HttpContext.Request.Headers.UserAgent = "Loop/57 CFNetwork Darwin";
+
+        await _controller.CreateEntries(new[] { new Entry { Sgv = 120, Mills = 1000 }, new Entry() });
+
+        VerifyInformationLogged("Refused 1 of 2 submitted entries", Times.Once());
+        VerifyInformationLogged("Loop/57 CFNetwork Darwin", Times.Once());
+    }
+
+    [Fact]
+    public async Task CreateEntries_NoEntryRefused_DoesNotReportARefusal()
+    {
+        _mockDocumentProcessingService
+            .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
+            .Returns<IEnumerable<Entry>>(entries => entries);
+        StubNothingStored();
+
+        await _controller.CreateEntries(new[] { new Entry { Sgv = 120, Mills = 1000 } });
+
+        VerifyInformationLogged("Refused", Times.Never());
+    }
+
+    [Fact]
+    public async Task CreateEntries_EmptyTypeWithNoData_IsStillRefused()
+    {
+        // Derived fields are now filled in before the refusal check, and NormalizeEntry defaults an
+        // empty type to "sgv". That must not rescue an entry: HasMeaningfulData accepts a type only
+        // when it is neither empty nor "sgv", so both forms have to land the same way.
+        var result = await _controller.CreateEntries(new[] { new Entry { Type = "" } });
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #1295.

`POST /api/v1/entries` built its response array from the entries that survived validation rather than the entries that were submitted. An entry dropped by `HasMeaningfulData` therefore shortened the response, and NightscoutKit reads a short array as a failed upload: it re-queues the batch and re-sends it next cycle, forever. The client never advances, so the tenant's CGM data stops arriving entirely — while treatments and devicestatus, which go to other endpoints, keep flowing.

The comment above `PartitionStoredEntriesAsync` already described this failure. #1284 fixed the **duplicate** source of shortening; this is the **validation** source, which sits upstream of the echo and was never covered.

## What triggers it

`HasMeaningfulData` refuses an entry only when it has no glucose value, no usable timestamp, and a type that is empty or `sgv`. A CGM sentinel reading — a sensor error or warmup placeholder — is exactly that shape. One of them anywhere in a 1,000-entry Loop batch is enough to wedge the client permanently, which is why this hits one tenant and not the rest.

The refusal was also silent: no log line, and nothing in the response to say an entry had been dropped.

## Change

The response is reassembled in submitted order. A refused entry is echoed as submitted; a duplicate still echoes the stored row; everything else echoes what the write path resolved it to. The write path itself is unchanged, and a wholly unusable batch still gets its `400`.

Derived fields are now filled in for every submitted entry rather than only the accepted ones, so a refused entry echoes as a well-formed v1 object with an `_id`. That cannot change which entries are refused: `NormalizeEntry` only defaults an empty type to `sgv` — which `HasMeaningfulData` already treats the same as empty — and only fills `dateString` when `mills > 0`, which already made the entry meaningful. There is a test pinning that equivalence.

Refusals are logged once per batch with the client's User-Agent, sanitised the same way the re-upload line is.

The async endpoint discards the echo, so it is untouched.

## Tests

`CreateEntries_WithMixedValidAndInvalidEntries_ProcessesOnlyValidOnes` read as coverage for this but contained two valid entries and no invalid one, and asserted nothing about the response. It is actually mixed now.

New: the echo positions for a refused entry; a refused entry alongside a duplicate and a new entry; the all-refused `400`; both branches of the refusal log; and an empty type still being refused.

Both echo tests fail against the previous behaviour — verified by reverting the reassembly and re-running (2 failed, 19 passed).
