### PR TITLE
fix(support): make the diagnostics toggles attach what they promise

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Platform/SupportController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/SupportController.cs
@@ -2,8 +2,11 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
 using Nocturne.API.Configuration;
 using Nocturne.API.Services;
+using Nocturne.Core.Models.Authorization;
 using OpenApi.Remote.Attributes;
 
 namespace Nocturne.API.Controllers.V4.Platform;
@@ -13,6 +16,7 @@ namespace Nocturne.API.Controllers.V4.Platform;
 [Route("api/v4/support")]
 public class SupportController(
     GitHubIssueService githubService,
+    ISupportDiagnosticsService diagnosticsService,
     IOptions<GitHubIssueOptions> options,
     IOptions<OperatorConfiguration> operatorOptions,
     ILogger<SupportController> logger) : ControllerBase
@@ -135,6 +139,25 @@ public class SupportController(
             return Problem(detail: "Failed to create issue. Try again or report directly on GitHub.",
                 statusCode: 502, title: "Bad Gateway");
         }
+    }
+
+    /// <summary>
+    /// Returns the tenant configuration a reporter may attach to a support issue.
+    /// </summary>
+    /// <remarks>
+    /// Gated like <see cref="V4.ConnectorStatusController"/>, whose connector health this reports a
+    /// subset of: reaching it with a narrower credential than that endpoint requires would make
+    /// support the way to read connector state without <c>tenant_settings</c>.
+    /// </remarks>
+    [HttpGet("diagnostics")]
+    [RemoteQuery]
+    [DenyDemoSubject]
+    [RequireScope(Scope.TenantSettings)]
+    [ProducesResponseType(typeof(SupportDiagnosticsResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<SupportDiagnosticsResponse>> GetSupportDiagnostics(
+        CancellationToken ct)
+    {
+        return Ok(await diagnosticsService.GetAsync(ct));
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -248,6 +248,7 @@ public static class ServiceRegistrationExtensions
         // GitHub issue creation
         services.Configure<GitHubIssueOptions>(configuration.GetSection("GitHub"));
         services.AddSingleton<GitHubIssueService>();
+        services.AddScoped<ISupportDiagnosticsService, SupportDiagnosticsService>();
 
         return services;
     }

--- a/src/API/Nocturne.API/Services/SupportDiagnosticsService.cs
+++ b/src/API/Nocturne.API/Services/SupportDiagnosticsService.cs
@@ -1,0 +1,112 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Infrastructure.Data.Services;
+
+namespace Nocturne.API.Services;
+
+/// <summary>
+/// The tenant configuration a support report may carry.
+/// </summary>
+/// <remarks>
+/// Every field here is published in a GitHub issue the reporter cannot retract, so this type is an
+/// allowlist and not a projection: fields are named one at a time, and nothing is copied wholesale
+/// from a DTO that might later grow a credential. <see cref="SupportConnectorSummary"/> exists for
+/// the same reason rather than reusing <c>ConnectorStatusDto</c>, which carries
+/// <c>StateMessage</c> — a connector's last error, which can quote a tenant-configured URL.
+/// </remarks>
+public class SupportDiagnosticsResponse
+{
+    /// <summary>Tenant display units, as <c>features.display.units</c> holds them.</summary>
+    public string? GlucoseUnits { get; set; }
+
+    /// <summary>Tenant time format, either <c>12</c> or <c>24</c>.</summary>
+    public string? TimeFormat { get; set; }
+
+    /// <summary>IANA zone the patient's day is rendered in, when one is set.</summary>
+    public string? PatientTimeZone { get; set; }
+
+    /// <summary>Which reading wins when several sources cover the same moment.</summary>
+    public string? DataSourcePriority { get; set; }
+
+    /// <summary>Alert rules the tenant has defined, enabled or not.</summary>
+    public int AlertRuleCount { get; set; }
+
+    /// <summary>Configured connectors, or those that have ever stored a reading.</summary>
+    public IReadOnlyList<SupportConnectorSummary> Connectors { get; set; } = [];
+}
+
+/// <summary>
+/// One connector, reduced to what a support reader needs to see.
+/// </summary>
+/// <seealso cref="SupportDiagnosticsResponse"/>
+public class SupportConnectorSummary
+{
+    /// <summary>Connector id, lowercased — <c>glooko</c>, <c>nightscout</c>.</summary>
+    public required string Name { get; set; }
+
+    public bool IsEnabled { get; set; }
+
+    public bool IsHealthy { get; set; }
+
+    public DateTime? LastSuccessfulSync { get; set; }
+}
+
+/// <summary>Assembles the snapshot a support report may attach.</summary>
+public interface ISupportDiagnosticsService
+{
+    Task<SupportDiagnosticsResponse> GetAsync(CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public class SupportDiagnosticsService(
+    IConnectorHealthService connectorHealth,
+    IUISettingsService uiSettings,
+    ITherapySettingsResolver therapySettings,
+    ITenantDbContextFactory contextFactory,
+    ILogger<SupportDiagnosticsService> logger
+) : ISupportDiagnosticsService
+{
+    /// <inheritdoc />
+    public async Task<SupportDiagnosticsResponse> GetAsync(CancellationToken ct = default)
+    {
+        var settings = await uiSettings.GetSettingsAsync(ct);
+        var statuses = await connectorHealth.GetConnectorStatusesAsync(ct);
+
+        await using var db = await contextFactory.CreateAsync(ct);
+        var alertRuleCount = await db.AlertRules.CountAsync(ct);
+
+        // The timezone resolver reads the patient record and falls back to the legacy per-profile
+        // value; a tenant that has set neither is not an error, so a failure here costs the field
+        // rather than the report.
+        string? timeZone = null;
+        try
+        {
+            timeZone = await therapySettings.GetTimezoneAsync(ct: ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Support diagnostics could not resolve the patient time zone");
+        }
+
+        return new SupportDiagnosticsResponse
+        {
+            GlucoseUnits = settings.Features.Display.Units,
+            TimeFormat = settings.Features.Display.TimeFormat,
+            PatientTimeZone = timeZone,
+            DataSourcePriority = settings.Devices.CgmConfiguration.DataSourcePriority,
+            AlertRuleCount = alertRuleCount,
+            Connectors = statuses
+                .Select(s => new SupportConnectorSummary
+                {
+                    Name = s.Name,
+                    IsEnabled = s.IsEnabled,
+                    IsHealthy = s.IsHealthy,
+                    LastSuccessfulSync = s.LastSuccessfulSync,
+                })
+                .ToList(),
+        };
+    }
+}

--- a/src/Web/packages/app/src/lib/api/support.remote.ts
+++ b/src/Web/packages/app/src/lib/api/support.remote.ts
@@ -4,6 +4,7 @@ import { error, redirect } from "@sveltejs/kit";
 export {
   getFallbackUrl,
   getSupportConfig,
+  getSupportDiagnostics,
 } from "$api/generated/supports.generated.remote";
 
 /**

--- a/src/Web/packages/app/src/lib/components/support/IssueCreatorDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/support/IssueCreatorDialog.svelte
@@ -21,9 +21,11 @@
     ArrowLeft,
     Copy,
   } from "lucide-svelte";
-  import { submitIssue, getFallbackUrl } from "$lib/api/support.remote";
+  import { submitIssue, getFallbackUrl, getSupportDiagnostics } from "$lib/api/support.remote";
+  import { readApiFailures, type ApiFailure } from "$lib/support/api-failure-log";
+  import { buildDiagnosticInfo } from "$lib/support/diagnostic-info";
   import { page } from "$app/state";
-  import type { CreateIssueResponse } from "$api-clients";
+  import type { CreateIssueResponse, SupportDiagnosticsResponse as SupportDiagnostics } from "$api-clients";
   import { copyToClipboard } from "$lib/utils";
   import { toast } from "svelte-sonner";
 
@@ -78,6 +80,12 @@
   let includeRecentLogs = $state(false);
   let includeSettings = $state(false);
 
+  // Snapshotted when the dialog opens rather than read live, so what the preview
+  // showed is what gets submitted even if a request fails while the form is open.
+  let recentFailures = $state<readonly ApiFailure[]>([]);
+  let collectedSettings = $state<SupportDiagnostics | null>(null);
+  const recentFailureCount = $derived(recentFailures.length);
+
   // UI state
   let formState = $state<"idle" | "preview" | "submitting" | "success" | "error">("idle");
   let issueUrl = $state("");
@@ -88,34 +96,31 @@
 
   const config = $derived(templateConfigs[template] ?? templateConfigs.bug);
 
-  const diagnosticInfo = $derived.by(() => {
-    const info: Record<string, unknown> = {
-      userAgent:
-        typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
-      screenSize:
-        typeof window !== "undefined"
-          ? `${window.innerWidth}x${window.innerHeight}`
-          : "unknown",
-      route: typeof window !== "undefined" ? window.location.pathname : "unknown",
-      locale:
-        typeof navigator !== "undefined" ? navigator.language : "unknown",
-    };
-
-    if (includeTenantSlug) {
-      info.tenantSlug = page.data.tenantSlug ?? "unknown";
-    }
-    if (includeCgmSource) {
-      info.cgmSource = cgmSource || "not specified";
-    }
-    if (includeRecentLogs) {
-      info.recentLogs = "included";
-    }
-    if (includeSettings) {
-      info.settings = "included";
-    }
-
-    return JSON.stringify(info, null, 2);
-  });
+  const diagnosticInfo = $derived(
+    buildDiagnosticInfo(
+      {
+        userAgent:
+          typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
+        screenSize:
+          typeof window !== "undefined"
+            ? `${window.innerWidth}x${window.innerHeight}`
+            : "unknown",
+        route:
+          typeof window !== "undefined" ? window.location.pathname : "unknown",
+        locale: typeof navigator !== "undefined" ? navigator.language : "unknown",
+        tenantSlug: page.data.tenantSlug ?? "unknown",
+        cgmSource,
+        recentFailures,
+        settings: collectedSettings,
+      },
+      {
+        tenantSlug: includeTenantSlug,
+        cgmSource: includeCgmSource,
+        recentErrors: includeRecentLogs,
+        settings: includeSettings,
+      }
+    )
+  );
 
   const isValid = $derived(
     title.trim().length > 0 &&
@@ -135,6 +140,32 @@
     if (fileInput) syncInputFiles(fileInput);
   });
 
+  // The failure log is a plain module buffer, not reactive state, so it is read once
+  // on open rather than tracked.
+  $effect(() => {
+    if (open) recentFailures = [...readApiFailures()];
+  });
+
+  $effect(() => {
+    if (!includeSettings) return;
+    if (collectedSettings) return;
+
+    let cancelled = false;
+    void getSupportDiagnostics()
+      .then((settings) => {
+        if (!cancelled) collectedSettings = settings;
+      })
+      .catch(() => {
+        // The report is worth more than the snapshot: a tenant whose settings cannot be
+        // read still gets to describe the problem.
+        if (!cancelled) includeSettings = false;
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
   function resetState() {
     title = "";
     description = "";
@@ -148,6 +179,8 @@
     includeCgmSource = false;
     includeRecentLogs = false;
     includeSettings = false;
+    recentFailures = [];
+    collectedSettings = null;
     formState = "idle";
     issueUrl = "";
     issueNumber = 0;
@@ -566,6 +599,11 @@
                 Browser, screen size, route, and locale are always included. Toggle
                 additional info below:
               </p>
+              <p class="text-xs text-muted-foreground">
+                Your report is filed as a public issue on GitHub. Anything you turn on
+                here is published with it and can be read by anyone — check the preview
+                before you send.
+              </p>
 
               <div class="space-y-3">
                 <div class="flex items-center justify-between">
@@ -590,19 +628,23 @@
 
                 <div class="flex items-center justify-between">
                   <div class="space-y-0.5">
-                    <Label class="text-sm">Recent logs</Label>
+                    <Label class="text-sm">Recent errors</Label>
                     <p class="text-xs text-muted-foreground">
-                      API calls and debug information
+                      {recentFailureCount === 0
+                        ? "No failed requests recorded this session"
+                        : `${recentFailureCount} failed ${recentFailureCount === 1 ? "request" : "requests"} — time, status, page and message`}
                     </p>
                   </div>
-                  <Switch bind:checked={includeRecentLogs} />
+                  <Switch bind:checked={includeRecentLogs} disabled={recentFailureCount === 0} />
                 </div>
 
                 <div class="flex items-center justify-between">
                   <div class="space-y-0.5">
                     <Label class="text-sm">Settings</Label>
                     <p class="text-xs text-muted-foreground">
-                      Your configuration (no passwords/tokens)
+                      {includeSettings && !collectedSettings
+                        ? "Collecting…"
+                        : "Units, timezone, CGM sources and connector names. Never passwords, tokens or glucose values."}
                     </p>
                   </div>
                   <Switch bind:checked={includeSettings} />

--- a/src/Web/packages/app/src/lib/forms/submit-error.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.ts
@@ -1,3 +1,5 @@
+import { recordApiFailure } from "$lib/support/api-failure-log";
+
 /** Fallback shown when a submission fails for a reason we can't safely surface. */
 export const GENERIC_SUBMIT_ERROR =
   "We couldn't save your changes. Please try again.";
@@ -199,6 +201,22 @@ export function describeRemoteError(
   policy: RemoteErrorPolicy
 ): string {
   const status = errorStatus(err);
+  const described = describe(err, fallback, policy, status);
+
+  // Every rejected API call the user is told about passes through here, and the
+  // transport carries no path or correlation id, so this is the only place the
+  // support form can learn what went wrong before the report was written.
+  recordApiFailure(status, described);
+
+  return described;
+}
+
+function describe(
+  err: unknown,
+  fallback: string,
+  policy: RemoteErrorPolicy,
+  status: number | undefined
+): string {
   if (status === 429) return RATE_LIMITED_ERROR;
   if (status === 404) return policy.missing ?? fallback;
   if (status === 403) {

--- a/src/Web/packages/app/src/lib/support/api-failure-log.test.ts
+++ b/src/Web/packages/app/src/lib/support/api-failure-log.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("$app/environment", () => ({ browser: true }));
+
+const { recordApiFailure, readApiFailures, clearApiFailures } = await import(
+  "./api-failure-log"
+);
+
+function stubRoute(pathname: string) {
+  vi.stubGlobal("window", { location: { pathname } });
+}
+
+describe("api-failure-log", () => {
+  beforeEach(() => {
+    clearApiFailures();
+    stubRoute("/reports");
+    vi.useRealTimers();
+  });
+
+  it("records the status, route and sentence the user was shown", () => {
+    recordApiFailure(403, "Changing alerts requires alerts.readwrite");
+
+    expect(readApiFailures()).toEqual([
+      {
+        at: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+        status: 403,
+        route: "/reports",
+        message: "Changing alerts requires alerts.readwrite",
+      },
+    ]);
+  });
+
+  it("keeps a failure with no status, since not every rejection carries one", () => {
+    recordApiFailure(undefined, "Something went wrong");
+
+    expect(readApiFailures()[0].status).toBeUndefined();
+  });
+
+  it("collapses the same failure repeated while a surface re-renders", () => {
+    for (let i = 0; i < 5; i++) recordApiFailure(500, "Something went wrong");
+
+    expect(readApiFailures()).toHaveLength(1);
+  });
+
+  it("keeps the same message from a different route as its own entry", () => {
+    recordApiFailure(500, "Something went wrong");
+    stubRoute("/settings/connectors");
+    recordApiFailure(500, "Something went wrong");
+
+    expect(readApiFailures().map((f) => f.route)).toEqual([
+      "/reports",
+      "/settings/connectors",
+    ]);
+  });
+
+  it("records the same failure again once the dedupe window has passed", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-11T00:00:00Z"));
+    recordApiFailure(500, "Something went wrong");
+
+    vi.setSystemTime(new Date("2026-09-11T00:00:05Z"));
+    recordApiFailure(500, "Something went wrong");
+
+    expect(readApiFailures()).toHaveLength(2);
+  });
+
+  it("keeps only the most recent failures", () => {
+    for (let i = 0; i < 30; i++) recordApiFailure(500, `failure ${i}`);
+
+    const recorded = readApiFailures();
+    expect(recorded).toHaveLength(20);
+    expect(recorded[0].message).toBe("failure 10");
+    expect(recorded[19].message).toBe("failure 29");
+  });
+
+  it("truncates a long server sentence so one message cannot fill the buffer", () => {
+    recordApiFailure(500, "x".repeat(500));
+
+    const { message } = readApiFailures()[0];
+    expect(message).toHaveLength(301);
+    expect(message.endsWith("…")).toBe(true);
+  });
+});
+
+describe("api-failure-log on the server", () => {
+  it("records nothing, so one request cannot leak into another's report", async () => {
+    vi.resetModules();
+    vi.doMock("$app/environment", () => ({ browser: false }));
+
+    const serverSide = await import("./api-failure-log");
+    serverSide.recordApiFailure(500, "Something went wrong");
+
+    expect(serverSide.readApiFailures()).toHaveLength(0);
+  });
+});

--- a/src/Web/packages/app/src/lib/support/api-failure-log.ts
+++ b/src/Web/packages/app/src/lib/support/api-failure-log.ts
@@ -1,0 +1,81 @@
+import { browser } from "$app/environment";
+
+/** One rejected API call, as the support form reports it. */
+export interface ApiFailure {
+  /** ISO 8601, UTC. */
+  at: string;
+  /** HTTP status, when the rejection carried one. */
+  status?: number;
+  /** Route the user was on, not the endpoint — the transport does not carry one. */
+  route: string;
+  /** The sentence the user was shown. */
+  message: string;
+}
+
+/**
+ * Most recent failures kept. A support report wants the run-up to the problem,
+ * not a session's history, and the whole buffer is pasted into an issue body.
+ */
+const CAPACITY = 20;
+
+/** Cap on a recorded sentence, so one long server message cannot dominate the buffer. */
+const MAX_MESSAGE_LENGTH = 300;
+
+/**
+ * Window within which an identical failure is treated as the same one. A rejected
+ * query is described again on every re-render of the surface showing it, so without
+ * this the buffer fills with one repeated line.
+ */
+const DEDUPE_WINDOW_MS = 2000;
+
+/**
+ * Deliberately a plain array rather than `$state`: nothing renders from it, and a
+ * reactive buffer written to during render — which is when a rejected query is
+ * described — would invalidate whatever read it.
+ */
+let failures: ApiFailure[] = [];
+
+/**
+ * Records a rejected API call for the support form.
+ *
+ * No-op on the server. The buffer is module state, so on the server it would be
+ * shared across every request the process handles and would leak one tenant's
+ * failures into another tenant's support report.
+ */
+export function recordApiFailure(
+  status: number | undefined,
+  message: string
+): void {
+  if (!browser) return;
+
+  const route = window.location.pathname;
+  const trimmed =
+    message.length > MAX_MESSAGE_LENGTH
+      ? `${message.slice(0, MAX_MESSAGE_LENGTH)}…`
+      : message;
+  const now = Date.now();
+
+  const previous = failures[failures.length - 1];
+  if (
+    previous &&
+    previous.status === status &&
+    previous.route === route &&
+    previous.message === trimmed &&
+    now - Date.parse(previous.at) < DEDUPE_WINDOW_MS
+  ) {
+    return;
+  }
+
+  failures.push({ at: new Date(now).toISOString(), status, route, message: trimmed });
+  if (failures.length > CAPACITY) failures = failures.slice(-CAPACITY);
+}
+
+/** The recorded failures, oldest first. */
+export function readApiFailures(): readonly ApiFailure[] {
+  return failures;
+}
+
+/** Drops everything recorded so far. */
+export function clearApiFailures(): void {
+  failures = [];
+}

--- a/src/Web/packages/app/src/lib/support/diagnostic-info.test.ts
+++ b/src/Web/packages/app/src/lib/support/diagnostic-info.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import type { SupportDiagnosticsResponse } from "$api-clients";
+import { buildDiagnosticInfo, type DiagnosticSources } from "./diagnostic-info";
+
+const lastSync = new Date("2026-09-10T21:00:00Z");
+
+const settings: SupportDiagnosticsResponse = {
+  glucoseUnits: "mg/dl",
+  timeFormat: "12",
+  patientTimeZone: "America/Chicago",
+  dataSourcePriority: "cgm",
+  alertRuleCount: 7,
+  connectors: [
+    {
+      name: "nightscout",
+      isEnabled: true,
+      isHealthy: false,
+      lastSuccessfulSync: lastSync,
+    },
+  ],
+};
+
+const sources: DiagnosticSources = {
+  userAgent: "Mozilla/5.0",
+  screenSize: "1485x1569",
+  route: "/settings/support",
+  locale: "en-US",
+  tenantSlug: "steph",
+  cgmSource: "Dexcom G7",
+  recentFailures: [
+    { at: "2026-09-10T21:04:11Z", status: 403, route: "/reports", message: "Denied" },
+  ],
+  settings,
+};
+
+const allOff = {
+  tenantSlug: false,
+  cgmSource: false,
+  recentErrors: false,
+  settings: false,
+};
+
+function parse(json: string) {
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+describe("buildDiagnosticInfo", () => {
+  it("always carries the session basics", () => {
+    expect(parse(buildDiagnosticInfo(sources, allOff))).toEqual({
+      userAgent: "Mozilla/5.0",
+      screenSize: "1485x1569",
+      route: "/settings/support",
+      locale: "en-US",
+    });
+  });
+
+  it("attaches the real settings snapshot, not a placeholder", () => {
+    const info = parse(buildDiagnosticInfo(sources, { ...allOff, settings: true }));
+
+    expect(info.settings).toEqual({
+      ...settings,
+      connectors: [{ ...settings.connectors![0], lastSuccessfulSync: lastSync.toISOString() }],
+    });
+  });
+
+  it("attaches the real failures, not a placeholder", () => {
+    const info = parse(buildDiagnosticInfo(sources, { ...allOff, recentErrors: true }));
+
+    expect(info.recentErrors).toEqual(sources.recentFailures);
+  });
+
+  it("omits settings that have not arrived rather than claiming they were sent", () => {
+    const info = parse(
+      buildDiagnosticInfo({ ...sources, settings: null }, { ...allOff, settings: true })
+    );
+
+    expect(info).not.toHaveProperty("settings");
+  });
+
+  it("omits an empty failure list rather than sending an empty array", () => {
+    const info = parse(
+      buildDiagnosticInfo({ ...sources, recentFailures: [] }, { ...allOff, recentErrors: true })
+    );
+
+    expect(info).not.toHaveProperty("recentErrors");
+  });
+
+  it("never emits the literal placeholder the toggles used to send", () => {
+    const everythingOn = buildDiagnosticInfo(sources, {
+      tenantSlug: true,
+      cgmSource: true,
+      recentErrors: true,
+      settings: true,
+    });
+
+    expect(everythingOn).not.toContain('"included"');
+  });
+
+  it("leaves out what was not asked for", () => {
+    const info = parse(buildDiagnosticInfo(sources, { ...allOff, tenantSlug: true }));
+
+    expect(info.tenantSlug).toBe("steph");
+    expect(info).not.toHaveProperty("cgmSource");
+    expect(info).not.toHaveProperty("settings");
+    expect(info).not.toHaveProperty("recentErrors");
+  });
+
+  it("says so when the reporter shared a CGM source but named none", () => {
+    const info = parse(
+      buildDiagnosticInfo({ ...sources, cgmSource: "" }, { ...allOff, cgmSource: true })
+    );
+
+    expect(info.cgmSource).toBe("not specified");
+  });
+});

--- a/src/Web/packages/app/src/lib/support/diagnostic-info.ts
+++ b/src/Web/packages/app/src/lib/support/diagnostic-info.ts
@@ -1,0 +1,50 @@
+import type { SupportDiagnosticsResponse } from "$api-clients";
+import type { ApiFailure } from "./api-failure-log";
+
+/** What the support form knows about the session, before the user chooses what to share. */
+export interface DiagnosticSources {
+  userAgent: string;
+  screenSize: string;
+  route: string;
+  locale: string;
+  tenantSlug: string;
+  cgmSource: string;
+  recentFailures: readonly ApiFailure[];
+  settings: SupportDiagnosticsResponse | null;
+}
+
+/** Which optional sections the user turned on. */
+export interface DiagnosticToggles {
+  tenantSlug: boolean;
+  cgmSource: boolean;
+  recentErrors: boolean;
+  settings: boolean;
+}
+
+/**
+ * Builds the diagnostic block attached to a support issue.
+ *
+ * A section appears only when it was both asked for and actually collected. The two are
+ * separate on purpose: the toggles used to emit the literal string `"included"` whatever
+ * happened, so a reporter could opt in to sharing diagnostics and send nothing.
+ */
+export function buildDiagnosticInfo(
+  sources: DiagnosticSources,
+  toggles: DiagnosticToggles
+): string {
+  const info: Record<string, unknown> = {
+    userAgent: sources.userAgent,
+    screenSize: sources.screenSize,
+    route: sources.route,
+    locale: sources.locale,
+  };
+
+  if (toggles.tenantSlug) info.tenantSlug = sources.tenantSlug;
+  if (toggles.cgmSource) info.cgmSource = sources.cgmSource || "not specified";
+  if (toggles.recentErrors && sources.recentFailures.length > 0) {
+    info.recentErrors = sources.recentFailures;
+  }
+  if (toggles.settings && sources.settings) info.settings = sources.settings;
+
+  return JSON.stringify(info, null, 2);
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/SupportConfigTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/SupportConfigTests.cs
@@ -24,6 +24,7 @@ public class SupportConfigTests
 
         var controller = new SupportController(
             githubService,
+            Mock.Of<ISupportDiagnosticsService>(),
             Options.Create(new GitHubIssueOptions()),
             Options.Create(config),
             NullLogger<SupportController>.Instance);

--- a/tests/Unit/Nocturne.API.Tests/Services/SupportDiagnosticsResponseTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/SupportDiagnosticsResponseTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.API.Services;
+
+namespace Nocturne.API.Tests.Services;
+
+/// <summary>
+/// The snapshot is published in an issue the reporter cannot retract, so its shape is pinned
+/// rather than trusted. These tests fail when a field is added, which is the point: adding one
+/// has to be a decision someone made, not a consequence of a DTO growing elsewhere.
+/// </summary>
+public class SupportDiagnosticsResponseTests
+{
+    private static readonly string[] ExpectedFields =
+    [
+        nameof(SupportDiagnosticsResponse.GlucoseUnits),
+        nameof(SupportDiagnosticsResponse.TimeFormat),
+        nameof(SupportDiagnosticsResponse.PatientTimeZone),
+        nameof(SupportDiagnosticsResponse.DataSourcePriority),
+        nameof(SupportDiagnosticsResponse.AlertRuleCount),
+        nameof(SupportDiagnosticsResponse.Connectors),
+    ];
+
+    private static readonly string[] ExpectedConnectorFields =
+    [
+        nameof(SupportConnectorSummary.Name),
+        nameof(SupportConnectorSummary.IsEnabled),
+        nameof(SupportConnectorSummary.IsHealthy),
+        nameof(SupportConnectorSummary.LastSuccessfulSync),
+    ];
+
+    [Fact]
+    public void Snapshot_CarriesOnlyTheFieldsItWasReviewedWith()
+    {
+        typeof(SupportDiagnosticsResponse)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Should()
+            .BeEquivalentTo(ExpectedFields);
+    }
+
+    [Fact]
+    public void ConnectorSummary_CarriesOnlyTheFieldsItWasReviewedWith()
+    {
+        // Deliberately not a projection of ConnectorStatusDto, which also carries StateMessage —
+        // a connector's last error, which can quote a tenant-configured URL or a provider's
+        // response body — and HasSecrets.
+        typeof(SupportConnectorSummary)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Should()
+            .BeEquivalentTo(ExpectedConnectorFields);
+    }
+
+    [Fact]
+    public void Snapshot_SerialisesNothingThatNamesACredential()
+    {
+        var snapshot = new SupportDiagnosticsResponse
+        {
+            GlucoseUnits = "mg/dl",
+            TimeFormat = "12",
+            PatientTimeZone = "America/Chicago",
+            DataSourcePriority = "cgm",
+            AlertRuleCount = 7,
+            Connectors =
+            [
+                new SupportConnectorSummary
+                {
+                    Name = "nightscout",
+                    IsEnabled = true,
+                    IsHealthy = true,
+                    LastSuccessfulSync = DateTime.UnixEpoch,
+                },
+            ],
+        };
+
+        var json = JsonSerializer.Serialize(snapshot);
+
+        foreach (var forbidden in new[]
+                 {
+                     "secret", "token", "password", "apiSecret", "clientSecret",
+                     "accessToken", "refreshToken", "url", "serialNumber", "stateMessage",
+                 })
+        {
+            json.Should().NotContainEquivalentOf(forbidden);
+        }
+    }
+
+    [Fact]
+    public void Snapshot_CarriesNoGlucoseValues()
+    {
+        // A support issue is public; a reading is patient data and has no diagnostic value here.
+        typeof(SupportDiagnosticsResponse)
+            .GetProperties()
+            .Should()
+            .NotContain(p => p.Name.Contains("Glucose", StringComparison.OrdinalIgnoreCase)
+                && p.Name != nameof(SupportDiagnosticsResponse.GlucoseUnits));
+    }
+}


### PR DESCRIPTION
Closes #1296.

The support form's "Recent logs" and "Settings" toggles emitted the literal string `"included"` and attached nothing. A reporter opted in to sharing diagnostics, was shown a confirmation, and sent a placeholder — then had to answer by hand for everything they believed they had already sent. #1294 is a live example of both toggles doing this.

## Settings

A new `GET /api/v4/support/diagnostics` returns a server-assembled snapshot: units, time format, patient time zone, CGM source priority, alert rule count, and per connector its name, enabled and healthy state, and last successful sync.

It is an **allowlist, not a projection**, because the destination is a public issue the reporter cannot retract. `SupportConnectorSummary` exists rather than reusing `ConnectorStatusDto`, which carries `StateMessage` — a connector's last error, which can quote a tenant-configured URL or a provider's response body — and `HasSecrets`. Reflection tests pin both shapes, so adding a field is a decision someone made rather than a consequence of a DTO growing elsewhere.

The endpoint carries `ConnectorStatusController`'s `[RequireScope(Scope.TenantSettings)]` and `[DenyDemoSubject]`. It reports a subset of the same connector health, so reaching it with a narrower credential would make support the way to read connector state without `tenant_settings`.

## Recent errors

A client-side ring buffer recorded at `describeRemoteError` — the one funnel every rejected API call the user is told about passes through, per that file's own documented invariant. Twenty entries of time, status, route and the sentence shown.

Two constraints shaped it:

- **The transport carries no path and no correlation id.** SvelteKit rethrows a remote function's `error(status, message)` as a bare `{ status, body.message }`. The route the user was on is the closest thing to where it happened.
- **It is written during render**, which is when a rejected query is described. So the buffer is a plain array rather than `$state` — a reactive one would invalidate whatever read it. It also no-ops on the server, where module state is shared across requests and would leak one tenant's failures into another's report. There is a test for that.

## Honesty of the payload

Assembly moved out of the component into `buildDiagnosticInfo` so the promise is testable without a component harness. A section appears only when it was **both asked for and actually collected** — a toggle turned on whose data has not arrived attaches nothing rather than a placeholder, which is the original fault. One test asserts the string `"included"` can no longer appear in any payload.

The form now states plainly that reports are filed as public GitHub issues and that anything toggled on is published with them. The errors toggle is disabled when there is nothing recorded, and the settings toggle shows "Collecting…" rather than letting a half-built payload reach the preview.

## Not in scope

Routing reports by origin — operator tenants to a private tracker, relayed self-hosted reports to the public repo — is blocked on #1298. The relay currently sends no credentials to an `[Authorize]` endpoint, so no relayed report arrives at all and a receiver has no way to tell one from its own tenant's. Until that lands, reports keep going to the public repo, which is what the new wording says.

## Tests

- `SupportDiagnosticsResponseTests` — both allowlists pinned by reflection; a serialisation test asserting no field names a credential; a test that no glucose values can appear.
- `api-failure-log.test.ts` — capture, the re-render dedupe and its window, the capacity cap, message truncation, and the server no-op.
- `diagnostic-info.test.ts` — each section attaches real data, an uncollected section is omitted, and `"included"` never appears.

App typecheck holds at its 76-error baseline (unbuilt `@nocturne/bot`/`@nocturne/bridge`), none in the changed files.
