### PR TITLE
feat(web): let a recovery link name the locked-out account

### DIFF
--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery/+page.svelte
@@ -23,13 +23,22 @@
     parseCeremonyOptions,
   } from "$lib/components/auth/passkey-errors";
   import { goto } from "$app/navigation";
+  import { page } from "$app/state";
 
   // Steps: identify -> codes -> done
   type Step = "identify" | "codes" | "done";
   let step = $state<Step>("identify");
 
-  // Form state
-  let username = $state("");
+  // Form state.
+  //
+  // The username can be named in the URL, so a link can send someone straight here with the
+  // locked-out account already filled in — a hosted deployment mails one when it notices an
+  // instance has been stuck in recovery mode. Seeded rather than $derived: it is the starting
+  // value of a field the person can still correct.
+  //
+  // Nothing is trusted from it. The server resolves the account itself and refuses any that can
+  // still sign in, so naming one here only saves typing.
+  let username = $state(page.url.searchParams.get("username") ?? "");
   let displayName = $state("");
   let isRegistering = $state(false);
   let errorMessage = $state<string | null>(null);


### PR DESCRIPTION
## What

`/auth/recovery` now seeds its username field from a `?username=` query parameter.

## Why

The recovery screen asks for the username of the account that has lost every way to sign in. Someone who is locked out often does not remember which one that was, and the screen cannot tell them — it is reachable without a session, so listing the instance's accounts there would hand them to anyone who can load the page while the instance is in recovery mode.

A link can carry it instead, so a deployment that already knows which account is stuck can send one that leaves nothing to remember. That covers an admin helping a user, and a hosted deployment noticing an instance has been sitting in recovery mode.

## Safety

Nothing is trusted from the URL. `ResolveRecoveryModeSubjectAsync` still resolves the account server-side and still fails closed for any account that holds a passkey or a linked provider, so naming one in the link only saves typing — it cannot widen what the page will enrol.

The field stays editable, so a wrong or stale value is corrected in place rather than blocking the flow.
