### PR TITLE
refactor(web): give each access section one home

### DIFF
--- a/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
+++ b/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
@@ -430,12 +430,14 @@ export const items: CommandPaletteItem[] = [
 		href: "/settings/connectors",
 	},
 	{
+		// /settings/integrations has no page — only the Discord child does, and the
+		// card that used to lead there now sits under Alerts.
 		id: "settings-integrations",
-		label: "Integrations",
+		label: "Discord",
 		group: "settings",
-		keywords: ["integrations", "api", "webhooks"],
+		keywords: ["discord", "bot", "chat", "integrations", "alerts"],
 		icon: Link,
-		href: "/settings/integrations",
+		href: "/settings/integrations/discord",
 	},
 	{
 		id: "settings-data-quality",

--- a/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
+++ b/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
@@ -430,8 +430,7 @@ export const items: CommandPaletteItem[] = [
 		href: "/settings/connectors",
 	},
 	{
-		// /settings/integrations has no page — only the Discord child does, and the
-		// card that used to lead there now sits under Alerts.
+		// Points at the child: /settings/integrations itself has no page.
 		id: "settings-integrations",
 		label: "Discord",
 		group: "settings",

--- a/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
+++ b/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
@@ -430,8 +430,10 @@ export const items: CommandPaletteItem[] = [
 		href: "/settings/connectors",
 	},
 	{
-		// Points at the child: /settings/integrations itself has no page.
+		// Kept while the label and href moved on: pinned and recent ids persist in local storage,
+		// and one that no longer matches an item is dropped from a user's pins without a word.
 		id: "settings-integrations",
+		// The parent /settings/integrations has no page of its own; only this child does.
 		label: "Discord",
 		group: "settings",
 		keywords: ["discord", "bot", "chat", "integrations", "alerts"],

--- a/src/Web/packages/app/src/lib/components/settings/DataMaintenanceCard.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DataMaintenanceCard.svelte
@@ -21,7 +21,19 @@
   import { page } from "$app/state";
 
   const isPlatformAdmin = $derived(
-    (page.data as { isPlatformAdmin?: boolean }).isPlatformAdmin ?? false,
+    (page.data as { isPlatformAdmin?: boolean }).isPlatformAdmin ?? false
+  );
+
+  // Both tools rewrite tenant-wide data and the API answers 403 to anyone but an admin, so the
+  // card self-gates on the same permissions RequireAdmin resolves to. It matters more here than
+  // it did on Connectors & Apps: Data Quality is a page an ordinary member opens to set a sleep
+  // schedule, so offering them a Remove Demo Data button that only fails would be its own answer.
+  const effectivePermissions: string[] = $derived(
+    (page.data as { effectivePermissions?: string[] }).effectivePermissions ??
+      []
+  );
+  const canMaintainData = $derived(
+    effectivePermissions.includes("*") || effectivePermissions.includes("admin")
   );
 
   let showDeduplicationDialog = $state(false);
@@ -29,95 +41,102 @@
   let showDemoDataDialog = $state(false);
 </script>
 
-<Card>
-  <CardHeader>
-    <CardTitle class="flex items-center gap-2">
-      <Wrench class="h-5 w-5" />
-      Data Maintenance
-    </CardTitle>
-    <CardDescription>Administrative tools for managing your data</CardDescription>
-  </CardHeader>
-  <CardContent class="space-y-4">
-    <div
-      data-testid="deduplicate-records"
-      class="flex items-start gap-4 p-4 rounded-lg border bg-card"
-    >
+{#if canMaintainData}
+  <Card>
+    <CardHeader>
+      <CardTitle class="flex items-center gap-2">
+        <Wrench class="h-5 w-5" />
+        Data Maintenance
+      </CardTitle>
+      <CardDescription>
+        Administrative tools for managing your data
+      </CardDescription>
+    </CardHeader>
+    <CardContent class="space-y-4">
       <div
-        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
-      >
-        <Link2 class="h-5 w-5 text-primary" />
-      </div>
-      <div class="flex-1">
-        <h4 class="font-medium">Deduplicate Records</h4>
-        <p class="text-sm text-muted-foreground mt-1">
-          Link records from multiple data sources that represent the same
-          underlying event. This improves data quality when the same glucose
-          readings or treatments are uploaded from different apps.
-        </p>
-        <Button
-          variant="outline"
-          size="sm"
-          class="mt-3 gap-2"
-          onclick={() => (showDeduplicationDialog = true)}
-        >
-          {#if isDeduplicating}
-            <Loader2 class="h-4 w-4 animate-spin" />
-            Deduplication Running...
-          {:else}
-            <Link2 class="h-4 w-4" />
-            Run Deduplication
-          {/if}
-        </Button>
-      </div>
-    </div>
-
-    <div class="flex items-start gap-4 p-4 rounded-lg border bg-card">
-      <div
-        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
-      >
-        <Sparkles class="h-5 w-5 text-primary" />
-      </div>
-      <div class="flex-1">
-        <h4 class="font-medium">Remove Demo Data</h4>
-        <p class="text-sm text-muted-foreground mt-1">
-          Delete the sample readings and treatments that were generated to show
-          you around. Your own data is not affected.
-        </p>
-        <Button
-          variant="outline"
-          size="sm"
-          class="mt-3 gap-2"
-          onclick={() => (showDemoDataDialog = true)}
-        >
-          <Sparkles class="h-4 w-4" />
-          Remove Demo Data
-        </Button>
-      </div>
-    </div>
-
-    {#if isPlatformAdmin}
-      <a
-        href={resolve("/settings/admin/connector-cursors")}
-        class="group flex items-center gap-4 rounded-lg border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-muted/40"
+        data-testid="deduplicate-records"
+        class="flex items-start gap-4 p-4 rounded-lg border bg-card"
       >
         <div
           class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
         >
-          <RefreshCw class="h-5 w-5 text-primary" />
+          <Link2 class="h-5 w-5 text-primary" />
         </div>
-        <div class="min-w-0 flex-1">
-          <h4 class="font-medium">Reset Connector Cursors</h4>
+        <div class="flex-1">
+          <h4 class="font-medium">Deduplicate Records</h4>
           <p class="text-sm text-muted-foreground mt-1">
-            Re-sync a connector from a chosen point.
+            Link records from multiple data sources that represent the same
+            underlying event. This improves data quality when the same glucose
+            readings or treatments are uploaded from different apps.
           </p>
+          <Button
+            variant="outline"
+            size="sm"
+            class="mt-3 gap-2"
+            onclick={() => (showDeduplicationDialog = true)}
+          >
+            {#if isDeduplicating}
+              <Loader2 class="h-4 w-4 animate-spin" />
+              Deduplication Running...
+            {:else}
+              <Link2 class="h-4 w-4" />
+              Run Deduplication
+            {/if}
+          </Button>
         </div>
-        <ChevronRight
-          class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-        />
-      </a>
-    {/if}
-  </CardContent>
-</Card>
+      </div>
 
-<DemoDataSection bind:open={showDemoDataDialog} />
-<DeduplicationDialog bind:open={showDeduplicationDialog} bind:isDeduplicating />
+      <div class="flex items-start gap-4 p-4 rounded-lg border bg-card">
+        <div
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
+        >
+          <Sparkles class="h-5 w-5 text-primary" />
+        </div>
+        <div class="flex-1">
+          <h4 class="font-medium">Remove Demo Data</h4>
+          <p class="text-sm text-muted-foreground mt-1">
+            Delete the sample readings and treatments that were generated to
+            show you around. Your own data is not affected.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            class="mt-3 gap-2"
+            onclick={() => (showDemoDataDialog = true)}
+          >
+            <Sparkles class="h-4 w-4" />
+            Remove Demo Data
+          </Button>
+        </div>
+      </div>
+
+      {#if isPlatformAdmin}
+        <a
+          href={resolve("/settings/admin/connector-cursors")}
+          class="group flex items-center gap-4 rounded-lg border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-muted/40"
+        >
+          <div
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
+          >
+            <RefreshCw class="h-5 w-5 text-primary" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <h4 class="font-medium">Reset Connector Cursors</h4>
+            <p class="text-sm text-muted-foreground mt-1">
+              Re-sync a connector from a chosen point.
+            </p>
+          </div>
+          <ChevronRight
+            class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+          />
+        </a>
+      {/if}
+    </CardContent>
+  </Card>
+
+  <DemoDataSection bind:open={showDemoDataDialog} />
+  <DeduplicationDialog
+    bind:open={showDeduplicationDialog}
+    bind:isDeduplicating
+  />
+{/if}

--- a/src/Web/packages/app/src/lib/components/settings/DataMaintenanceCard.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DataMaintenanceCard.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card";
+  import { Button } from "$lib/components/ui/button";
+  import {
+    Link2,
+    Loader2,
+    RefreshCw,
+    Sparkles,
+    Wrench,
+    ChevronRight,
+  } from "lucide-svelte";
+  import DeduplicationDialog from "$lib/components/connectors/DeduplicationDialog.svelte";
+  import DemoDataSection from "$lib/components/connectors/DemoDataSection.svelte";
+  import { resolve } from "$app/paths";
+  import { page } from "$app/state";
+
+  const isPlatformAdmin = $derived(
+    (page.data as { isPlatformAdmin?: boolean }).isPlatformAdmin ?? false,
+  );
+
+  let showDeduplicationDialog = $state(false);
+  let isDeduplicating = $state(false);
+  let showDemoDataDialog = $state(false);
+</script>
+
+<Card>
+  <CardHeader>
+    <CardTitle class="flex items-center gap-2">
+      <Wrench class="h-5 w-5" />
+      Data Maintenance
+    </CardTitle>
+    <CardDescription>Administrative tools for managing your data</CardDescription>
+  </CardHeader>
+  <CardContent class="space-y-4">
+    <div
+      data-testid="deduplicate-records"
+      class="flex items-start gap-4 p-4 rounded-lg border bg-card"
+    >
+      <div
+        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
+      >
+        <Link2 class="h-5 w-5 text-primary" />
+      </div>
+      <div class="flex-1">
+        <h4 class="font-medium">Deduplicate Records</h4>
+        <p class="text-sm text-muted-foreground mt-1">
+          Link records from multiple data sources that represent the same
+          underlying event. This improves data quality when the same glucose
+          readings or treatments are uploaded from different apps.
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          class="mt-3 gap-2"
+          onclick={() => (showDeduplicationDialog = true)}
+        >
+          {#if isDeduplicating}
+            <Loader2 class="h-4 w-4 animate-spin" />
+            Deduplication Running...
+          {:else}
+            <Link2 class="h-4 w-4" />
+            Run Deduplication
+          {/if}
+        </Button>
+      </div>
+    </div>
+
+    <div class="flex items-start gap-4 p-4 rounded-lg border bg-card">
+      <div
+        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
+      >
+        <Sparkles class="h-5 w-5 text-primary" />
+      </div>
+      <div class="flex-1">
+        <h4 class="font-medium">Remove Demo Data</h4>
+        <p class="text-sm text-muted-foreground mt-1">
+          Delete the sample readings and treatments that were generated to show
+          you around. Your own data is not affected.
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          class="mt-3 gap-2"
+          onclick={() => (showDemoDataDialog = true)}
+        >
+          <Sparkles class="h-4 w-4" />
+          Remove Demo Data
+        </Button>
+      </div>
+    </div>
+
+    {#if isPlatformAdmin}
+      <a
+        href={resolve("/settings/admin/connector-cursors")}
+        class="group flex items-center gap-4 rounded-lg border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-muted/40"
+      >
+        <div
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
+        >
+          <RefreshCw class="h-5 w-5 text-primary" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <h4 class="font-medium">Reset Connector Cursors</h4>
+          <p class="text-sm text-muted-foreground mt-1">
+            Re-sync a connector from a chosen point.
+          </p>
+        </div>
+        <ChevronRight
+          class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+        />
+      </a>
+    {/if}
+  </CardContent>
+</Card>
+
+<DemoDataSection bind:open={showDemoDataDialog} />
+<DeduplicationDialog bind:open={showDeduplicationDialog} bind:isDeduplicating />

--- a/src/Web/packages/app/src/lib/components/settings/DataMaintenanceCard.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/settings/DataMaintenanceCard.svelte.test.ts
@@ -1,0 +1,71 @@
+import { render } from "vitest-browser-svelte";
+import { page as browser } from "vitest/browser";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { page } from "$app/state";
+
+// The dialogs each open a remote command on mount; the card under test only owns whether they
+// are reachable, so they are stubbed down to nothing renderable.
+vi.mock("$lib/components/connectors/DeduplicationDialog.svelte", () => ({
+  default: () => {},
+}));
+vi.mock("$lib/components/connectors/DemoDataSection.svelte", () => ({
+  default: () => {},
+}));
+
+import DataMaintenanceCard from "./DataMaintenanceCard.svelte";
+
+describe("DataMaintenanceCard", () => {
+  beforeEach(() => {
+    page.data = { effectivePermissions: [], isPlatformAdmin: false };
+  });
+
+  it("offers nothing to someone the API would refuse", async () => {
+    // Both tools are RequireAdmin server-side. An ordinary member opens Data Quality to set a
+    // sleep schedule, so a Remove Demo Data button that could only 403 is worse than none.
+    page.data = {
+      effectivePermissions: ["glucose.read"],
+      isPlatformAdmin: false,
+    };
+    render(DataMaintenanceCard);
+
+    expect(
+      document.querySelector('[data-testid="deduplicate-records"]')
+    ).toBeNull();
+    expect(document.body.textContent).not.toContain("Remove Demo Data");
+  });
+
+  it("offers both tools to an admin", async () => {
+    page.data = { effectivePermissions: ["admin"], isPlatformAdmin: false };
+    render(DataMaintenanceCard);
+
+    await expect
+      .element(browser.getByTestId("deduplicate-records"))
+      .toBeVisible();
+    expect(document.body.textContent).toContain("Remove Demo Data");
+  });
+
+  it("reads a wildcard grant as admin", async () => {
+    page.data = { effectivePermissions: ["*"], isPlatformAdmin: false };
+    render(DataMaintenanceCard);
+
+    await expect
+      .element(browser.getByTestId("deduplicate-records"))
+      .toBeVisible();
+  });
+
+  it("keeps connector cursors to platform admins, not tenant admins", async () => {
+    // Resetting a cursor re-syncs a connector for the whole instance, so it answers to
+    // isPlatformAdmin rather than to the tenant's own admin permission.
+    page.data = { effectivePermissions: ["admin"], isPlatformAdmin: false };
+    render(DataMaintenanceCard);
+
+    expect(document.body.textContent).not.toContain("Reset Connector Cursors");
+  });
+
+  it("offers connector cursors to a platform admin", async () => {
+    page.data = { effectivePermissions: ["admin"], isPlatformAdmin: true };
+    render(DataMaintenanceCard);
+
+    expect(document.body.textContent).toContain("Reset Connector Cursors");
+  });
+});

--- a/src/Web/packages/app/src/lib/components/settings/SettingsLinkCard.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/SettingsLinkCard.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import * as Card from "$lib/components/ui/card";
+  import { ChevronRight } from "lucide-svelte";
+  import type { SettingsLink } from "./settings-links";
+
+  let { link }: { link: SettingsLink } = $props();
+</script>
+
+<a href={link.href} class="group block">
+  <Card.Root
+    class="h-full transition-colors hover:border-primary/40 hover:bg-muted/40"
+  >
+    <Card.Content class="flex items-center gap-4 p-4">
+      <div
+        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
+      >
+        <link.icon class="h-5 w-5 text-primary" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <p class="font-medium">{link.title}</p>
+        <p class="text-sm text-muted-foreground">{link.description}</p>
+      </div>
+      <ChevronRight
+        class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+      />
+    </Card.Content>
+  </Card.Root>
+</a>

--- a/src/Web/packages/app/src/lib/components/settings/settings-links.ts
+++ b/src/Web/packages/app/src/lib/components/settings/settings-links.ts
@@ -1,0 +1,126 @@
+import type { ComponentType } from "svelte";
+import {
+  Building2,
+  HeartHandshake,
+  HeartPulse,
+  KeyRound,
+  ListChecks,
+  Palette,
+  Plug,
+  Shield,
+  ShieldCheck,
+  Syringe,
+  Timer,
+  User,
+  UserPlus,
+  Users,
+} from "lucide-svelte";
+
+/** One destination on the settings index, and anywhere else that links to a settings page. */
+export type SettingsLink = {
+  title: string;
+  description: string;
+  href: string;
+  icon: ComponentType;
+};
+
+/**
+ * Named where another page links to the same destination, so a retitled page cannot say one thing
+ * on the index and another wherever else it is offered.
+ */
+export const connectorsLink: SettingsLink = {
+  title: "Connectors & Apps",
+  description: "Connect data sources and authorized devices.",
+  href: "/settings/connectors",
+  icon: Plug,
+};
+
+/** @see {@link connectorsLink} */
+export const sharingLink: SettingsLink = {
+  title: "Sharing & Privacy",
+  description: "Members, invitations, and public sharing.",
+  href: "/settings/members",
+  icon: Users,
+};
+
+/** Mirrors the Settings group in the sidebar so both stay in sync. */
+export const settingsSections: SettingsLink[] = [
+  {
+    title: "Account",
+    description: "Profile, passkeys, authenticator apps, and recovery codes.",
+    href: "/settings/account",
+    icon: User,
+  },
+  {
+    title: "Patient Record",
+    description: "Details for the person being monitored.",
+    href: "/settings/patient",
+    icon: HeartPulse,
+  },
+  {
+    title: "Appearance",
+    description: "Theme, units, and display preferences.",
+    href: "/settings/appearance",
+    icon: Palette,
+  },
+  {
+    title: "Therapy",
+    description: "Targets, basal rates, ratios, and treatment profiles.",
+    href: "/settings/profile",
+    icon: Syringe,
+  },
+  {
+    title: "Data Quality",
+    description: "Data validation, cleanup, and maintenance tools.",
+    href: "/settings/data-quality",
+    icon: ShieldCheck,
+  },
+  {
+    title: "Notifications & Trackers",
+    description: "Alerts, reminders, and tracked events.",
+    href: "/settings/trackers",
+    icon: Timer,
+  },
+  {
+    title: "Active Access",
+    description: "Browser sessions signed in to this account.",
+    href: "/settings/access",
+    icon: KeyRound,
+  },
+  connectorsLink,
+  sharingLink,
+  {
+    title: "Support & Community",
+    description: "Get help and connect with the community.",
+    href: "/settings/support",
+    icon: HeartHandshake,
+  },
+];
+
+export const adminSettingsSections: SettingsLink[] = [
+  {
+    title: "Administration",
+    description: "Identity providers and integrations.",
+    href: "/settings/admin",
+    icon: Shield,
+  },
+  {
+    title: "Tenant Management",
+    description: "Tenant details and platform administrators.",
+    href: "/settings/admin/tenants",
+    icon: Building2,
+  },
+  {
+    title: "Access Requests",
+    description: "Review people asking to join this instance.",
+    href: "/settings/access-requests",
+    icon: UserPlus,
+  },
+];
+
+export const onboardingSection: SettingsLink = {
+  title: "Setup",
+  description: "Re-run the guided onboarding checklist.",
+  href: "/setup",
+  icon: ListChecks,
+};

--- a/src/Web/packages/app/src/lib/components/settings/settings-links.ts
+++ b/src/Web/packages/app/src/lib/components/settings/settings-links.ts
@@ -16,7 +16,10 @@ import {
   Users,
 } from "lucide-svelte";
 
-/** One destination on the settings index, and anywhere else that links to a settings page. */
+/**
+ * One destination on the settings index, and anywhere else that links to a
+ * settings page.
+ */
 export type SettingsLink = {
   title: string;
   description: string;
@@ -25,8 +28,8 @@ export type SettingsLink = {
 };
 
 /**
- * Named where another page links to the same destination, so a retitled page cannot say one thing
- * on the index and another wherever else it is offered.
+ * Named where another page links to the same destination, so a retitled page
+ * cannot say one thing on the index and another wherever else it is offered.
  */
 export const connectorsLink: SettingsLink = {
   title: "Connectors & Apps",

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -356,9 +356,7 @@
       </CardContent>
     </Card>
 
-    <!-- Delivery beyond the browser. Lives here rather than under Connectors
-         because it answers this page's "where you're notified", not "where the
-         data comes from". -->
+    <!-- Lives here because it answers this page's "where you're notified". -->
     <Card>
       <CardHeader>
         <CardTitle>Where alerts reach you</CardTitle>

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -34,7 +34,9 @@
   } from "$lib/components/ui/card";
   import { Badge } from "$lib/components/ui/badge";
   import SettingsPageSkeleton from "$lib/components/settings/SettingsPageSkeleton.svelte";
-  import { Bell, Plus, AlertTriangle, Check, Loader2 } from "lucide-svelte";
+  import { Bell, Plus, AlertTriangle, Check, ChevronRight, Loader2 } from "lucide-svelte";
+  import AppLogo from "$lib/components/ui/AppLogo.svelte";
+  import { resolve } from "$app/paths";
 
   import AlertRuleRow from "$lib/components/alerts/AlertRuleRow.svelte";
   import DndNoticeStrip from "$lib/components/alerts/DndNoticeStrip.svelte";
@@ -351,6 +353,34 @@
             {/each}
           </div>
         {/if}
+      </CardContent>
+    </Card>
+
+    <!-- Delivery beyond the browser. Lives here rather than under Connectors
+         because it answers this page's "where you're notified", not "where the
+         data comes from". -->
+    <Card>
+      <CardHeader>
+        <CardTitle>Where alerts reach you</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <a
+          href={resolve("/settings/integrations/discord")}
+          class="flex items-center justify-between rounded-lg border p-4 transition-colors hover:bg-accent"
+        >
+          <div class="flex items-center gap-3">
+            <div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-md bg-muted">
+              <AppLogo icon="discord" />
+            </div>
+            <div>
+              <p class="font-medium">Discord</p>
+              <p class="text-sm text-muted-foreground">
+                Link a Discord account to receive alerts and use the Nocturne bot
+              </p>
+            </div>
+          </div>
+          <ChevronRight class="h-4 w-4 text-muted-foreground" />
+        </a>
       </CardContent>
     </Card>
   </svelte:boundary>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/+page.svelte
@@ -1,128 +1,16 @@
 <script lang="ts">
-  import type { ComponentType } from "svelte";
-  import * as Card from "$lib/components/ui/card";
+  import { Settings } from "lucide-svelte";
+  import SettingsLinkCard from "$lib/components/settings/SettingsLinkCard.svelte";
   import {
-    Settings,
-    ListChecks,
-    User,
-    HeartPulse,
-    Palette,
-    Syringe,
-    ShieldCheck,
-    Timer,
-    Plug,
-    KeyRound,
-    Users,
-    HeartHandshake,
-    Building2,
-    Shield,
-    UserPlus,
-    ChevronRight,
-  } from "lucide-svelte";
+    adminSettingsSections,
+    onboardingSection,
+    settingsSections,
+  } from "$lib/components/settings/settings-links";
   import type { PageData } from "./$types";
 
   const { data }: { data: PageData } = $props();
 
   const isPlatformAdmin = $derived(data.isPlatformAdmin ?? false);
-
-  type SettingsLink = {
-    title: string;
-    description: string;
-    href: string;
-    icon: ComponentType;
-  };
-
-  // Mirrors the Settings group in the sidebar so both stay in sync.
-  const sections: SettingsLink[] = [
-    {
-      title: "Account",
-      description: "Profile, passkeys, authenticator apps, and recovery codes.",
-      href: "/settings/account",
-      icon: User,
-    },
-    {
-      title: "Patient Record",
-      description: "Details for the person being monitored.",
-      href: "/settings/patient",
-      icon: HeartPulse,
-    },
-    {
-      title: "Appearance",
-      description: "Theme, units, and display preferences.",
-      href: "/settings/appearance",
-      icon: Palette,
-    },
-    {
-      title: "Therapy",
-      description: "Targets, basal rates, ratios, and treatment profiles.",
-      href: "/settings/profile",
-      icon: Syringe,
-    },
-    {
-      title: "Data Quality",
-      description: "Data validation and cleanup settings.",
-      href: "/settings/data-quality",
-      icon: ShieldCheck,
-    },
-    {
-      title: "Notifications & Trackers",
-      description: "Alerts, reminders, and tracked events.",
-      href: "/settings/trackers",
-      icon: Timer,
-    },
-    {
-      title: "Active Access",
-      description: "Signed-in devices, guest links, and connected apps.",
-      href: "/settings/access",
-      icon: KeyRound,
-    },
-    {
-      title: "Connectors & Apps",
-      description: "Connect data sources and authorized devices.",
-      href: "/settings/connectors",
-      icon: Plug,
-    },
-    {
-      title: "Sharing & Privacy",
-      description: "Members, invitations, and public sharing.",
-      href: "/settings/members",
-      icon: Users,
-    },
-    {
-      title: "Support & Community",
-      description: "Get help and connect with the community.",
-      href: "/settings/support",
-      icon: HeartHandshake,
-    },
-  ];
-
-  const adminSections: SettingsLink[] = [
-    {
-      title: "Administration",
-      description: "Identity providers and integrations.",
-      href: "/settings/admin",
-      icon: Shield,
-    },
-    {
-      title: "Tenant Management",
-      description: "Tenant details and platform administrators.",
-      href: "/settings/admin/tenants",
-      icon: Building2,
-    },
-    {
-      title: "Access Requests",
-      description: "Review people asking to join this instance.",
-      href: "/settings/access-requests",
-      icon: UserPlus,
-    },
-  ];
-
-  const onboardingSection: SettingsLink = {
-    title: "Setup",
-    description: "Re-run the guided onboarding checklist.",
-    href: "/setup",
-    icon: ListChecks,
-  };
 </script>
 
 <svelte:head>
@@ -143,8 +31,8 @@
   </div>
 
   <div class="grid gap-3 @md:grid-cols-2">
-    {#each sections as section (section.href)}
-      {@render sectionCard(section)}
+    {#each settingsSections as section (section.href)}
+      <SettingsLinkCard link={section} />
     {/each}
   </div>
 
@@ -154,8 +42,8 @@
         Platform Administration
       </h2>
       <div class="grid gap-3 @md:grid-cols-2">
-        {#each adminSections as section (section.href)}
-          {@render sectionCard(section)}
+        {#each adminSettingsSections as section (section.href)}
+          <SettingsLinkCard link={section} />
         {/each}
       </div>
     </div>
@@ -166,30 +54,8 @@
       Onboarding
     </h2>
     <div class="grid gap-3 @md:grid-cols-2">
-      {@render sectionCard(onboardingSection)}
+      <SettingsLinkCard link={onboardingSection} />
     </div>
   </div>
 </div>
 
-{#snippet sectionCard(section: SettingsLink)}
-  <a href={section.href} class="group block">
-    <Card.Root
-      class="h-full transition-colors hover:border-primary/40 hover:bg-muted/40"
-    >
-      <Card.Content class="flex items-center gap-4 p-4">
-        <div
-          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
-        >
-          <section.icon class="h-5 w-5 text-primary" />
-        </div>
-        <div class="min-w-0 flex-1">
-          <p class="font-medium">{section.title}</p>
-          <p class="text-sm text-muted-foreground">{section.description}</p>
-        </div>
-        <ChevronRight
-          class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-        />
-      </Card.Content>
-    </Card.Root>
-  </a>
-{/snippet}

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/access/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/access/+page.svelte
@@ -1,9 +1,30 @@
 <script lang="ts">
-  import { KeyRound } from "lucide-svelte";
+  import { KeyRound, Plug, Users, ChevronRight } from "lucide-svelte";
+  import * as Card from "$lib/components/ui/card";
   import ActiveSessions from "$lib/components/settings/ActiveSessions.svelte";
   import ApiReference from "$lib/components/settings/ApiReference.svelte";
-  import ConnectedApps from "$lib/components/settings/ConnectedApps.svelte";
-  import GuestLinksSection from "$lib/components/members/GuestLinksSection.svelte";
+  import { resolve } from "$app/paths";
+
+  // Everything below this page's own Sessions section is managed on another
+  // page. Rendering those sections here too meant Connected Apps and Guest
+  // Links each existed on two pages, where revoking on one left the other
+  // stale; link out instead so each has one home.
+  const managedElsewhere = [
+    {
+      href: resolve("/settings/connectors"),
+      icon: Plug,
+      title: "Connectors & Apps",
+      description:
+        "Apps you have authorised, devices that receive your alerts, and API keys.",
+    },
+    {
+      href: resolve("/settings/members"),
+      icon: Users,
+      title: "Sharing & Privacy",
+      description:
+        "People you have invited, temporary guest links, and your public link.",
+    },
+  ];
 </script>
 
 <svelte:head>
@@ -27,8 +48,45 @@
 
   <div class="space-y-10">
     <ActiveSessions />
-    <GuestLinksSection />
-    <ConnectedApps />
+
+    <div class="space-y-4">
+      <div class="space-y-1">
+        <h2 class="text-lg font-semibold tracking-tight">
+          What else can reach your data
+        </h2>
+        <p class="text-sm text-muted-foreground">
+          Each of these is granted, and taken away again, on its own page.
+        </p>
+      </div>
+      <div class="space-y-3">
+        {#each managedElsewhere as entry (entry.href)}
+          {@const EntryIcon = entry.icon}
+          <a href={entry.href} class="group block">
+            <Card.Root
+              class="transition-colors hover:border-primary/40 hover:bg-muted/40"
+            >
+              <Card.Content class="flex items-center gap-4 p-4">
+                <div
+                  class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
+                >
+                  <EntryIcon class="h-5 w-5 text-primary" />
+                </div>
+                <div class="min-w-0 flex-1">
+                  <p class="font-medium">{entry.title}</p>
+                  <p class="text-sm text-muted-foreground">
+                    {entry.description}
+                  </p>
+                </div>
+                <ChevronRight
+                  class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                />
+              </Card.Content>
+            </Card.Root>
+          </a>
+        {/each}
+      </div>
+    </div>
+
     <ApiReference />
   </div>
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/access/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/access/+page.svelte
@@ -1,30 +1,16 @@
 <script lang="ts">
-  import { KeyRound, Plug, Users, ChevronRight } from "lucide-svelte";
-  import * as Card from "$lib/components/ui/card";
+  import { KeyRound } from "lucide-svelte";
   import ActiveSessions from "$lib/components/settings/ActiveSessions.svelte";
   import ApiReference from "$lib/components/settings/ApiReference.svelte";
-  import { resolve } from "$app/paths";
+  import SettingsLinkCard from "$lib/components/settings/SettingsLinkCard.svelte";
+  import {
+    connectorsLink,
+    sharingLink,
+  } from "$lib/components/settings/settings-links";
 
-  // Everything below this page's own Sessions section is managed on another
-  // page. Rendering those sections here too meant Connected Apps and Guest
-  // Links each existed on two pages, where revoking on one left the other
-  // stale; link out instead so each has one home.
-  const managedElsewhere = [
-    {
-      href: resolve("/settings/connectors"),
-      icon: Plug,
-      title: "Connectors & Apps",
-      description:
-        "Apps you have authorised, devices that receive your alerts, and API keys.",
-    },
-    {
-      href: resolve("/settings/members"),
-      icon: Users,
-      title: "Sharing & Privacy",
-      description:
-        "People you have invited, temporary guest links, and your public link.",
-    },
-  ];
+  // Connected apps and guest links are granted and revoked on the pages below, and were rendered
+  // here as well. One home each keeps this page from claiming to own a section it cannot change.
+  const managedElsewhere = [connectorsLink, sharingLink];
 </script>
 
 <svelte:head>
@@ -41,7 +27,8 @@
     <div>
       <h1 class="text-2xl font-bold tracking-tight">Active Access</h1>
       <p class="text-muted-foreground">
-        Everything currently able to access this account's data.
+        The browsers signed in to this account, and where to find everything
+        else that can reach your data.
       </p>
     </div>
   </div>
@@ -59,30 +46,8 @@
         </p>
       </div>
       <div class="space-y-3">
-        {#each managedElsewhere as entry (entry.href)}
-          {@const EntryIcon = entry.icon}
-          <a href={entry.href} class="group block">
-            <Card.Root
-              class="transition-colors hover:border-primary/40 hover:bg-muted/40"
-            >
-              <Card.Content class="flex items-center gap-4 p-4">
-                <div
-                  class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
-                >
-                  <EntryIcon class="h-5 w-5 text-primary" />
-                </div>
-                <div class="min-w-0 flex-1">
-                  <p class="font-medium">{entry.title}</p>
-                  <p class="text-sm text-muted-foreground">
-                    {entry.description}
-                  </p>
-                </div>
-                <ChevronRight
-                  class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-                />
-              </Card.Content>
-            </Card.Root>
-          </a>
+        {#each managedElsewhere as link (link.href)}
+          <SettingsLinkCard {link} />
         {/each}
       </div>
     </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -33,7 +33,6 @@
     Database,
     Copy,
     Check,
-    Loader2,
     KeyRound,
   } from "lucide-svelte";
   import SettingsPageSkeleton from "$lib/components/settings/SettingsPageSkeleton.svelte";
@@ -50,15 +49,12 @@
   import ServerConnectorsCard, { type ConnectorStatusWithDescription } from "$lib/components/connectors/ServerConnectorsCard.svelte";
   import DataSourceManageDialog from "$lib/components/connectors/DataSourceManageDialog.svelte";
   import { describeSubmitError } from "$lib/forms/submit-error";
-  import { page } from "$app/state";
   import { toast } from "svelte-sonner";
   import { getUploaderName } from "$lib/utils/uploader-labels";
   import { coachmark } from "@nocturne/coach";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { copyToClipboard } from "$lib/utils";
   import { createTerminalRunTracker } from "./terminal-run-tracker";
-
-  const isPlatformAdmin = $derived((page.data as { isPlatformAdmin?: boolean }).isPlatformAdmin ?? false);
 
   // Queries — fire on the server during SSR; results land in cache for hydration.
   const servicesOverviewQuery = getServicesOverview();
@@ -132,7 +128,6 @@
   let apiTokenPrefillLabel = $state("");
   let apiTokenPrefillScopes = $state<string[]>([]);
   const uploaderHandoff = createUploaderTokenHandoff();
-
 
   // Whether the user has already been told these lists are stale. The effect
   // below refreshes once per finished run, so a batch of them and the refresh

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -386,7 +386,7 @@
         <Wifi class="h-6 w-6 text-primary" />
       </div>
       <div>
-        <h1 class="text-2xl font-bold tracking-tight">Connectors & Connected Apps</h1>
+        <h1 class="text-2xl font-bold tracking-tight">Connectors & Apps</h1>
         <p class="text-muted-foreground">
           Manage data sources, set up new connections, and control app access
         </p>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -33,9 +33,6 @@
     Database,
     Copy,
     Check,
-    Link2,
-    Wrench,
-    ChevronRight,
     Loader2,
     KeyRound,
   } from "lucide-svelte";
@@ -45,18 +42,14 @@
   import ConnectedApps from "$lib/components/settings/ConnectedApps.svelte";
   import ClientDevices from "$lib/components/settings/ClientDevices.svelte";
   import ApiTokens from "$lib/components/settings/ApiTokens.svelte";
-  import DeduplicationDialog from "$lib/components/connectors/DeduplicationDialog.svelte";
-  import AppLogo from "$lib/components/ui/AppLogo.svelte";
   import UploaderSetupDialog from "$lib/components/connectors/UploaderSetupDialog.svelte";
   import { createUploaderTokenHandoff } from "./uploader-token-handoff";
   import ConnectorDetailsDialog from "$lib/components/connectors/ConnectorDetailsDialog.svelte";
   import ManualSyncDialog, { type BatchSyncResult } from "$lib/components/connectors/ManualSyncDialog.svelte";
-  import DemoDataSection from "$lib/components/connectors/DemoDataSection.svelte";
   import UploaderAppsCard from "$lib/components/connectors/UploaderAppsCard.svelte";
   import ServerConnectorsCard, { type ConnectorStatusWithDescription } from "$lib/components/connectors/ServerConnectorsCard.svelte";
   import DataSourceManageDialog from "$lib/components/connectors/DataSourceManageDialog.svelte";
   import { describeSubmitError } from "$lib/forms/submit-error";
-  import { resolve } from "$app/paths";
   import { page } from "$app/state";
   import { toast } from "svelte-sonner";
   import { getUploaderName } from "$lib/utils/uploader-labels";
@@ -90,9 +83,6 @@
   let selectedUploader = $state<UploaderApp | null>(null);
   let showSetupDialog = $state(false);
   let copiedField = $state<string | null>(null);
-
-  // Demo data dialog state
-  let showDemoDataDialog = $state(false);
 
   // Data source management dialog state
   let selectedDataSource = $state<DataSourceInfo | null>(null);
@@ -143,9 +133,6 @@
   let apiTokenPrefillScopes = $state<string[]>([]);
   const uploaderHandoff = createUploaderTokenHandoff();
 
-  // Deduplication state
-  let showDeduplicationDialog = $state(false);
-  let isDeduplicating = $state(false);
 
   // Whether the user has already been told these lists are stale. The effect
   // below refreshes once per finished run, so a batch of them and the refresh
@@ -584,128 +571,6 @@
       </Card>
     {/if}
 
-    <!-- Data Maintenance -->
-    <Card>
-      <CardHeader>
-        <CardTitle class="flex items-center gap-2">
-          <Wrench class="h-5 w-5" />
-          Data Maintenance
-        </CardTitle>
-        <CardDescription>
-          Administrative tools for managing your data
-        </CardDescription>
-      </CardHeader>
-      <CardContent class="space-y-4">
-        <div data-testid="deduplicate-records" class="flex items-start gap-4 p-4 rounded-lg border bg-card">
-          <div
-            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
-          >
-            <Link2 class="h-5 w-5 text-primary" />
-          </div>
-          <div class="flex-1">
-            <h4 class="font-medium">Deduplicate Records</h4>
-            <p class="text-sm text-muted-foreground mt-1">
-              Link records from multiple data sources that represent the same
-              underlying event. This improves data quality when the same glucose
-              readings or treatments are uploaded from different apps.
-            </p>
-            <Button
-              variant="outline"
-              size="sm"
-              class="mt-3 gap-2"
-              onclick={() => (showDeduplicationDialog = true)}
-            >
-              {#if isDeduplicating}
-                <Loader2 class="h-4 w-4 animate-spin" />
-                Deduplication Running...
-              {:else}
-                <Link2 class="h-4 w-4" />
-                Run Deduplication
-              {/if}
-            </Button>
-          </div>
-        </div>
-
-        <div class="flex items-start gap-4 p-4 rounded-lg border bg-card">
-          <div
-            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
-          >
-            <Sparkles class="h-5 w-5 text-primary" />
-          </div>
-          <div class="flex-1">
-            <h4 class="font-medium">Remove Demo Data</h4>
-            <p class="text-sm text-muted-foreground mt-1">
-              Delete the sample readings and treatments that were generated to
-              show you around. Your own data is not affected.
-            </p>
-            <Button
-              variant="outline"
-              size="sm"
-              class="mt-3 gap-2"
-              onclick={() => (showDemoDataDialog = true)}
-            >
-              <Sparkles class="h-4 w-4" />
-              Remove Demo Data
-            </Button>
-          </div>
-        </div>
-
-        {#if isPlatformAdmin}
-          <a
-            href={resolve("/settings/admin/connector-cursors")}
-            class="group flex items-center gap-4 rounded-lg border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-muted/40"
-          >
-            <div
-              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
-            >
-              <RefreshCw class="h-5 w-5 text-primary" />
-            </div>
-            <div class="min-w-0 flex-1">
-              <h4 class="font-medium">Reset Connector Cursors</h4>
-              <p class="text-sm text-muted-foreground mt-1">
-                Re-sync a connector from a chosen point.
-              </p>
-            </div>
-            <ChevronRight
-              class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-            />
-          </a>
-        {/if}
-      </CardContent>
-    </Card>
-
-    <!-- Integrations -->
-    <Card>
-      <CardHeader>
-        <CardTitle class="flex items-center gap-2">
-          <Link2 class="h-5 w-5" />
-          Integrations
-        </CardTitle>
-        <CardDescription>
-          Connect Nocturne to chat platforms and other external services
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <a
-          href={resolve("/settings/integrations/discord")}
-          class="flex items-center justify-between rounded-lg border p-4 hover:bg-accent transition-colors"
-        >
-          <div class="flex items-center gap-3">
-            <div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-md bg-muted">
-              <AppLogo icon="discord" />
-            </div>
-            <div>
-              <p class="font-medium">Discord</p>
-              <p class="text-sm text-muted-foreground">
-                Link a Discord account to receive alerts and use the Nocturne bot
-              </p>
-            </div>
-          </div>
-          <ChevronRight class="h-4 w-4 text-muted-foreground" />
-        </a>
-      </CardContent>
-    </Card>
-
     <!-- Connected Apps Section -->
     <ConnectedApps />
 
@@ -738,9 +603,6 @@
   }}
 />
 
-<!-- Demo Data Management Dialog -->
-<DemoDataSection bind:open={showDemoDataDialog} onDeleteComplete={loadServices} />
-
 <!-- Data Source Management Dialog -->
 <DataSourceManageDialog
   bind:open={showManageDataSourceDialog}
@@ -753,4 +615,3 @@
 <!-- Connector Details Dialog -->
 <ConnectorDetailsDialog bind:open={showConnectorDialog} {selectedConnector} {selectedConnectorCapabilities} onSyncComplete={loadConnectorStatuses} />
 
-<DeduplicationDialog bind:open={showDeduplicationDialog} bind:isDeduplicating />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/data-quality/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/data-quality/+page.svelte
@@ -9,6 +9,7 @@
 	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
 	import { Moon, Activity, AlertCircle, Globe, Weight, ChevronRight } from 'lucide-svelte';
 	import SettingsPageSkeleton from '$lib/components/settings/SettingsPageSkeleton.svelte';
+	import DataMaintenanceCard from '$lib/components/settings/DataMaintenanceCard.svelte';
 	import { resolve } from '$app/paths';
 	import { toast } from 'svelte-sonner';
 
@@ -245,4 +246,8 @@
 			</Card>
 		</a>
 	{/if}
+
+	<!-- Outside the branches above: these tools read no UI settings, so a
+	     settings load failure must not take them away. -->
+	<DataMaintenanceCard />
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/data-quality/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/data-quality/+page.svelte
@@ -7,15 +7,31 @@
 	import { Switch } from '$lib/components/ui/switch';
 	import { Label } from '$lib/components/ui/label';
 	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
-	import { Moon, Activity, AlertCircle, Globe, Weight, ChevronRight } from 'lucide-svelte';
+	import { Moon, Activity, AlertCircle, Globe, Weight } from 'lucide-svelte';
 	import SettingsPageSkeleton from '$lib/components/settings/SettingsPageSkeleton.svelte';
 	import DataMaintenanceCard from '$lib/components/settings/DataMaintenanceCard.svelte';
-	import { resolve } from '$app/paths';
+	import SettingsLinkCard from '$lib/components/settings/SettingsLinkCard.svelte';
+	import type { SettingsLink } from '$lib/components/settings/settings-links';
 	import { toast } from 'svelte-sonner';
 
 	// Read via .current rather than an {#await} block: consuming a remote query
 	// through its thenable reads the hydration cache and throws
 	// hydratable_missing_but_required during hydration.
+	const historyLinks: SettingsLink[] = [
+		{
+			title: 'Timezone History',
+			description: "Where you've lived and travelled, for correct timestamps.",
+			href: '/settings/timezone',
+			icon: Globe
+		},
+		{
+			title: 'Weight History',
+			description: 'Your recorded weights over time.',
+			href: '/settings/weight',
+			icon: Weight
+		}
+	];
+
 	const settingsQuery = getUiSettings();
 	const dataQuality = $derived(settingsQuery.current?.dataQuality);
 
@@ -206,45 +222,11 @@
 			</CardContent>
 		</Card>
 
-		<!-- Timezone History (lives under Data Quality — correct timestamps are a data-quality concern) -->
-		<a href={resolve('/settings/timezone')} class="group block">
-			<Card class="transition-colors hover:border-primary/40 hover:bg-muted/40">
-				<CardContent class="flex items-center gap-4 p-4">
-					<div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-						<Globe class="h-5 w-5 text-primary" />
-					</div>
-					<div class="min-w-0 flex-1">
-						<p class="font-medium">Timezone History</p>
-						<p class="text-sm text-muted-foreground">
-							Where you've lived and travelled, for correct timestamps.
-						</p>
-					</div>
-					<ChevronRight
-						class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-					/>
-				</CardContent>
-			</Card>
-		</a>
-
-		<!-- Weight History (lives under Data Quality — same pattern as Timezone History) -->
-		<a href={resolve('/settings/weight')} class="group block">
-			<Card class="transition-colors hover:border-primary/40 hover:bg-muted/40">
-				<CardContent class="flex items-center gap-4 p-4">
-					<div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-						<Weight class="h-5 w-5 text-primary" />
-					</div>
-					<div class="min-w-0 flex-1">
-						<p class="font-medium">Weight History</p>
-						<p class="text-sm text-muted-foreground">
-							Your recorded weights over time.
-						</p>
-					</div>
-					<ChevronRight
-						class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-					/>
-				</CardContent>
-			</Card>
-		</a>
+		<!-- Both live here because correct timestamps and weights are what the rest of this
+		     page's analysis is computed from. -->
+		{#each historyLinks as link (link.href)}
+			<SettingsLinkCard {link} />
+		{/each}
 	{/if}
 
 	<!-- Outside the branches above: these tools read no UI settings, so a

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
@@ -13,9 +13,7 @@
     Globe,
     Lock,
     ScrollText,
-    ChevronRight,
   } from "lucide-svelte";
-  import { resolve } from "$app/paths";
   import { getRoles } from "$lib/api/generated/roles.generated.remote";
   import { getShareLink } from "$api/generated/shareLinks.generated.remote";
   import {
@@ -41,6 +39,7 @@
   import PublicAccessCard from "$lib/components/members/PublicAccessCard.svelte";
   import MembershipRequestsCard from "$lib/components/members/MembershipRequestsCard.svelte";
   import RolesSection from "$lib/components/members/RolesSection.svelte";
+  import SettingsLinkCard from "$lib/components/settings/SettingsLinkCard.svelte";
   import { retainQuery } from "$lib/api/retain-query.svelte";
 
   const effectivePermissions: string[] = $derived(
@@ -387,26 +386,16 @@
     <RolesSection />
   {/if}
 
-  <!-- Audit Log (lives under Sharing & Privacy — access and change history is a privacy concern) -->
+  <!-- Lives here because who reached the data, and when, is the question this page answers. -->
   {#if canViewAudit}
-    <a href={resolve("/settings/audit")} class="group block">
-      <Card.Root class="transition-colors hover:border-primary/40 hover:bg-muted/40">
-        <Card.Content class="flex items-center gap-4 p-4">
-          <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <ScrollText class="h-5 w-5 text-primary" />
-          </div>
-          <div class="min-w-0 flex-1">
-            <p class="font-medium">Audit Log</p>
-            <p class="text-sm text-muted-foreground">
-              Review changes and access history.
-            </p>
-          </div>
-          <ChevronRight
-            class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-          />
-        </Card.Content>
-      </Card.Root>
-    </a>
+    <SettingsLinkCard
+      link={{
+        title: "Audit Log",
+        description: "Review changes and access history.",
+        href: "/settings/audit",
+        icon: ScrollText,
+      }}
+    />
   {/if}
 
   {#if !canInvite && !canManageMembers && !canManageSharing && !canManageRoles && !canCreateGuestLinks && !canViewAudit}

--- a/src/Web/packages/portal/src/content/docs/food/deduplication.svx
+++ b/src/Web/packages/portal/src/content/docs/food/deduplication.svx
@@ -80,7 +80,7 @@ Three times, so that a duplicate is caught whichever way it arrives:
   recently created links and merges groups that ingest could not have seen —
   most often because two connectors synced out of order, and the second copy
   arrived hours after the first.
-- **On demand, as a full pass.** Under **Settings > Connectors & Apps**, the
+- **On demand, as a full pass.** Under **Settings > Data Quality**, the
   **Run Deduplication** action walks your entire history. It reports how many
   records it processed, how many groups it created and how many duplicates it
   found, and it can be cancelled while it runs.

--- a/src/Web/packages/portal/src/content/docs/sharing/guest-links.svx
+++ b/src/Web/packages/portal/src/content/docs/sharing/guest-links.svx
@@ -15,9 +15,8 @@ look; they can't change anything. It **expires on its own 48 hours after you mak
 it** and can only be used **once**, so there's nothing to remember to switch off
 afterwards.
 
-You create and manage guest links from **Settings > Sharing & Privacy**. The same
-list also appears on your **Active Access** page, alongside everything else that
-currently reaches your data:
+You create and manage guest links from **Settings > Sharing & Privacy**, where
+they sit alongside the people you have invited and your public link:
 
 <Screenshot id="sharing-guest-links" />
 

--- a/src/Web/packages/screenshots/src/manifest.ts
+++ b/src/Web/packages/screenshots/src/manifest.ts
@@ -246,10 +246,10 @@ export const definitions: ScreenshotDefinition[] = [
 	},
 	{
 		id: 'deduplication-card',
-		route: '/settings/connectors',
+		route: '/settings/data-quality',
 		scenario: 'patient',
 		clip: '[data-testid="deduplicate-records"]',
-		alt: 'The Deduplicate Records tool, under Data Maintenance on the Connectors and Apps settings page. It explains that it links records from different data sources that describe the same event, and offers a Run Deduplication button.',
+		alt: 'The Deduplicate Records tool, under Data Maintenance on the Data Quality settings page. It explains that it links records from different data sources that describe the same event, and offers a Run Deduplication button.',
 	},
 	{
 		id: 'alerts-configuration',


### PR DESCRIPTION
## Problem

Three settings pages answered overlapping questions, and two sections were rendered on **two pages each**:

| Section | Rendered on |
|---|---|
| `ConnectedApps` | `/settings/access` **and** `/settings/connectors` |
| `GuestLinksSection` | `/settings/access` **and** `/settings/members` |

Active Access was four sections of which only two were its own, while Connectors & Apps carried the weight:

| Page | Lines | Top-level sections |
|---|---|---|
| Connectors & Apps | 756 | **9** |
| Sharing & Privacy | 426 | 7 |
| Active Access | 34 | 4 (2 duplicated) |

Two of those nine sections weren't connections at all.

## Change

**Data Maintenance → Data Quality.** Deduplicate records, remove demo data, reset connector cursors: a data-management chore, not a connection. Extracted to `DataMaintenanceCard` and rendered on Data Quality, which already absorbs Timezone History and Weight History on the same reasoning. It sits *outside* that page's settings-query branches, because it reads no UI settings and a settings load failure should not take the tools away. Note this is a change in the other direction too: on the connectors page it sat inside `{:else if servicesOverview}`, so a services failure did remove it.

**Discord → Alerts.** It answers "where you're notified", which is that page's own subject, not "where the data comes from".

**Active Access links out.** Keeps the two sections that are genuinely its own, your sessions and the API reference, and links to Connectors & Apps and Sharing & Privacy for the rest instead of rendering a second copy.

Connectors & Apps ends at 617 lines. No new pages, no new nav entries.

## DRY

The settings index already had exactly the link card this branch was about to hand-copy, and two more byte-identical copies sat on Data Quality and Sharing & Privacy. All four now share `SettingsLinkCard`, and the destinations Active Access links to come from the same `settings-links` module the index renders from, so a retitled page cannot say one thing on the index and another wherever else it is offered. The settings index drops from ~200 lines to 62.

## Corrections after review

A hostile review found four things wrong with the first cut, all fixed here:

1. **Three references still pointed at the old homes.** The screenshot pipeline's `deduplication-card` clipped `[data-testid="deduplicate-records"]` on `/settings/connectors`; `capture.ts` throws when a clip matches nothing, so the next `screenshot-regen` would have failed outright. Two portal docs told readers to find Run Deduplication under Connectors & Apps and guest links on Active Access. PR CI cannot catch any of these: the screenshot checks are structural and never resolve a route.
2. **Three symbols went dead** on the connectors page (`Loader2`, `isPlatformAdmin`, the `$app/state` import) and `svelte-check` reports them. My earlier check missed it because `svelte-check` emits Windows backslash paths and I grepped the log with forward slashes.
3. **Two descriptions had gone stale** against the pages they describe.
4. **The "revoking on one page left the other stale" claim was false** and has been removed from this description and from the source comment that repeated it. `connectedApps`' generated `revoke` already does `list(undefined).refresh()` plus `refreshAll()`, and `GuestLinksSection` refreshes its own query after every mutation. Remote queries are refcounted per `(id, arg)`, so two render sites are the same resource. There was no staleness bug. Each section having one home stands on its own.

Two questions the review closed out: the dropped `onDeleteComplete={loadServices}` is **not** a regression (`ServicesController.DeleteDemoData` already carries `[RemoteCommand(Invalidates = [...])]` covering the same queries, so the hand-wired callback was redundant), and there is **no permission regression** on Data Maintenance (both pages sit under the same `settings/+layout.server.ts` guard, neither had a role gate, and both operations are `[RequireAdmin]` server-side).

## Also from review

**The maintenance tools now carry a client-side gate.** Deduplicate Records and Remove Demo Data both rewrite tenant-wide data and both answer 403 to anyone but an admin, but neither had a gate on either page. Survivable on Connectors & Apps, which an ordinary member has little reason to open; not on Data Quality, which they open to set a sleep schedule. The card self-gates on what `RequireAdmin` resolves to, and has tests, including that connector cursors stay behind `isPlatformAdmin` rather than the tenant's own admin permission.

**One name for the page.** The heading said "Connectors & Connected Apps" while the nav, the settings index, the palette and the new link card all said "Connectors & Apps".

The palette entry keeps its id. The review suggested renaming it to match its new label, but pinned and recent ids persist in local storage and one that no longer matches an item is dropped from a user's pins without a word, so the id is a handle rather than a description. The comment says that now instead of describing the mismatch.

## Verification

- `pnpm check`: 43 errors, none in any changed file.
- `pnpm vitest run`: 1204 pass, 1 skipped, 0 fail.
- `pnpm validate` / `check-refs` / `check-embeds` in `@nocturne/screenshots`: all clean.

An earlier revision of this description quoted "1203 pass, 1 failure in `alarm-profile.test.ts`". That does not reproduce; it was a stale artifact from a mid-refactor tree.

https://claude.ai/code/session_01Kr7oRsePv4LL2QFSuQdpNd