### PR TITLE
fix(web): write "Created"/"Last used" dates in a readable, regional shape

### DIFF
--- a/src/Web/packages/app/src/lib/components/account/SecurityCredentialCard.svelte
+++ b/src/Web/packages/app/src/lib/components/account/SecurityCredentialCard.svelte
@@ -3,7 +3,7 @@
   import * as Card from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
   import { Clock, Plus, Trash2, Loader2 } from "lucide-svelte";
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
 
   interface Credential {
     id: string;
@@ -97,12 +97,12 @@
             >
               <span class="flex items-center gap-1">
                 <Clock class="h-3 w-3" />
-                Created {credential.createdAt ? formatDate(credential.createdAt) : "Unknown"}
+                Created {credential.createdAt ? formatMediumDateTime(credential.createdAt) : "Unknown"}
               </span>
               {#if credential.lastUsedAt}
                 <span class="flex items-center gap-1">
                   <Clock class="h-3 w-3" />
-                  Last used {formatDate(credential.lastUsedAt)}
+                  Last used {formatMediumDateTime(credential.lastUsedAt)}
                 </span>
               {/if}
             </div>

--- a/src/Web/packages/app/src/lib/components/account/UserProfileCard.svelte
+++ b/src/Web/packages/app/src/lib/components/account/UserProfileCard.svelte
@@ -16,7 +16,7 @@
     Trash2,
   } from "lucide-svelte";
   import { formatSessionExpiry, getAuthStore } from "$lib/stores/auth-store.svelte";
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import { upload as uploadAvatar, remove as deleteAvatar } from "$lib/api/generated/avatars.generated.remote";
   import { describeSubmitError } from "$lib/forms/submit-error";
 
@@ -207,7 +207,7 @@
             <p class="text-sm text-muted-foreground">Session Expires</p>
             <p class="text-sm flex items-center gap-2">
               <Clock class="h-4 w-4 text-muted-foreground" />
-              {formatDate(user.expiresAt)}
+              {formatMediumDateTime(user.expiresAt)}
               {#if timeUntilExpiry !== null}
                 <span class="text-muted-foreground">
                   ({formatSessionExpiry(timeUntilExpiry)})

--- a/src/Web/packages/app/src/lib/components/layout/ReportsFilterSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/ReportsFilterSidebar.svelte
@@ -9,7 +9,7 @@
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { RangeCalendar } from "$lib/components/ui/range-calendar";
   import { dayCount } from "$lib/utils/date-range";
-  import { formatLocale } from "$lib/utils/formatting";
+  import { formatLocale, formatMediumDateRange } from "$lib/utils/formatting";
   import { Calendar, Filter, RotateCcw } from "lucide-svelte";
 
   interface Props {
@@ -122,12 +122,12 @@
     onOpenChange?.(false);
   }
 
-  // Get formatted date range for display
   const dateRangeText = $derived.by(() => {
     if (draftCalendarValue?.start && draftCalendarValue?.end) {
-      const start = draftCalendarValue.start.toDate(getLocalTimeZone());
-      const end = draftCalendarValue.end.toDate(getLocalTimeZone());
-      return `${start.toLocaleDateString(formatLocale())} - ${end.toLocaleDateString(formatLocale())}`;
+      return formatMediumDateRange(
+        draftCalendarValue.start.toDate(getLocalTimeZone()),
+        draftCalendarValue.end.toDate(getLocalTimeZone()),
+      );
     }
     return "Select dates";
   });

--- a/src/Web/packages/app/src/lib/components/members/MemberCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/MemberCard.svelte
@@ -17,7 +17,7 @@
     ChevronDown,
     ChevronUp,
   } from "lucide-svelte";
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import type { TenantMemberDto, TenantRoleDto } from "$lib/api/generated/nocturne-api-client";
 
   interface Props {
@@ -306,12 +306,12 @@
         {/if}
         <span class="flex items-center gap-1.5">
           <Clock class="h-3 w-3" />
-          Joined {formatDate(member.sysCreatedAt)}
+          Joined {formatMediumDateTime(member.sysCreatedAt)}
         </span>
         {#if member.lastUsedAt}
           <span class="flex items-center gap-1.5">
             <Clock class="h-3 w-3" />
-            Last active {formatDate(member.lastUsedAt)}
+            Last active {formatMediumDateTime(member.lastUsedAt)}
           </span>
         {/if}
       </div>

--- a/src/Web/packages/app/src/lib/components/members/PendingInvitesList.svelte
+++ b/src/Web/packages/app/src/lib/components/members/PendingInvitesList.svelte
@@ -3,7 +3,7 @@
   import { Badge } from "$lib/components/ui/badge";
   import * as Card from "$lib/components/ui/card";
   import { Trash2, Link, Loader2, Check } from "lucide-svelte";
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import type { TenantRoleDto } from "$lib/api/generated/nocturne-api-client";
 
   interface Props {
@@ -48,7 +48,7 @@
             {/if}
           </div>
           <p class="text-xs text-muted-foreground">
-            Expires {formatDate(invite.expiresAt)}
+            Expires {formatMediumDateTime(invite.expiresAt)}
             {#if invite.maxUses}
               &middot; {invite.useCount}/{invite.maxUses} uses
             {:else}
@@ -71,7 +71,7 @@
                   <Check class="inline h-3 w-3 mr-1 text-primary" />
                   {usage.name ?? "Unknown"}
                   <span class="text-muted-foreground ml-1">
-                    on {formatDate(usage.joinedAt)}
+                    on {formatMediumDateTime(usage.joinedAt)}
                   </span>
                 </p>
               {/each}

--- a/src/Web/packages/app/src/lib/components/settings/ActiveSessions.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ActiveSessions.svelte
@@ -13,7 +13,7 @@
     LoaderCircle,
     LogOut,
   } from "lucide-svelte";
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import {
     list,
     revoke,
@@ -210,7 +210,7 @@
                   >
                     <span class="flex items-center gap-1.5">
                       <Clock class="h-3 w-3" />
-                      Last active {formatDate(session.lastActiveAt)}
+                      Last active {formatMediumDateTime(session.lastActiveAt)}
                     </span>
                     {#if session.ipAddress}
                       <span>IP {session.ipAddress}</span>

--- a/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
@@ -16,7 +16,7 @@
     AlertTriangle,
     Loader2,
   } from "lucide-svelte";
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import {
     list as listGrants,
     create as createGrant,
@@ -292,12 +292,12 @@
             >
               <span class="flex items-center gap-1">
                 <Clock class="h-3 w-3" />
-                Created {formatDate(grant.createdAt)}
+                Created {formatMediumDateTime(grant.createdAt)}
               </span>
               {#if grant.lastUsedAt}
                 <span class="flex items-center gap-1">
                   <Clock class="h-3 w-3" />
-                  Last used {formatDate(grant.lastUsedAt)}
+                  Last used {formatMediumDateTime(grant.lastUsedAt)}
                 </span>
               {/if}
             </div>

--- a/src/Web/packages/app/src/lib/components/settings/ConnectedApps.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ConnectedApps.svelte
@@ -15,7 +15,7 @@
     BadgeCheck,
     ExternalLink,
   } from "lucide-svelte";
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import { list, revoke } from "$lib/api/generated/connectedApps.generated.remote";
   import { getOAuthScopeDescription } from "$lib/constants/oauth-scopes";
 
@@ -196,12 +196,12 @@
           >
             <span class="flex items-center gap-1.5">
               <Clock class="h-3 w-3" />
-              Created {formatDate(app.createdAt)}
+              Created {formatMediumDateTime(app.createdAt)}
             </span>
             {#if app.lastUsedAt}
               <span class="flex items-center gap-1.5">
                 <Clock class="h-3 w-3" />
-                Last used {formatDate(app.lastUsedAt)}
+                Last used {formatMediumDateTime(app.lastUsedAt)}
               </span>
             {/if}
           </div>

--- a/src/Web/packages/app/src/lib/components/settings/LinkedOidcIdentities.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/LinkedOidcIdentities.svelte
@@ -11,7 +11,7 @@
     AlertTriangle,
     Check,
   } from "lucide-svelte";
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import {
     getLinkedIdentities,
     unlinkIdentity,
@@ -191,13 +191,13 @@
               {#if identity.linkedAt}
                 <span class="flex items-center gap-1">
                   <Clock class="h-3 w-3" />
-                  Linked {formatDate(identity.linkedAt)}
+                  Linked {formatMediumDateTime(identity.linkedAt)}
                 </span>
               {/if}
               {#if identity.lastUsedAt}
                 <span class="flex items-center gap-1">
                   <Clock class="h-3 w-3" />
-                  Last used {formatDate(identity.lastUsedAt)}
+                  Last used {formatMediumDateTime(identity.lastUsedAt)}
                 </span>
               {/if}
             </div>

--- a/src/Web/packages/app/src/lib/components/status-pills/BasalPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/BasalPill.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import StatusPill from "./StatusPill.svelte";
   import type {
     BasalPillData,
@@ -52,7 +52,7 @@
       if (data.tempBasal.startTime) {
         items.push({
           label: "Active Temp Basal Start",
-          value: formatDate(data.tempBasal.startTime),
+          value: formatMediumDateTime(data.tempBasal.startTime),
         });
       }
 

--- a/src/Web/packages/app/src/lib/components/ui/date-range-picker.svelte
+++ b/src/Web/packages/app/src/lib/components/ui/date-range-picker.svelte
@@ -5,7 +5,7 @@
   import { queryParam } from "sveltekit-search-params";
 
   import { RangeCalendar } from "$lib/components/ui/range-calendar";
-  import { formatLocale } from "$lib/utils/formatting";
+  import { formatLocale, formatMediumDateRange } from "$lib/utils/formatting";
   import * as Popover from "$lib/components/ui/popover/index.js";
   import { ChevronDown as ChevronDownIcon } from "lucide-svelte";
 
@@ -170,7 +170,10 @@
           class="w-56 justify-between font-normal"
         >
           {value?.start && value?.end
-            ? `${value.start.toDate(getLocalTimeZone()).toLocaleDateString(formatLocale())} - ${value.end.toDate(getLocalTimeZone()).toLocaleDateString(formatLocale())}`
+            ? formatMediumDateRange(
+                value.start.toDate(getLocalTimeZone()),
+                value.end.toDate(getLocalTimeZone()),
+              )
             : "Select date"}
           <ChevronDownIcon />
         </Button>

--- a/src/Web/packages/app/src/lib/utils/formatting.test.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.test.ts
@@ -227,20 +227,23 @@ describe("Date formatting", () => {
 			expect(result).not.toBe("N/A");
 		});
 
-		it("writes an abbreviated month and no seconds, in the regional format", () => {
-			// A bare toLocaleString gave "4/30/2026, 11:00:39 PM" on the token cards:
-			// all-numeric, so unreadable to anyone who does not share the locale's
-			// field order, and precise to a second that nothing on those rows needs.
-			// Built in local time for the reason "Shared date shapes" gives.
+		it("names the month and drops the seconds, whatever the region writes", () => {
+			// Local time, for the reason the "Shared date shapes" fixture gives.
 			const date = new Date(2026, 7, 29, 14, 5, 9);
 			const british = withRegionValue("en-GB", () => formatDate(date));
 			expect(british).toContain("29 Aug 2026");
 			expect(british).toContain("14:05");
 			expect(british).not.toContain(":09");
 
-			// The month is named, not numbered, whatever the region writes.
 			expect(withRegionValue("de-DE", () => formatDate(date))).toMatch(/Aug/);
 			expect(withRegionValue("en-US", () => formatDate(date))).toMatch(/Aug 29, 2026/);
+		});
+
+		it("reads a null as no value rather than as 1970", () => {
+			// Without the explicit guard, null coerces to the epoch and renders a
+			// date; undefined and "" fall through to the NaN branch and are caught
+			// either way, so null is the only case that pins it.
+			expect(formatDate(null as unknown as undefined)).toBe("N/A");
 		});
 	});
 

--- a/src/Web/packages/app/src/lib/utils/formatting.test.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.test.ts
@@ -44,11 +44,11 @@ const {
 	formatDayTime,
 	formatNumber,
 	formatNumericDate,
+	formatMediumDateRange,
 	time,
 	formatShortDate,
 	formatWeekdayDate,
 	formatDateTime,
-	formatDate,
 	formatDateDetailed,
 	formatDateForInput,
 	formatDateTimeCompact,
@@ -200,6 +200,33 @@ describe("Date formatting", () => {
 		});
 	});
 
+	describe("formatMediumDateTime", () => {
+		it("reads every unusable value as no value rather than as 1970", () => {
+			// null is the case that needs the explicit guard: it coerces to the epoch and would
+			// otherwise render a date. The rest reach the NaN branch on their own.
+			expect(formatMediumDateTime(null)).toBe("—");
+			expect(formatMediumDateTime(undefined)).toBe("—");
+			expect(formatMediumDateTime("")).toBe("—");
+			expect(formatMediumDateTime("not a date")).toBe("—");
+		});
+
+		it("names the month and drops the seconds, whatever the region writes", () => {
+			// What the "Created"/"Last used" rows across the app are built from: a bare
+			// toLocaleString gave "4/30/2026, 11:00:39 PM", which is unreadable to anyone who
+			// does not share the locale's field order, and precise to a second nothing needs.
+			const stamp = new Date(2026, 7, 29, 14, 5, 9);
+			const british = withRegionValue("en-GB", () => formatMediumDateTime(stamp));
+			expect(british).toContain("29 Aug 2026");
+			expect(british).toContain("14:05");
+			expect(british).not.toContain(":09");
+
+			expect(withRegionValue("de-DE", () => formatMediumDateTime(stamp))).toMatch(/Aug/);
+			expect(withRegionValue("en-US", () => formatMediumDateTime(stamp))).toMatch(
+				/Aug 29, 2026/
+			);
+		});
+	});
+
 	describe("formatDateTime", () => {
 		it("returns — for undefined", () => {
 			expect(formatDateTime(undefined)).toBe("—");
@@ -209,41 +236,6 @@ describe("Date formatting", () => {
 			const result = formatDateTime("2025-06-15T10:30:00Z");
 			expect(result).toBeTruthy();
 			expect(result).not.toBe("—");
-		});
-	});
-
-	describe("formatDate", () => {
-		it("returns N/A for undefined", () => {
-			expect(formatDate(undefined)).toBe("N/A");
-		});
-
-		it("formats a Date object", () => {
-			const result = formatDate(new Date(2025, 0, 1));
-			expect(result).not.toBe("N/A");
-		});
-
-		it("formats a string date", () => {
-			const result = formatDate("2025-06-15T10:30:00Z");
-			expect(result).not.toBe("N/A");
-		});
-
-		it("names the month and drops the seconds, whatever the region writes", () => {
-			// Local time, for the reason the "Shared date shapes" fixture gives.
-			const date = new Date(2026, 7, 29, 14, 5, 9);
-			const british = withRegionValue("en-GB", () => formatDate(date));
-			expect(british).toContain("29 Aug 2026");
-			expect(british).toContain("14:05");
-			expect(british).not.toContain(":09");
-
-			expect(withRegionValue("de-DE", () => formatDate(date))).toMatch(/Aug/);
-			expect(withRegionValue("en-US", () => formatDate(date))).toMatch(/Aug 29, 2026/);
-		});
-
-		it("reads a null as no value rather than as 1970", () => {
-			// Without the explicit guard, null coerces to the epoch and renders a
-			// date; undefined and "" fall through to the NaN branch and are caught
-			// either way, so null is the only case that pins it.
-			expect(formatDate(null as unknown as undefined)).toBe("N/A");
 		});
 	});
 
@@ -478,6 +470,21 @@ describe("Shared date shapes", () => {
 				expect(formatDateTimeCompact(date)).toMatch(/02:05\s*pm/i);
 			});
 		});
+	});
+
+	it("writes a range through ICU rather than joining two dates", () => {
+		const end = new Date(2026, 8, 3, 9, 0);
+		// Collapsing the shared year is the tell that ICU formatted the range: hyphenating two
+		// whole dates by hand would repeat "2026" on both sides.
+		const british = withRegionValue("en-GB", () => formatMediumDateRange(date, end));
+		expect(british).toContain("29 Aug");
+		// "Sept", not "Sep": the abbreviation is ICU's to choose, and en-GB writes four letters.
+		expect(british).toContain("3 Sept 2026");
+		expect(british.match(/2026/g)).toHaveLength(1);
+
+		expect(withRegionValue("en-US", () => formatMediumDateRange(date, end))).toContain(
+			"Aug 29"
+		);
 	});
 
 	it("lets the locale glue the date to the time", () => {

--- a/src/Web/packages/app/src/lib/utils/formatting.test.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.test.ts
@@ -226,6 +226,22 @@ describe("Date formatting", () => {
 			const result = formatDate("2025-06-15T10:30:00Z");
 			expect(result).not.toBe("N/A");
 		});
+
+		it("writes an abbreviated month and no seconds, in the regional format", () => {
+			// A bare toLocaleString gave "4/30/2026, 11:00:39 PM" on the token cards:
+			// all-numeric, so unreadable to anyone who does not share the locale's
+			// field order, and precise to a second that nothing on those rows needs.
+			// Built in local time for the reason "Shared date shapes" gives.
+			const date = new Date(2026, 7, 29, 14, 5, 9);
+			const british = withRegionValue("en-GB", () => formatDate(date));
+			expect(british).toContain("29 Aug 2026");
+			expect(british).toContain("14:05");
+			expect(british).not.toContain(":09");
+
+			// The month is named, not numbered, whatever the region writes.
+			expect(withRegionValue("de-DE", () => formatDate(date))).toMatch(/Aug/);
+			expect(withRegionValue("en-US", () => formatDate(date))).toMatch(/Aug 29, 2026/);
+		});
 	});
 
 	describe("formatDateDetailed", () => {

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -302,20 +302,6 @@ export function formatDateTime(dateStr: string | undefined): string {
 }
 
 /**
- * {@link formatMediumDateTime} with "N/A" for a missing value, for the rows that
- * read "Created ..." or "Last used ...".
- *
- * A reader whose regional format is unset resolves to their display language,
- * and the default "en" writes month-first, so an all-numeric date here cannot be
- * told apart from a day-first one.
- */
-export function formatDate(date: Date | string | number | undefined): string {
-  if (date == null || date === "") return "N/A";
-  const d = new Date(date);
-  return Number.isNaN(d.getTime()) ? "N/A" : formatMediumDateTime(d);
-}
-
-/**
  * Formats a date string with detailed formatting options
  * @param dateString - ISO date string or undefined
  * @returns Formatted date and time with full details, or "Unknown"
@@ -386,6 +372,20 @@ export function formatMediumDate(date: Date | string | number): string {
     month: "short",
     day: "numeric",
   });
+}
+
+/**
+ * A date range at {@link formatMediumDate}'s precision, e.g. "29 Aug - 3 Sep 2026".
+ *
+ * Built by ICU rather than by joining two formatted dates with a hyphen, so the parts the two
+ * share are collapsed and the separator is the one the region writes.
+ */
+export function formatMediumDateRange(start: Date, end: Date): string {
+  return new Intl.DateTimeFormat(formatLocale(), {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).formatRange(start, end);
 }
 
 /**

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -302,14 +302,20 @@ export function formatDateTime(dateStr: string | undefined): string {
 }
 
 /**
- * Formats a date string or Date object to locale string
+ * {@link formatMediumDateTime} for the metadata rows that read "Created …" or
+ * "Last used …", with "N/A" for a missing value rather than an em dash.
+ *
+ * The abbreviated month is what makes this readable to everyone: a bare
+ * `toLocaleString` gives an all-numeric date, and a reader whose regional format
+ * is unset cannot tell "4/30/2026" apart from a day-first one. It also drops the
+ * seconds, which no surface here is precise enough to want.
  * @param date - Date object, ISO date string, or undefined
  * @returns Formatted date and time string, or "N/A"
  */
 export function formatDate(date: Date | string | number | undefined): string {
   if (date == null || date === "") return "N/A";
   const d = new Date(date);
-  return Number.isNaN(d.getTime()) ? "N/A" : d.toLocaleString(formatLocale());
+  return Number.isNaN(d.getTime()) ? "N/A" : formatMediumDateTime(d);
 }
 
 /**

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -302,15 +302,12 @@ export function formatDateTime(dateStr: string | undefined): string {
 }
 
 /**
- * {@link formatMediumDateTime} for the metadata rows that read "Created …" or
- * "Last used …", with "N/A" for a missing value rather than an em dash.
+ * {@link formatMediumDateTime} with "N/A" for a missing value, for the rows that
+ * read "Created ..." or "Last used ...".
  *
- * The abbreviated month is what makes this readable to everyone: a bare
- * `toLocaleString` gives an all-numeric date, and a reader whose regional format
- * is unset cannot tell "4/30/2026" apart from a day-first one. It also drops the
- * seconds, which no surface here is precise enough to want.
- * @param date - Date object, ISO date string, or undefined
- * @returns Formatted date and time string, or "N/A"
+ * A reader whose regional format is unset resolves to their display language,
+ * and the default "en" writes month-first, so an all-numeric date here cannot be
+ * told apart from a day-first one.
  */
 export function formatDate(date: Date | string | number | undefined): string {
   if (date == null || date === "") return "N/A";

--- a/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
@@ -9,7 +9,7 @@
   import { NotificationUrgency as NotificationUrgencyEnum } from "$api";
   import { Button } from "$lib/components/ui/button";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
-  import { getUnitLabel, formatLocale, formatDate, time } from "$lib/utils/formatting";
+  import { getUnitLabel, formatLocale, formatMediumDateTime, time } from "$lib/utils/formatting";
   import {
     leadingBlankDays,
     weekdayLabels,
@@ -397,7 +397,7 @@
         {currentYear}
       </h1>
       <p class="text-sm text-muted-foreground">
-        Generated {formatDate(new Date())}
+        Generated {formatMediumDateTime(new Date())}
       </p>
     </div>
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
     import {page} from "$app/state";
     import { Button } from "$lib/components/ui/button";
     import {ReportsFilterSidebar} from "$lib/components/layout";
@@ -87,7 +87,7 @@
         <div class="hidden print:block border-b border-border pb-3 mb-4 px-3">
             <h1 class="text-xl font-bold text-foreground">{reportName}</h1>
             <p class="text-sm text-muted-foreground">
-                {#if showFilters}{dateRangeDisplay} · {/if}Generated {formatDate(new Date())}
+                {#if showFilters}{dateRangeDisplay} · {/if}Generated {formatMediumDateTime(new Date())}
             </p>
         </div>
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
@@ -21,7 +21,7 @@
   import TIRStackedChart from "$lib/components/reports/TIRStackedChart.svelte";
   import ReliabilityBadge from "$lib/components/reports/ReliabilityBadge.svelte";
   import { getReportsData } from "$api/reports.remote";
-  import { bg, bgLabel, bgRange, formatDate, formatNumber, formatNumericDate } from "$lib/utils/formatting";
+  import { bg, bgLabel, bgRange, formatMediumDateTime, formatNumber, formatNumericDate } from "$lib/utils/formatting";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
 
@@ -331,7 +331,7 @@
   <div class="text-xs text-muted-foreground text-center">
     Data from {formatNumericDate(startDate)} – {formatNumericDate(endDate)}.
     {#if lastUpdated}
-      Last updated {formatDate(new Date(lastUpdated))}.
+      Last updated {formatMediumDateTime(new Date(lastUpdated))}.
     {/if}
   </div>
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/executive-summary/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/executive-summary/+page.svelte
@@ -26,7 +26,7 @@
   import { getReportsData } from "$api/reports.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
-  import { bg, bgLabel, bgRange, formatDate, formatNumber } from "$lib/utils/formatting";
+  import { bg, bgLabel, bgRange, formatMediumDateTime, formatNumber } from "$lib/utils/formatting";
   import { formatMinutesDuration } from "$lib/utils/duration";
 
   // Format a nullable mg/dL value in the user's preferred units, or em dash if absent.
@@ -539,7 +539,7 @@
     <!-- Footer -->
     <div class="text-xs text-muted-foreground text-center space-y-1 print:mt-8">
       {#if lastUpdated}
-        <p>Report generated: {formatDate(new Date(lastUpdated))}</p>
+        <p>Report generated: {formatMediumDateTime(new Date(lastUpdated))}</p>
       {/if}
       <p class="text-muted-foreground/60">
         This report is for informational purposes. Always consult your

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
@@ -24,7 +24,7 @@
   import HourlyBolusChart from "$lib/components/reports/HourlyBolusChart.svelte";
   import ScheduleFooter from "$lib/components/reports/ScheduleFooter.svelte";
   import { getIdpData } from "$api/idp.remote";
-  import { bg, bgLabel, formatDate, formatNumber, formatNumericDate } from "$lib/utils/formatting";
+  import { bg, bgLabel, formatMediumDateTime, formatNumber, formatNumericDate } from "$lib/utils/formatting";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
 
@@ -362,7 +362,7 @@
   <div class="text-xs text-muted-foreground text-center">
     Data from {formatNumericDate(startDate)} – {formatNumericDate(endDate)}.
     {#if lastUpdated}
-      Last updated {formatDate(new Date(lastUpdated))}.
+      Last updated {formatMediumDateTime(new Date(lastUpdated))}.
     {/if}
   </div>
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatMediumDateTime } from "$lib/utils/formatting";
+  import { formatDate } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -179,14 +179,6 @@
     }
   }
 
-  // Format date
-  function formatDate(dateStr: Date | string | undefined): string {
-    if (!dateStr) return "N/A";
-    const date = new Date(dateStr);
-    return formatMediumDateTime(date);
-  }
-
-  // Get state badge
   function getStateBadge(state: MigrationJobState | undefined) {
     switch (state) {
       case MigrationJobState.Pending:

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatDate } from "$lib/utils/formatting";
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -629,7 +629,7 @@
                           </Badge>
                         </div>
                         <div class="text-sm text-muted-foreground">
-                          Started: {formatDate(job.startedAt)}
+                          Started: {formatMediumDateTime(job.startedAt)}
                         </div>
                         {#if job.errorMessage}
                           <div
@@ -646,7 +646,7 @@
                     </div>
                     <div class="text-right text-sm text-muted-foreground">
                       {#if job.completedAt}
-                        <div>Completed: {formatDate(job.completedAt)}</div>
+                        <div>Completed: {formatMediumDateTime(job.completedAt)}</div>
                       {/if}
                     </div>
                   </div>
@@ -687,7 +687,7 @@
                             "Unknown"}
                         </div>
                         <div class="text-sm text-muted-foreground">
-                          Last migration: {formatDate(source.lastMigrationAt)}
+                          Last migration: {formatMediumDateTime(source.lastMigrationAt)}
                         </div>
                       </div>
                     </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/nightscout-transition/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/nightscout-transition/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatDate, formatNumber } from "$lib/utils/formatting";
+  import { formatMediumDateTime, formatNumber } from "$lib/utils/formatting";
 	import {
 		Card,
 		CardContent,
@@ -39,7 +39,7 @@
 	function formatTimestamp(ts: Date | string | null | undefined): string {
 		if (!ts) return 'Never';
 		try {
-			return formatDate(new Date(ts));
+			return formatMediumDateTime(new Date(ts));
 		} catch {
 			return 'Unknown';
 		}


### PR DESCRIPTION
## Problem

`formatDate` was the only date helper calling `toLocaleString` with no options, so it emitted the locale's raw default: all-numeric and precise to the second.

> Created 4/30/2026, 11:00:39 PM  Last used 6/12/2026, 4:25:30 PM

The seconds are noise. More importantly, an all-numeric date is unreadable to anyone who doesn't already share the locale's field order, and that isn't a rare case here: `regionFormat` defaults to `""` (`appearance-store.svelte.ts:283`), falling back to `preferredLanguage`, whose default is `"en"` (`:779`), which ICU resolves to US field order. A British reader who never opened Appearance is shown `4/30/2026` with no way to tell it from a day-first date.

## Change

Those rows now use the existing `formatMediumDateTime` shape: `29 Aug 2026, 14:05`. The month is named, so it can't be misread whatever the region writes, and it keeps the locale's own hour cycle per the convention the shared date shapes already follow (forcing `prefersHour12()` would hand a German reader an English "AM").

**`formatDate` is gone.** Once it delegated to `formatMediumDateTime` the two differed only in the placeholder they return for a missing value, which left a function named for a date returning a date *and* a time, next to a `formatDateTime` returning something different again. Its 16 remaining callers name the shape they want, and the sentinel settles on the em dash every sibling already used.

Ten other files define their own local `formatDate` over a different shape. They were never calling this one and are untouched. `settings/migration/+page.svelte` had a hand-written twin of exactly the delegating version and is now folded in.

**Date ranges.** Two labels built their text by hyphenating two whole `toLocaleDateString` calls — the same unreadable all-numeric date, plus a hardcoded separator. `formatMediumDateRange` hands both dates to ICU, which collapses the parts they share and joins them the way the region does: `29 Aug – 3 Sept 2026`.

`formatNumericDate` keeps its bare call. Numeric is what it is for, and its doc already sends readers to the named-month shapes where one reads better.

## Scope

**26 call sites across 19 files.**

An earlier revision said "86 call sites across 30 files" and named guest links, trackers and reports among the beneficiaries. That was a raw grep of the string `formatDate`, counting imports, local definitions and the test file, and the list was wrong too: eleven files shadow the shared helper with their own.

## Tests

`formatMediumDateTime` now carries the coverage: the shape across three regions with seconds gone, and every unusable value reading as no value rather than the epoch. `formatMediumDateRange` is pinned on the collapsed year, which is the tell that ICU formatted the range rather than two dates being joined by hand. 65 pass in the file, 1204 across the app.

Mutation-checked, all red as expected: restoring the bare `toLocaleString`; dropping the time; dropping the year; deleting the `null` guard. The last of those survived before this revision, because `undefined` and `""` reach the `NaN` branch and are caught either way, so `null` is the only input that pins the explicit guard.

`pnpm check`: no errors in the changed files. The three prettier warnings in files this touches all reproduce on `main`, so they are left rather than reformatted into the diff.

https://claude.ai/code/session_01Kr7oRsePv4LL2QFSuQdpNd
