### PR TITLE
feat(share): let the owner see the public link again, redacted by default

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/ShareAppearanceController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ShareAppearanceController.cs
@@ -29,12 +29,12 @@ namespace Nocturne.API.Controllers.V4.Identity;
 [Produces("application/json")]
 public class ShareAppearanceController : ControllerBase
 {
-    private readonly IShareLinkService _shareLinkService;
+    private readonly IShareAppearanceReader _appearance;
     private readonly ITenantAccessor _tenantAccessor;
 
-    public ShareAppearanceController(IShareLinkService shareLinkService, ITenantAccessor tenantAccessor)
+    public ShareAppearanceController(IShareAppearanceReader appearance, ITenantAccessor tenantAccessor)
     {
-        _shareLinkService = shareLinkService;
+        _appearance = appearance;
         _tenantAccessor = tenantAccessor;
     }
 
@@ -48,6 +48,6 @@ public class ShareAppearanceController : ControllerBase
         if (!HttpContext.IsShareAccess())
             return NotFound();
 
-        return Ok(await _shareLinkService.GetSharedAppearanceAsync(_tenantAccessor.TenantId, ct));
+        return Ok(await _appearance.GetSharedAppearanceAsync(_tenantAccessor.TenantId, ct));
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Identity/ShareLinkController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ShareLinkController.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Models.Responses;
 using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.API.Extensions;
 
@@ -22,11 +24,16 @@ public class ShareLinkController : ControllerBase
 {
     private readonly IShareLinkService _shareLinkService;
     private readonly ITenantAccessor _tenantAccessor;
+    private readonly IAuthAuditService _auditService;
 
-    public ShareLinkController(IShareLinkService shareLinkService, ITenantAccessor tenantAccessor)
+    public ShareLinkController(
+        IShareLinkService shareLinkService,
+        ITenantAccessor tenantAccessor,
+        IAuthAuditService auditService)
     {
         _shareLinkService = shareLinkService;
         _tenantAccessor = tenantAccessor;
+        _auditService = auditService;
     }
 
     /// <summary>Get the current public share link state.</summary>
@@ -40,6 +47,42 @@ public class ShareLinkController : ControllerBase
             return Forbid();
 
         return Ok(await _shareLinkService.GetAsync(_tenantAccessor.TenantId, ct));
+    }
+
+    /// <summary>
+    /// Show the live link in the clear. A command rather than a query so the secret travels only
+    /// when the owner asks for it, instead of on every read of the sharing settings.
+    /// </summary>
+    /// <remarks>
+    /// Succeeds with a null URL where nothing recoverable was stored — a link minted before the
+    /// token was kept that way, or an instance with no encryption key. The response's
+    /// <c>canReveal</c> tells a caller which it is before it asks.
+    /// </remarks>
+    [HttpPost("reveal")]
+    [RemoteCommand]
+    [ProducesResponseType(typeof(ShareLinkDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<ShareLinkDto>> RevealShareLink(CancellationToken ct)
+    {
+        if (!HttpContext.HasScope(Scope.SharingManage))
+            return Forbid();
+
+        var link = await _shareLinkService.RevealAsync(_tenantAccessor.TenantId, ct);
+
+        // Anyone holding this link reads the tenant's data without signing in, so record who was
+        // handed it. Logged on the outcome, not the request: a reveal that produced nothing gave
+        // nothing away.
+        if (link.Url != null)
+        {
+            await _auditService.LogAsync(
+                AuthAuditEventType.ShareLinkRevealed,
+                HttpContext.GetSubjectId(),
+                success: true,
+                ipAddress: HttpContext.Connection.RemoteIpAddress?.ToString(),
+                userAgent: Request.Headers.UserAgent.ToString());
+        }
+
+        return Ok(link);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/Identity/ShareLinkController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ShareLinkController.cs
@@ -51,13 +51,10 @@ public class ShareLinkController : ControllerBase
 
     /// <summary>
     /// Show the live link in the clear. A command rather than a query so the secret travels only
-    /// when the owner asks for it, instead of on every read of the sharing settings.
+    /// when the owner asks for it, instead of on every read of the sharing settings. Succeeds
+    /// with a null URL and <c>canReveal</c> false in the cases
+    /// <see cref="TenantEntity.ShareTokenEncrypted"/> lists.
     /// </summary>
-    /// <remarks>
-    /// Succeeds with a null URL where nothing recoverable was stored — a link minted before the
-    /// token was kept that way, or an instance with no encryption key. The response's
-    /// <c>canReveal</c> tells a caller which it is before it asks.
-    /// </remarks>
     [HttpPost("reveal")]
     [RemoteCommand]
     [ProducesResponseType(typeof(ShareLinkDto), StatusCodes.Status200OK)]
@@ -69,9 +66,8 @@ public class ShareLinkController : ControllerBase
 
         var link = await _shareLinkService.RevealAsync(_tenantAccessor.TenantId, ct);
 
-        // Anyone holding this link reads the tenant's data without signing in, so record who was
-        // handed it. Logged on the outcome, not the request: a reveal that produced nothing gave
-        // nothing away.
+        // Logged on the outcome, not the request: a reveal that produced nothing gave nothing away.
+        // Why it is audited at all: <see cref="AuthAuditEventType.ShareLinkRevealed"/>.
         if (link.Url != null)
         {
             await _auditService.LogAsync(

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -314,6 +314,7 @@ public static class ServiceRegistrationExtensions
         services.AddSingleton<IShareTokenResolver>(sp => sp.GetRequiredService<ShareTokenCacheService>());
         services.AddSingleton<IShareTokenGenerator, ShareTokenGenerator>();
         services.AddScoped<IShareLinkService, ShareLinkService>();
+        services.AddScoped<IShareAppearanceReader>(sp => sp.GetRequiredService<IShareLinkService>());
         // Singleton because its consumer runs at startup outside any request scope; it creates its
         // own scope per notification.
         services.AddSingleton<IShareLinkRotatedNotifier, ShareLinkRotatedNotifier>();

--- a/src/API/Nocturne.API/Models/Responses/ShareLinkDto.cs
+++ b/src/API/Nocturne.API/Models/Responses/ShareLinkDto.cs
@@ -9,28 +9,24 @@ public class ShareLinkDto
     public bool Enabled { get; set; }
 
     /// <summary>
-    /// The full share URL, carrying the token in the clear. Returned only by the call that
-    /// generates the link and by the call that reveals it — never by the plain read, so it does
-    /// not ride along on every page load of the sharing settings.
+    /// The full share URL, carrying the token in the clear. Returned only by the calls that
+    /// generate and reveal the link, never by the plain read, so it does not ride along on every
+    /// page load of the sharing settings.
     /// </summary>
-    /// <remarks>
-    /// Null on a reveal when the link predates <c>TenantEntity.ShareTokenEncrypted</c>, or when
-    /// the instance has no key to decrypt with. <see cref="CanReveal"/> says which case a caller
-    /// is in before it asks.
-    /// </remarks>
     public string? Url { get; set; }
 
     /// <summary>
     /// The share URL with the token replaced by bullets, e.g.
-    /// <c>https://••••••••••••••••.share.example.com</c>. Null when no link is active. Lets the
-    /// owner see the shape of the link, and that one exists, without the secret crossing the wire.
+    /// <c>https://••••••••••••••••.share.example.com</c>. Null when no link is active. Shows the
+    /// owner that a link exists, and its shape, without the secret crossing the wire.
     /// </summary>
     public string? RedactedUrl { get; set; }
 
     /// <summary>
-    /// Whether the reveal call can produce <see cref="Url"/> for this link. False for a link
-    /// minted before the token was kept recoverably, or on an instance with no encryption key —
-    /// in both cases regenerating is the only way to see a link, as it was for every link before.
+    /// Whether <see cref="Url"/> can be produced for this link. A reveal reports this from what it
+    /// actually found; every other call can only read the columns, which cannot see the
+    /// changed-key case, so a true here is a guess until a reveal settles it. The cases are listed
+    /// on <c>TenantEntity.ShareTokenEncrypted</c>.
     /// </summary>
     public bool CanReveal { get; set; }
 

--- a/src/API/Nocturne.API/Models/Responses/ShareLinkDto.cs
+++ b/src/API/Nocturne.API/Models/Responses/ShareLinkDto.cs
@@ -9,11 +9,30 @@ public class ShareLinkDto
     public bool Enabled { get; set; }
 
     /// <summary>
-    /// The full share URL, returned only by the call that generates the link. Null on every other
-    /// call, including when <see cref="Enabled"/> is true: only the token's digest is stored, so the
-    /// URL cannot be reproduced afterwards. Generating a new link is the only way to see one again.
+    /// The full share URL, carrying the token in the clear. Returned only by the call that
+    /// generates the link and by the call that reveals it — never by the plain read, so it does
+    /// not ride along on every page load of the sharing settings.
     /// </summary>
+    /// <remarks>
+    /// Null on a reveal when the link predates <c>TenantEntity.ShareTokenEncrypted</c>, or when
+    /// the instance has no key to decrypt with. <see cref="CanReveal"/> says which case a caller
+    /// is in before it asks.
+    /// </remarks>
     public string? Url { get; set; }
+
+    /// <summary>
+    /// The share URL with the token replaced by bullets, e.g.
+    /// <c>https://••••••••••••••••.share.example.com</c>. Null when no link is active. Lets the
+    /// owner see the shape of the link, and that one exists, without the secret crossing the wire.
+    /// </summary>
+    public string? RedactedUrl { get; set; }
+
+    /// <summary>
+    /// Whether the reveal call can produce <see cref="Url"/> for this link. False for a link
+    /// minted before the token was kept recoverably, or on an instance with no encryption key —
+    /// in both cases regenerating is the only way to see a link, as it was for every link before.
+    /// </summary>
+    public bool CanReveal { get; set; }
 
     /// <summary>When true the public view shows full history; when false, only the last 24 hours.</summary>
     public bool FullHistory { get; set; }

--- a/src/API/Nocturne.API/Services/Auth/ShareLinkRotatedNotifier.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareLinkRotatedNotifier.cs
@@ -9,8 +9,8 @@ namespace Nocturne.API.Services.Auth;
 /// <summary>
 /// Tells a tenant's owner that their public share link no longer resolves and has to be
 /// regenerated. Used by the rotation pass in <see cref="CredentialAtRestStartupTask"/>, which
-/// retires a plaintext token. Only the digest of the replacement is stored, so the pass cannot hand
-/// back a URL — the owner is the only one who can produce a working link.
+/// retires a plaintext token. That pass keeps no recoverable copy of the replacement, so it cannot
+/// hand back a URL; the owner is the only one who can produce a working link.
 /// </summary>
 public interface IShareLinkRotatedNotifier
 {

--- a/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Nocturne.Core.Contracts.Auth;
 using Nocturne.API.Models.Responses;
 using Nocturne.API.Multitenancy;
 using Nocturne.Core.Models.Authorization;
@@ -20,14 +22,23 @@ namespace Nocturne.API.Services.Auth;
 public interface IShareLinkService
 {
     /// <summary>
-    /// Reports the link's state. <see cref="ShareLinkDto.Url"/> is always null — only the token's
-    /// digest is stored, so the URL is knowable only to the caller of <see cref="RotateAsync"/>.
+    /// Reports the link's state. <see cref="ShareLinkDto.Url"/> is always null; the redacted form
+    /// and <see cref="ShareLinkDto.CanReveal"/> say whether <see cref="RevealAsync"/> can produce
+    /// it. Keeping the secret out of this response keeps it off every render of the settings page.
     /// </summary>
     Task<ShareLinkDto> GetAsync(Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns the live link's URL, decrypted from the stored ciphertext. The URL is null — with
+    /// the rest of the state still reported — when nothing recoverable was kept for this link:
+    /// it was minted before the token was stored recoverably, or the instance has no encryption
+    /// key. Callers audit this; it hands out a credential.
+    /// </summary>
+    Task<ShareLinkDto> RevealAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
     /// Mints a new token, replacing any existing one, and returns the resulting
-    /// <see cref="ShareLinkDto.Url"/>. This is the only call that can return the URL.
+    /// <see cref="ShareLinkDto.Url"/>. The previous link stops resolving immediately.
     /// </summary>
     Task<ShareLinkDto> RotateAsync(Guid tenantId, CancellationToken ct = default);
     Task<ShareLinkDto> DisableAsync(Guid tenantId, CancellationToken ct = default);
@@ -60,6 +71,8 @@ public sealed class ShareLinkService : IShareLinkService
     private readonly IShareTokenGenerator _tokenGenerator;
     private readonly ShareTokenCacheService _shareTokenCache;
     private readonly PublicAccessCacheService _publicAccessCache;
+    private readonly ISecretEncryptionService _secrets;
+    private readonly ILogger<ShareLinkService> _logger;
     private readonly string _baseDomain;
 
     public ShareLinkService(
@@ -67,12 +80,16 @@ public sealed class ShareLinkService : IShareLinkService
         IShareTokenGenerator tokenGenerator,
         ShareTokenCacheService shareTokenCache,
         PublicAccessCacheService publicAccessCache,
+        ISecretEncryptionService secrets,
+        ILogger<ShareLinkService> logger,
         IOptions<BaseDomainOptions> baseDomain)
     {
         _dbContext = dbContext;
         _tokenGenerator = tokenGenerator;
         _shareTokenCache = shareTokenCache;
         _publicAccessCache = publicAccessCache;
+        _secrets = secrets;
+        _logger = logger;
         _baseDomain = baseDomain.Value.BaseDomain;
     }
 
@@ -90,6 +107,22 @@ public sealed class ShareLinkService : IShareLinkService
                 && m.Subject!.IsSystemSubject && m.Subject.Name == PublicSubjectName, ct);
 
         return ToDto(tenant, member);
+    }
+
+    public async Task<ShareLinkDto> RevealAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        var tenant = await _dbContext.Tenants.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == tenantId, ct)
+            ?? throw new InvalidOperationException($"Tenant {tenantId} not found");
+
+        var member = await _dbContext.TenantMembers.AsNoTracking()
+            .Include(m => m.MemberRoles)
+                .ThenInclude(mr => mr.TenantRole)
+            .Include(m => m.Subject)
+            .FirstOrDefaultAsync(m => m.TenantId == tenantId
+                && m.Subject!.IsSystemSubject && m.Subject.Name == PublicSubjectName, ct);
+
+        return ToDto(tenant, member, DecryptToken(tenant));
     }
 
     public async Task<ShareLinkDto> RotateAsync(Guid tenantId, CancellationToken ct = default)
@@ -114,6 +147,7 @@ public sealed class ShareLinkService : IShareLinkService
         }
 
         tenant.ShareToken = CredentialHash.ShareToken(newToken);
+        tenant.ShareTokenEncrypted = EncryptToken(newToken);
         tenant.ShareTokenSetAt = now;
         member.SysUpdatedAt = now;
 
@@ -135,6 +169,7 @@ public sealed class ShareLinkService : IShareLinkService
         var oldTokenHash = tenant.ShareToken;
 
         tenant.ShareToken = null;
+        tenant.ShareTokenEncrypted = null;
         tenant.ShareTokenSetAt = null;
 
         if (member != null)
@@ -237,18 +272,69 @@ public sealed class ShareLinkService : IShareLinkService
     }
 
     /// <summary>
-    /// Projects the share link. <paramref name="token"/> is supplied only by the rotate path, which
-    /// has just minted it; every other path can only report that a link exists, because the stored
-    /// value is a digest and the URL cannot be reconstructed from it.
+    /// Projects the share link. <paramref name="token"/> is supplied by the paths entitled to hand
+    /// the secret back — rotate, which has just minted it, and reveal, which has just decrypted it.
+    /// Every other path reports only that a link exists, and in what shape.
     /// </summary>
-    private ShareLinkDto ToDto(TenantEntity tenant, TenantMemberEntity? member, string? token = null) => new()
+    private ShareLinkDto ToDto(TenantEntity tenant, TenantMemberEntity? member, string? token = null)
     {
-        Enabled = tenant.ShareToken != null,
-        Url = token != null ? $"https://{token}.share.{_baseDomain}" : null,
-        FullHistory = member is { LimitTo24Hours: false },
-        Scopes = ComputeScopes(member),
-        LastAccessedAt = tenant.ShareLastAccessedAt,
-    };
+        var enabled = tenant.ShareToken != null;
+        return new ShareLinkDto
+        {
+            Enabled = enabled,
+            Url = token != null ? ShareUrl(token) : null,
+            RedactedUrl = enabled ? ShareUrl(new string('•', ShareTokenGenerator.TokenLength)) : null,
+            CanReveal = enabled && tenant.ShareTokenEncrypted != null && _secrets.IsConfigured,
+            FullHistory = member is { LimitTo24Hours: false },
+            Scopes = ComputeScopes(member),
+            LastAccessedAt = tenant.ShareLastAccessedAt,
+        };
+    }
+
+    private string ShareUrl(string token) => $"https://{token}.share.{_baseDomain}";
+
+    /// <summary>
+    /// Ciphertext of <paramref name="token"/>, or null on an instance with no key. A share link is
+    /// not worth refusing to mint over — the tenant simply keeps the pre-existing behaviour of
+    /// having to rotate to see one.
+    /// </summary>
+    private string? EncryptToken(string token)
+    {
+        if (!_secrets.IsConfigured)
+            return null;
+
+        try
+        {
+            return _secrets.Encrypt(token);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not keep a recoverable copy of the share token; the owner will have to rotate to see the link");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The token behind <paramref name="tenant"/>'s live link, or null when none was kept or the
+    /// ciphertext no longer decrypts — which is what a changed instance key looks like. The link
+    /// itself still resolves in that case, since resolution reads the digest, so this is reported
+    /// as "cannot reveal" rather than as a broken link.
+    /// </summary>
+    private string? DecryptToken(TenantEntity tenant)
+    {
+        if (tenant.ShareToken == null || tenant.ShareTokenEncrypted == null || !_secrets.IsConfigured)
+            return null;
+
+        try
+        {
+            return _secrets.Decrypt(tenant.ShareTokenEncrypted);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Stored share token did not decrypt for tenant {TenantId}", tenant.Id);
+            return null;
+        }
+    }
 
     /// <summary>
     /// The public-shareable read scopes the Public subject currently resolves to — the union of any

--- a/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
@@ -19,7 +19,27 @@ namespace Nocturne.API.Services.Auth;
 /// the membership tables are not RLS-scoped, so tenant isolation comes from the explicit tenant-id
 /// predicate on every query — those predicates must be preserved.
 /// </summary>
-public interface IShareLinkService
+/// <summary>
+/// The one member of <see cref="IShareLinkService"/> a public share viewer is allowed to reach.
+/// </summary>
+/// <remarks>
+/// Separate so that <c>ShareAppearanceController</c>, which answers unauthenticated requests on a
+/// share host, does not depend on an interface carrying <see cref="IShareLinkService.RevealAsync"/>.
+/// Nothing routes an anonymous caller there today; the narrower seam is what keeps that true when
+/// someone adds the next member.
+/// </remarks>
+public interface IShareAppearanceReader
+{
+    /// <summary>
+    /// The appearance an anonymous share viewer renders the tenant's data with: the owner's
+    /// display preferences, narrowed by <see cref="UserDisplayPreferences.ToPresentationOnly"/>.
+    /// All-null when the tenant has no owner or the owner saved nothing, which leaves the viewer
+    /// on the frontend's own defaults.
+    /// </summary>
+    Task<UserDisplayPreferences> GetSharedAppearanceAsync(Guid tenantId, CancellationToken ct = default);
+}
+
+public interface IShareLinkService : IShareAppearanceReader
 {
     /// <summary>
     /// Reports the link's state. <see cref="ShareLinkDto.Url"/> is always null, so the secret
@@ -50,14 +70,6 @@ public interface IShareLinkService
     /// authoritative.
     /// </summary>
     Task<ShareLinkDto> SetScopesAsync(Guid tenantId, IReadOnlyList<string> scopes, CancellationToken ct = default);
-
-    /// <summary>
-    /// The appearance an anonymous share viewer renders the tenant's data with: the owner's
-    /// display preferences, narrowed by <see cref="UserDisplayPreferences.ToPresentationOnly"/>.
-    /// All-null when the tenant has no owner or the owner saved nothing, which leaves the viewer
-    /// on the frontend's own defaults.
-    /// </summary>
-    Task<UserDisplayPreferences> GetSharedAppearanceAsync(Guid tenantId, CancellationToken ct = default);
 }
 
 /// <inheritdoc />

--- a/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
@@ -22,17 +22,16 @@ namespace Nocturne.API.Services.Auth;
 public interface IShareLinkService
 {
     /// <summary>
-    /// Reports the link's state. <see cref="ShareLinkDto.Url"/> is always null; the redacted form
-    /// and <see cref="ShareLinkDto.CanReveal"/> say whether <see cref="RevealAsync"/> can produce
-    /// it. Keeping the secret out of this response keeps it off every render of the settings page.
+    /// Reports the link's state. <see cref="ShareLinkDto.Url"/> is always null, so the secret
+    /// stays off every render of the settings page.
     /// </summary>
     Task<ShareLinkDto> GetAsync(Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns the live link's URL, decrypted from the stored ciphertext. The URL is null — with
-    /// the rest of the state still reported — when nothing recoverable was kept for this link:
-    /// it was minted before the token was stored recoverably, or the instance has no encryption
-    /// key. Callers audit this; it hands out a credential.
+    /// Returns the live link's URL, decrypted from the stored ciphertext, leaving the URL null and
+    /// <see cref="ShareLinkDto.CanReveal"/> false in the cases
+    /// <see cref="TenantEntity.ShareTokenEncrypted"/> lists. Callers audit this; it hands out a
+    /// credential.
     /// </summary>
     Task<ShareLinkDto> RevealAsync(Guid tenantId, CancellationToken ct = default);
 
@@ -95,21 +94,19 @@ public sealed class ShareLinkService : IShareLinkService
 
     public async Task<ShareLinkDto> GetAsync(Guid tenantId, CancellationToken ct = default)
     {
-        var tenant = await _dbContext.Tenants.AsNoTracking()
-            .FirstOrDefaultAsync(t => t.Id == tenantId, ct)
-            ?? throw new InvalidOperationException($"Tenant {tenantId} not found");
-
-        var member = await _dbContext.TenantMembers.AsNoTracking()
-            .Include(m => m.MemberRoles)
-                .ThenInclude(mr => mr.TenantRole)
-            .Include(m => m.Subject)
-            .FirstOrDefaultAsync(m => m.TenantId == tenantId
-                && m.Subject!.IsSystemSubject && m.Subject.Name == PublicSubjectName, ct);
-
+        var (tenant, member) = await ReadAsync(tenantId, ct);
         return ToDto(tenant, member);
     }
 
     public async Task<ShareLinkDto> RevealAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        var (tenant, member) = await ReadAsync(tenantId, ct);
+        return ToDto(tenant, member, DecryptToken(tenant), attemptedDecrypt: true);
+    }
+
+    /// <summary>The tenant and its Public membership, read-only, for the reporting paths.</summary>
+    private async Task<(TenantEntity Tenant, TenantMemberEntity? Member)> ReadAsync(
+        Guid tenantId, CancellationToken ct)
     {
         var tenant = await _dbContext.Tenants.AsNoTracking()
             .FirstOrDefaultAsync(t => t.Id == tenantId, ct)
@@ -122,7 +119,7 @@ public sealed class ShareLinkService : IShareLinkService
             .FirstOrDefaultAsync(m => m.TenantId == tenantId
                 && m.Subject!.IsSystemSubject && m.Subject.Name == PublicSubjectName, ct);
 
-        return ToDto(tenant, member, DecryptToken(tenant));
+        return (tenant, member);
     }
 
     public async Task<ShareLinkDto> RotateAsync(Guid tenantId, CancellationToken ct = default)
@@ -157,7 +154,6 @@ public sealed class ShareLinkService : IShareLinkService
             _shareTokenCache.EvictByHash(oldTokenHash);
         _publicAccessCache.Evict(tenantId);
 
-        // The only moment the URL can be produced: the token itself is not stored.
         return ToDto(tenant, member, newToken);
     }
 
@@ -273,10 +269,20 @@ public sealed class ShareLinkService : IShareLinkService
 
     /// <summary>
     /// Projects the share link. <paramref name="token"/> is supplied by the paths entitled to hand
-    /// the secret back — rotate, which has just minted it, and reveal, which has just decrypted it.
+    /// the secret back: rotate, which has just minted it, and reveal, which has just decrypted it.
     /// Every other path reports only that a link exists, and in what shape.
     /// </summary>
-    private ShareLinkDto ToDto(TenantEntity tenant, TenantMemberEntity? member, string? token = null)
+    /// <param name="attemptedDecrypt">
+    /// True on the reveal path, where <paramref name="token"/> is the outcome of an actual decrypt
+    /// and so a null one settles <see cref="ShareLinkDto.CanReveal"/>. Off the reveal path the
+    /// columns are all there is to go on, and they cannot see the changed-key case
+    /// <see cref="TenantEntity.ShareTokenEncrypted"/> describes.
+    /// </param>
+    private ShareLinkDto ToDto(
+        TenantEntity tenant,
+        TenantMemberEntity? member,
+        string? token = null,
+        bool attemptedDecrypt = false)
     {
         var enabled = tenant.ShareToken != null;
         return new ShareLinkDto
@@ -284,7 +290,9 @@ public sealed class ShareLinkService : IShareLinkService
             Enabled = enabled,
             Url = token != null ? ShareUrl(token) : null,
             RedactedUrl = enabled ? ShareUrl(new string('•', ShareTokenGenerator.TokenLength)) : null,
-            CanReveal = enabled && tenant.ShareTokenEncrypted != null && _secrets.IsConfigured,
+            CanReveal = attemptedDecrypt
+                ? token != null
+                : enabled && tenant.ShareTokenEncrypted != null && _secrets.IsConfigured,
             FullHistory = member is { LimitTo24Hours: false },
             Scopes = ComputeScopes(member),
             LastAccessedAt = tenant.ShareLastAccessedAt,
@@ -294,9 +302,8 @@ public sealed class ShareLinkService : IShareLinkService
     private string ShareUrl(string token) => $"https://{token}.share.{_baseDomain}";
 
     /// <summary>
-    /// Ciphertext of <paramref name="token"/>, or null on an instance with no key. A share link is
-    /// not worth refusing to mint over — the tenant simply keeps the pre-existing behaviour of
-    /// having to rotate to see one.
+    /// Ciphertext of <paramref name="token"/>, or null when it could not be produced. Minting is
+    /// not refused over it; see <see cref="TenantEntity.ShareTokenEncrypted"/>.
     /// </summary>
     private string? EncryptToken(string token)
     {
@@ -315,10 +322,9 @@ public sealed class ShareLinkService : IShareLinkService
     }
 
     /// <summary>
-    /// The token behind <paramref name="tenant"/>'s live link, or null when none was kept or the
-    /// ciphertext no longer decrypts — which is what a changed instance key looks like. The link
-    /// itself still resolves in that case, since resolution reads the digest, so this is reported
-    /// as "cannot reveal" rather than as a broken link.
+    /// The token behind <paramref name="tenant"/>'s live link, or null in any of the cases
+    /// <see cref="TenantEntity.ShareTokenEncrypted"/> lists. This is the only place the third of
+    /// them is detectable.
     /// </summary>
     private string? DecryptToken(TenantEntity tenant)
     {

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenGenerator.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenGenerator.cs
@@ -26,8 +26,7 @@ public sealed class ShareTokenGenerator : IShareTokenGenerator
 {
     private const string Alphabet = "0123456789abcdefghjkmnpqrstvwxyz";
 
-    /// <summary>How many characters a generated token has. Public so a redacted rendering of a
-    /// link can be the right length without guessing at it.</summary>
+    /// <summary>Public so a redacted rendering of a link is the right length without guessing.</summary>
     public const int TokenLength = 16;
 
     public string Generate() =>

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenGenerator.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenGenerator.cs
@@ -25,7 +25,10 @@ public interface IShareTokenGenerator
 public sealed class ShareTokenGenerator : IShareTokenGenerator
 {
     private const string Alphabet = "0123456789abcdefghjkmnpqrstvwxyz";
-    private const int TokenLength = 16;
+
+    /// <summary>How many characters a generated token has. Public so a redacted rendering of a
+    /// link can be the right length without guessing at it.</summary>
+    public const int TokenLength = 16;
 
     public string Generate() =>
         new(RandomNumberGenerator.GetItems<char>(Alphabet, TokenLength));

--- a/src/API/Nocturne.API/Services/Demo/DemoTenantService.cs
+++ b/src/API/Nocturne.API/Services/Demo/DemoTenantService.cs
@@ -254,6 +254,7 @@ public sealed class DemoTenantService
             IsActive = tenant.IsActive,
             IsDemo = true,
             ShareToken = tenant.ShareToken,
+            ShareTokenEncrypted = tenant.ShareTokenEncrypted,
             ShareTokenSetAt = tenant.ShareTokenSetAt,
             SysCreatedAt = tenant.SysCreatedAt,
             SysUpdatedAt = DateTime.UtcNow,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/AuthAuditLogEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/AuthAuditLogEntity.cs
@@ -195,6 +195,12 @@ public static class AuthAuditEventType
     public const string ApiSecretUsed = "api_secret_used";
 
     /// <summary>
+    /// Event type when the tenant's public share link is shown to an owner in the clear. The link
+    /// needs no credential to use, so handing it back is worth a record of who asked and when.
+    /// </summary>
+    public const string ShareLinkRevealed = "share_link_revealed";
+
+    /// <summary>
     /// Event type when a session has expired.
     /// </summary>
     public const string SessionExpired = "session_expired";

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
@@ -81,15 +81,21 @@ public class TenantEntity : ISystemTimestamped
     /// <summary>
     /// The same token again, AES-256-GCM ciphertext under the instance key
     /// (<c>ISecretEncryptionService</c>), so the owner can be shown the link they are already
-    /// handing out rather than being told to rotate it — which would break it for everyone
-    /// holding it. Nothing authenticates against this column; <see cref="ShareToken"/> remains
-    /// the only resolution path.
+    /// handing out instead of rotating it, which would break it for everyone holding it.
+    /// Nothing authenticates against this column; <see cref="ShareToken"/> remains the only
+    /// resolution path.
     /// </summary>
     /// <remarks>
-    /// Null on two kinds of tenant that must both keep working: one whose link was minted before
-    /// this column existed, and one on an instance with no instance key configured, where
-    /// encryption is unavailable. Both fall back to "regenerate to see a link", which is the
-    /// behaviour every tenant had before.
+    /// The single site for why a live link can still be unshowable. Three ways that happens, and
+    /// all three must leave the link itself working, because resolution reads the digest:
+    /// <list type="bullet">
+    /// <item>the link was minted before this column existed, so nothing was kept;</item>
+    /// <item>the instance has no key, so nothing could be kept;</item>
+    /// <item>the key changed since, so what was kept no longer decrypts.</item>
+    /// </list>
+    /// Only the third is invisible in the columns, so it is knowable only by attempting the
+    /// decrypt. All three fall back to "regenerate to see a link", the behaviour every tenant had
+    /// before this column existed.
     /// </remarks>
     [Column("share_token_encrypted")]
     public string? ShareTokenEncrypted { get; set; }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
@@ -70,13 +70,29 @@ public class TenantEntity : ISystemTimestamped
     /// <summary>
     /// SHA-256 hex digest (<see cref="Security.CredentialHash.ShareToken"/>) of the unguessable
     /// token for the tenant's public read-only dashboard, served at {token}.share.{baseDomain}.
-    /// Null when public sharing is disabled. The token itself is never stored: it is returned once
-    /// when the link is generated and resolved thereafter by digest. Rotating replaces the value
-    /// and evicts the resolution cache, so the previous link stops resolving.
+    /// Null when public sharing is disabled. This is what an incoming request is resolved by:
+    /// the digest is compared, never the token. Rotating replaces the value and evicts the
+    /// resolution cache, so the previous link stops resolving.
     /// </summary>
     [Column("share_token")]
     [MaxLength(Security.CredentialHash.HexLength)]
     public string? ShareToken { get; set; }
+
+    /// <summary>
+    /// The same token again, AES-256-GCM ciphertext under the instance key
+    /// (<c>ISecretEncryptionService</c>), so the owner can be shown the link they are already
+    /// handing out rather than being told to rotate it — which would break it for everyone
+    /// holding it. Nothing authenticates against this column; <see cref="ShareToken"/> remains
+    /// the only resolution path.
+    /// </summary>
+    /// <remarks>
+    /// Null on two kinds of tenant that must both keep working: one whose link was minted before
+    /// this column existed, and one on an instance with no instance key configured, where
+    /// encryption is unavailable. Both fall back to "regenerate to see a link", which is the
+    /// behaviour every tenant had before.
+    /// </remarks>
+    [Column("share_token_encrypted")]
+    public string? ShareTokenEncrypted { get; set; }
 
     /// <summary>When <see cref="ShareToken"/> was last minted or rotated.</summary>
     [Column("share_token_set_at")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/CredentialAtRestInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/CredentialAtRestInitializationExtensions.cs
@@ -167,9 +167,14 @@ public static class CredentialAtRestInitializationExtensions
 
                 await using var update = connection.CreateCommand();
                 update.Transaction = transaction;
+                // Clearing the ciphertext matters more than it looks: this replaces the token
+                // itself, so a copy kept for the old one would decrypt to a link that no longer
+                // resolves, which the owner would be handed with no error at all.
                 update.CommandText = """
                     UPDATE tenants
-                    SET share_token = @digest, share_token_set_at = @setAt
+                    SET share_token = @digest,
+                        share_token_encrypted = NULL,
+                        share_token_set_at = @setAt
                     WHERE id = @id
                     """;
                 update.Parameters.AddWithValue("@digest", digest);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260911232705_AddRecoverableShareToken.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260911232705_AddRecoverableShareToken.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260911232705_AddRecoverableShareToken")]
+    partial class AddRecoverableShareToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260911232705_AddRecoverableShareToken.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260911232705_AddRecoverableShareToken.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRecoverableShareToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "share_token_encrypted",
+                table: "tenants",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "share_token_encrypted",
+                table: "tenants");
+        }
+    }
+}

--- a/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
@@ -59,18 +59,22 @@
   let errorMessage = $state<string | null>(null);
   let scopeWritesInFlight = $state(0);
 
-  // The URL, once this visit has asked for it. The read that loads this card deliberately does
-  // not carry it: the link needs no credential to use, so it travels only when asked for, and
-  // each reveal is audited.
+  // The read that loads this card deliberately does not carry the URL; it travels only when asked
+  // for, and each reveal is audited.
   let revealedUrl = $state<string | null>(null);
   let revealing = $state(false);
-  /** Whether the URL is on screen, as opposed to merely fetched — copying does not show it. */
+  /** Whether the URL is on screen, as opposed to merely fetched. Copying does not show it. */
   let plainVisible = $state(false);
+  /**
+   * What a reveal found, once one has run. It outranks the query's answer, which is read off the
+   * columns and so cannot see a link whose stored copy no longer decrypts.
+   */
+  let revealSucceeded = $state<boolean | null>(null);
 
   const redactedUrl = $derived(share?.redactedUrl ?? null);
-  // False for a link minted before the token was stored recoverably, and on an instance with no
-  // encryption key. Both keep the older behaviour: regenerate to get a link you can send.
-  const canReveal = $derived(share?.canReveal ?? false);
+  const canReveal = $derived(revealSucceeded ?? share?.canReveal ?? false);
+  /** Whether there is a link to show or copy at all, as opposed to only to regenerate. */
+  const recoverable = $derived(canReveal || revealedUrl != null);
 
   const sharedLabels = $derived(
     publicDataCategories.filter((c) => scopes.includes(c.scope)).map((c) => c.name.toLowerCase()),
@@ -85,14 +89,12 @@
     errorMessage = null;
     pendingEnabled = on;
     try {
-      if (on) {
-        revealedUrl = (await rotateShareLink()).url ?? null;
-        // Just minted at the owner's request, so it starts on screen.
-        plainVisible = revealedUrl != null;
-      } else {
+      if (on) await mint(rotateShareLink);
+      else {
         await disableShareLink();
         revealedUrl = null;
         plainVisible = false;
+        revealSucceeded = null;
       }
     } catch (err) {
       errorMessage = describeSubmitError(
@@ -112,8 +114,7 @@
     errorMessage = null;
     confirmingRotate = false;
     try {
-      revealedUrl = (await rotateShareLink()).url ?? null;
-      plainVisible = revealedUrl != null;
+      await mint(rotateShareLink);
     } catch (err) {
       errorMessage = describeSubmitError(err, "Couldn't regenerate the link. Please try again.");
     } finally {
@@ -121,17 +122,25 @@
     }
   }
 
-  /**
-   * The URL, fetched once per visit and then reused. Null when the server kept nothing it could
-   * decrypt, which the card has already told the owner about via {@link canReveal}.
-   */
+  /** Takes a freshly minted link onto the screen: the owner just asked for it. */
+  async function mint(rotate: typeof rotateShareLink) {
+    revealedUrl = (await rotate()).url ?? null;
+    plainVisible = revealedUrl != null;
+    revealSucceeded = null;
+  }
+
+  /** The URL, fetched once per visit and then reused. */
   async function loadUrl(): Promise<string | null> {
     if (revealedUrl) return revealedUrl;
 
     revealing = true;
     errorMessage = null;
     try {
-      revealedUrl = (await revealShareLink()).url ?? null;
+      const link = await revealShareLink();
+      revealedUrl = link.url ?? null;
+      // Settles what the card could only guess at until now, which is what withdraws the show and
+      // copy controls when the stored copy turns out not to decrypt.
+      revealSucceeded = link.canReveal ?? revealedUrl != null;
       return revealedUrl;
     } catch (err) {
       errorMessage = describeSubmitError(err, "Couldn't show the link. Please try again.");
@@ -182,7 +191,6 @@
   }
 
   async function copyLink() {
-    // Fetches the URL if this visit has not yet, so copying never requires showing it first.
     const url = await loadUrl();
     if (!url) return;
     if (!(await copyToClipboard(url))) {
@@ -253,13 +261,15 @@
                   {redactedUrl}
                 </span>
               {:else}
+                <!-- The optimistic toggle turns this section on before the refreshed share
+                     arrives, so this is the moment between the two, not a steady state. -->
                 <span class="truncate font-sans text-muted-foreground">
-                  Your link is only shown when you create it
+                  Fetching your link...
                 </span>
               {/if}
             </div>
             <div class="flex gap-2">
-              {#if canReveal || revealedUrl}
+              {#if recoverable}
                 <Button
                   variant="ghost"
                   size="icon"
@@ -322,20 +332,18 @@
                 </Button>
               </div>
             </div>
-          {:else if canReveal || revealedUrl}
+          {:else if recoverable}
             <p class="text-xs text-muted-foreground">
-              Anyone you send this link to can open the read-only view — no sign-in
-              needed. It stays hidden here until you show or copy it. Last viewed
-              {formatDate(share?.lastAccessedAt)}.
+              Anyone you send this link to can open the read-only view without
+              signing in. It stays hidden here until you show or copy it. Last
+              viewed {formatDate(share?.lastAccessedAt)}.
             </p>
           {:else}
             <p class="text-xs text-muted-foreground">
-              Anyone who already has your link can open the read-only view — no
-              sign-in needed. This one was created before Nocturne could show it to
-              you again, so to get a link you can send, regenerate it; that also
-              stops the previous one from working. Last viewed {formatDate(
-                share?.lastAccessedAt,
-              )}.
+              Anyone who already has your link can still open the read-only view
+              without signing in, but Nocturne can no longer show you what it is.
+              To get a link you can send, regenerate it; that stops the current one
+              from working. Last viewed {formatDate(share?.lastAccessedAt)}.
             </p>
           {/if}
         </div>

--- a/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
@@ -14,10 +14,12 @@
     Loader2,
     Link as LinkIcon,
     Eye,
+    EyeOff,
     Clock,
   } from "lucide-svelte";
   import {
     getShareLink,
+    revealShareLink,
     rotateShareLink,
     disableShareLink,
     setShareLinkFullHistory,
@@ -57,9 +59,18 @@
   let errorMessage = $state<string | null>(null);
   let scopeWritesInFlight = $state(0);
 
-  // The server stores only a fingerprint of the link, so it can return the URL once — when the
-  // link is created. Held here for the rest of the visit; a reload shows the hidden state.
+  // The URL, once this visit has asked for it. The read that loads this card deliberately does
+  // not carry it: the link needs no credential to use, so it travels only when asked for, and
+  // each reveal is audited.
   let revealedUrl = $state<string | null>(null);
+  let revealing = $state(false);
+  /** Whether the URL is on screen, as opposed to merely fetched — copying does not show it. */
+  let plainVisible = $state(false);
+
+  const redactedUrl = $derived(share?.redactedUrl ?? null);
+  // False for a link minted before the token was stored recoverably, and on an instance with no
+  // encryption key. Both keep the older behaviour: regenerate to get a link you can send.
+  const canReveal = $derived(share?.canReveal ?? false);
 
   const sharedLabels = $derived(
     publicDataCategories.filter((c) => scopes.includes(c.scope)).map((c) => c.name.toLowerCase()),
@@ -74,10 +85,14 @@
     errorMessage = null;
     pendingEnabled = on;
     try {
-      if (on) revealedUrl = (await rotateShareLink()).url ?? null;
-      else {
+      if (on) {
+        revealedUrl = (await rotateShareLink()).url ?? null;
+        // Just minted at the owner's request, so it starts on screen.
+        plainVisible = revealedUrl != null;
+      } else {
         await disableShareLink();
         revealedUrl = null;
+        plainVisible = false;
       }
     } catch (err) {
       errorMessage = describeSubmitError(
@@ -98,11 +113,40 @@
     confirmingRotate = false;
     try {
       revealedUrl = (await rotateShareLink()).url ?? null;
+      plainVisible = revealedUrl != null;
     } catch (err) {
       errorMessage = describeSubmitError(err, "Couldn't regenerate the link. Please try again.");
     } finally {
       busy = false;
     }
+  }
+
+  /**
+   * The URL, fetched once per visit and then reused. Null when the server kept nothing it could
+   * decrypt, which the card has already told the owner about via {@link canReveal}.
+   */
+  async function loadUrl(): Promise<string | null> {
+    if (revealedUrl) return revealedUrl;
+
+    revealing = true;
+    errorMessage = null;
+    try {
+      revealedUrl = (await revealShareLink()).url ?? null;
+      return revealedUrl;
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Couldn't show the link. Please try again.");
+      return null;
+    } finally {
+      revealing = false;
+    }
+  }
+
+  async function togglePlain() {
+    if (plainVisible) {
+      plainVisible = false;
+      return;
+    }
+    plainVisible = (await loadUrl()) != null;
   }
 
   async function toggleScope(scope: string) {
@@ -138,8 +182,10 @@
   }
 
   async function copyLink() {
-    if (!revealedUrl) return;
-    if (!(await copyToClipboard(revealedUrl))) {
+    // Fetches the URL if this visit has not yet, so copying never requires showing it first.
+    const url = await loadUrl();
+    if (!url) return;
+    if (!(await copyToClipboard(url))) {
       errorMessage = "Couldn't copy the link to the clipboard. Copy it manually instead.";
       return;
     }
@@ -200,8 +246,12 @@
               class="flex h-11 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-background px-3 font-mono text-sm"
             >
               <LinkIcon class="h-4 w-4 shrink-0 text-muted-foreground" />
-              {#if revealedUrl}
-                <span class="truncate">{revealedUrl}</span>
+              {#if plainVisible && revealedUrl}
+                <span class="truncate" data-testid="public-access-url">{revealedUrl}</span>
+              {:else if redactedUrl}
+                <span class="truncate" data-testid="public-access-url-redacted">
+                  {redactedUrl}
+                </span>
               {:else}
                 <span class="truncate font-sans text-muted-foreground">
                   Your link is only shown when you create it
@@ -209,8 +259,30 @@
               {/if}
             </div>
             <div class="flex gap-2">
-              {#if revealedUrl}
-                <Button variant="outline" class="shrink-0" onclick={copyLink}>
+              {#if canReveal || revealedUrl}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="shrink-0"
+                  disabled={revealing}
+                  onclick={togglePlain}
+                  aria-label={plainVisible ? "Hide the link" : "Show the link"}
+                  data-testid="public-access-reveal"
+                >
+                  {#if revealing}
+                    <Loader2 class="h-4 w-4 animate-spin" />
+                  {:else if plainVisible}
+                    <EyeOff class="h-4 w-4" />
+                  {:else}
+                    <Eye class="h-4 w-4" />
+                  {/if}
+                </Button>
+                <Button
+                  variant="outline"
+                  class="shrink-0"
+                  disabled={revealing}
+                  onclick={copyLink}
+                >
                   {#if copied}
                     <Check class="mr-1.5 h-4 w-4 text-green-600" />
                   {:else}
@@ -250,16 +322,17 @@
                 </Button>
               </div>
             </div>
-          {:else if revealedUrl}
+          {:else if canReveal || revealedUrl}
             <p class="text-xs text-muted-foreground">
               Anyone you send this link to can open the read-only view — no sign-in
-              needed. Copy it now: it isn't shown again after you leave this page.
-              Last viewed {formatDate(share?.lastAccessedAt)}.
+              needed. It stays hidden here until you show or copy it. Last viewed
+              {formatDate(share?.lastAccessedAt)}.
             </p>
           {:else}
             <p class="text-xs text-muted-foreground">
               Anyone who already has your link can open the read-only view — no
-              sign-in needed. To get a link you can send, regenerate it; that also
+              sign-in needed. This one was created before Nocturne could show it to
+              you again, so to get a link you can send, regenerate it; that also
               stops the previous one from working. Last viewed {formatDate(
                 share?.lastAccessedAt,
               )}.

--- a/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte.test.ts
@@ -11,8 +11,11 @@ import { remoteQuery } from "$lib/test-stubs/remote-resource";
 // component has stopped consuming is released, and the refresh below then has nothing to write to.
 let registered = 0;
 
-const REDACTED_URL = "https://••••••••.share.example.com";
-const PLAIN_URL = "https://abcdefgh.share.example.com";
+// Sixteen bullets and a sixteen-character token, matching ShareTokenGenerator.TokenLength;
+// the component only echoes what it is handed, so a shorter fixture would still pass while
+// documenting a shape the server never sends.
+const REDACTED_URL = `https://${"•".repeat(16)}.share.example.com`;
+const PLAIN_URL = "https://abcdefghjkmnpqrs.share.example.com";
 
 const enabledShare = {
   enabled: true,
@@ -55,7 +58,8 @@ const disableShareLink = vi.fn(() => {
   return disableCall;
 });
 
-const revealShareLink = vi.fn(async () => ({ ...enabledShare, url: PLAIN_URL }));
+let revealResult = { ...enabledShare, url: PLAIN_URL as string | null, canReveal: true };
+const revealShareLink = vi.fn(async () => revealResult);
 
 vi.mock("$api/generated/shareLinks.generated.remote", () => ({
   getShareLink: () => registerShareQuery(),
@@ -74,6 +78,7 @@ describe("PublicAccessCard", () => {
     registered = 0;
     disableCall = null;
     share = enabledShare;
+    revealResult = { ...enabledShare, url: PLAIN_URL, canReveal: true };
     page.data = { effectivePermissions: ["*"] };
   });
 
@@ -123,6 +128,54 @@ describe("PublicAccessCard", () => {
     expect(revealShareLink).toHaveBeenCalledTimes(1);
   });
 
+  it("copies without putting the link on screen", async () => {
+    const clipboard: string[] = [];
+    // defineProperty, not Object.assign: navigator.clipboard is getter-only in a real browser.
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          clipboard.push(text);
+        },
+      },
+    });
+
+    render(PublicAccessCard);
+    await expect
+      .element(browser.getByTestId("public-access-url-redacted"))
+      .toBeVisible();
+
+    await browser.getByRole("button", { name: "Copy" }).click();
+
+    await vi.waitFor(() => expect(clipboard).toEqual([PLAIN_URL]));
+    // The point of fetching separately from showing: the link reaches the clipboard
+    // without ever being rendered where someone behind you could read it.
+    expect(
+      document.querySelector('[data-testid="public-access-url"]')
+    ).toBeNull();
+    await expect
+      .element(browser.getByTestId("public-access-url-redacted"))
+      .toBeVisible();
+  });
+
+  it("withdraws the controls when the reveal finds the link unreadable", async () => {
+    // A changed instance key: the columns still show a ciphertext, so the card renders
+    // the controls, and only the attempt can discover the copy no longer decrypts.
+    revealResult = { ...enabledShare, url: null, canReveal: false };
+    render(PublicAccessCard);
+
+    await browser.getByTestId("public-access-reveal").click();
+
+    await vi.waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="public-access-reveal"]')
+      ).toBeNull()
+    );
+    expect(document.body.textContent?.replace(/\s+/g, " ")).toContain(
+      "Nocturne can no longer show you what it is"
+    );
+  });
+
   it("offers no way to see a link the server cannot reproduce", async () => {
     share = { ...enabledShare, canReveal: false };
     render(PublicAccessCard);
@@ -136,7 +189,7 @@ describe("PublicAccessCard", () => {
     // Normalised: the copy wraps across source lines, so the rendered text carries
     // the template's own newlines and indentation mid-sentence.
     expect(document.body.textContent?.replace(/\s+/g, " ")).toContain(
-      "created before Nocturne could show it to you again"
+      "Nocturne can no longer show you what it is"
     );
   });
 });

--- a/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte.test.ts
@@ -11,9 +11,14 @@ import { remoteQuery } from "$lib/test-stubs/remote-resource";
 // component has stopped consuming is released, and the refresh below then has nothing to write to.
 let registered = 0;
 
+const REDACTED_URL = "https://••••••••.share.example.com";
+const PLAIN_URL = "https://abcdefgh.share.example.com";
+
 const enabledShare = {
   enabled: true,
   url: null,
+  redactedUrl: REDACTED_URL as string | null,
+  canReveal: true,
   fullHistory: false,
   scopes: ["glucose.read"],
   lastAccessedAt: null,
@@ -21,6 +26,8 @@ const enabledShare = {
 const disabledShare = {
   enabled: false,
   url: null,
+  redactedUrl: null,
+  canReveal: false,
   fullHistory: false,
   scopes: [] as string[],
   lastAccessedAt: null,
@@ -48,9 +55,12 @@ const disableShareLink = vi.fn(() => {
   return disableCall;
 });
 
+const revealShareLink = vi.fn(async () => ({ ...enabledShare, url: PLAIN_URL }));
+
 vi.mock("$api/generated/shareLinks.generated.remote", () => ({
   getShareLink: () => registerShareQuery(),
   disableShareLink: () => disableShareLink(),
+  revealShareLink: () => revealShareLink(),
   rotateShareLink: vi.fn(),
   setShareLinkFullHistory: vi.fn(),
   setShareLinkScopes: vi.fn(),
@@ -85,5 +95,48 @@ describe("PublicAccessCard", () => {
       document.querySelector('[data-testid="public-access-window"]')
     ).toBeNull();
     expect(document.body.textContent).toContain("Public access is off.");
+  });
+
+  it("shows the link redacted until asked, and does not fetch it before then", async () => {
+    render(PublicAccessCard);
+
+    await expect
+      .element(browser.getByTestId("public-access-url-redacted"))
+      .toHaveTextContent(REDACTED_URL);
+    // The secret must not ride along on the read that renders the card.
+    expect(revealShareLink).not.toHaveBeenCalled();
+
+    await browser.getByTestId("public-access-reveal").click();
+
+    await expect
+      .element(browser.getByTestId("public-access-url"))
+      .toHaveTextContent(PLAIN_URL);
+    expect(revealShareLink).toHaveBeenCalledTimes(1);
+
+    await browser.getByTestId("public-access-reveal").click();
+
+    await expect
+      .element(browser.getByTestId("public-access-url-redacted"))
+      .toHaveTextContent(REDACTED_URL);
+    // Hiding and showing again reuses what this visit already fetched.
+    await browser.getByTestId("public-access-reveal").click();
+    expect(revealShareLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers no way to see a link the server cannot reproduce", async () => {
+    share = { ...enabledShare, canReveal: false };
+    render(PublicAccessCard);
+
+    await expect
+      .element(browser.getByTestId("public-access-url-redacted"))
+      .toHaveTextContent(REDACTED_URL);
+    expect(
+      document.querySelector('[data-testid="public-access-reveal"]')
+    ).toBeNull();
+    // Normalised: the copy wraps across source lines, so the rendered text carries
+    // the template's own newlines and indentation mid-sentence.
+    expect(document.body.textContent?.replace(/\s+/g, " ")).toContain(
+      "created before Nocturne could show it to you again"
+    );
   });
 });

--- a/src/Web/packages/portal/src/content/docs/sharing/public-link.svx
+++ b/src/Web/packages/portal/src/content/docs/sharing/public-link.svx
@@ -27,17 +27,31 @@ It is **off until you turn it on**, and you turn it on under
 The address pictured belongs to a local test instance; yours will end in your own
 domain, in the shape `https://<random>.share.<your domain>`.
 
-## The link is shown once
+## Seeing the link again
 
-When you first switch public access on, Nocturne creates the link and shows it to
-you **that one time**. Copy it there and then, and keep it somewhere you can get
-back to; a password manager is ideal. If you lose it, you can't ask Nocturne to
-show it again; you **Regenerate** to get a new one, which also stops the old one
-working.
+The link stays hidden behind dots on this page. Use the eye button to show it, or
+**Copy** to put it on your clipboard without showing it at all, which is worth
+doing if anyone can see your screen. Each time you show it, Nocturne records that
+in your audit log.
 
 The address is a long random code on its own web address, along the lines of
 `k7m2p9x4q1.share.example.com`. That random part is the whole of the security:
-there's no list of shares to browse and nothing to guess your way to.
+there's no list of shares to browse and nothing to guess your way to. Because
+anyone holding it gets in, treat it like a password: a password manager is a good
+place to keep it.
+
+**Regenerate** replaces the link with a new one. Reach for it if the current one
+has gone somewhere you did not intend, and bear in mind it stops the old one
+working for everyone you have already sent it to, so they will each need the new
+one.
+
+<Callout type="note">
+On some instances Nocturne cannot show you an existing link, and says so on the
+page. That happens if the link was created before this feature existed, if your
+instance has no encryption key set, or if that key has changed since the link was
+made. The link itself keeps working for anyone who has it; only showing it again
+is impossible, so regenerating is the only way to get a copy you can send.
+</Callout>
 
 ## Choosing what's visible
 

--- a/src/Web/packages/screenshots/src/manifest.ts
+++ b/src/Web/packages/screenshots/src/manifest.ts
@@ -5,10 +5,7 @@ import type { ArrangeContext, ScreenshotDefinition } from './types.js';
 /** Rich enough that the public view is worth a screenshot; still short of everything on offer. */
 const SHARED_CATEGORIES = ['glucose.read', 'treatments.read', 'devices.read'];
 
-/**
- * Turns the tenant's public link on, widens what it shows, and hands back the link itself — the one
- * moment the URL is knowable, since the server keeps only its digest.
- */
+/** Turns the tenant's public link on, widens what it shows, and hands back the link to navigate to. */
 async function openPublicShare({ fetch }: ArrangeContext): Promise<Record<string, string>> {
 	const rotated = await fetch<{ url: string | null }>('/api/v4/share/rotate', { method: 'POST' });
 	await fetch('/api/v4/share/scopes', { method: 'PUT', body: { scopes: SHARED_CATEGORIES } });
@@ -19,22 +16,12 @@ async function openPublicShare({ fetch }: ArrangeContext): Promise<Record<string
 }
 
 /**
- * The card can show the link's address exactly once — at the moment the link is minted, since the
- * server keeps only its digest — so a share arranged through the API alone is photographed with an
- * empty link field. Regenerate mints one from the browser and is the card's own answer to "I no
- * longer have the address", which makes it the one control that reaches this state whether or not
- * public access was already on: the enable switch would only do it on a share that is currently
- * off, and both themes photograph the same tenant.
+ * The redacted address is what the card rests on, so a share arranged through the API is already in
+ * the state worth photographing, and the image no longer changes every capture the way a minted
+ * address did.
  */
-async function revealThePublicLink(page: Page): Promise<void> {
-	const regenerate = page.getByRole('button', { name: 'Regenerate' });
-	await regenerate.click();
-	await page.getByText('Regenerating invalidates the current link immediately.').waitFor();
-	// Confirming adds a second Regenerate after the first in the document.
-	await regenerate.last().click();
-	// Copy is offered only while the card is holding an address it can copy, so it is the receipt
-	// for a link that is actually in the frame.
-	await page.getByRole('button', { name: 'Copy', exact: true }).waitFor();
+async function settledPublicLink(page: Page): Promise<void> {
+	await page.getByTestId('public-access-url-redacted').waitFor();
 }
 
 async function inviteAGuest({ fetch }: ArrangeContext): Promise<Record<string, string>> {
@@ -279,10 +266,9 @@ export const definitions: ScreenshotDefinition[] = [
 		route: '/settings/members',
 		scenario: 'patient',
 		arrange: openPublicShare,
-		prepare: revealThePublicLink,
+		prepare: settledPublicLink,
 		clip: '[data-testid="public-access-card"]',
-		// The address is minted per run, so this one image differs every capture.
-		alt: 'The Public access card, switched on and holding a freshly minted link. The address is spelled out in full (the one time Nocturne shows it) with Copy and Regenerate beside it, then a tile for each kind of data you can share or keep back, a choice between all history and the last 24 hours, and a sentence spelling out what a viewer would see.',
+		alt: 'The Public access card, switched on. The address is hidden behind dots, with buttons to show it, copy it, and regenerate it beside them, then a tile for each kind of data you can share or keep back, a choice between all history and the last 24 hours, and a sentence spelling out what a viewer would see.',
 		anchors: {
 			enable: '[data-testid="public-access-toggle"]',
 			'time-window': '[data-testid="public-access-window"]',

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareAppearanceControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareAppearanceControllerTests.cs
@@ -20,7 +20,10 @@ namespace Nocturne.API.Tests.Controllers.V4.Identity;
 /// </summary>
 public sealed class ShareAppearanceControllerTests
 {
-    private readonly Mock<IShareLinkService> _service = new();
+    // The narrow interface, not IShareLinkService: mocking the wide one would still compile if
+    // the controller took a dependency that can hand out the share token, which is the thing this
+    // seam exists to prevent.
+    private readonly Mock<IShareAppearanceReader> _service = new();
 
     private ShareAppearanceController BuildController(bool onShareHost)
     {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareLinkControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareLinkControllerTests.cs
@@ -68,9 +68,12 @@ public sealed class ShareLinkControllerTests
 
         await controller.RevealShareLink(CancellationToken.None);
 
+        // detailsJson is pinned to null, not It.IsAny: writing the URL into the audit row is
+        // exactly the leak this endpoint exists to avoid, and an any-matcher cannot see it.
         _audit.Verify(a => a.LogAsync(
             AuthAuditEventType.ShareLinkRevealed, It.IsAny<Guid?>(), true,
-            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.Is<string?>(detailsJson => detailsJson == null),
             It.IsAny<Guid?>(), It.IsAny<AuthAuditActor>(), It.IsAny<Guid?>()), Times.Once);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareLinkControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareLinkControllerTests.cs
@@ -6,7 +6,9 @@ using Moq;
 using Nocturne.API.Controllers.V4.Identity;
 using Nocturne.API.Models.Responses;
 using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Core.Models.Authorization;
 using Xunit;
 
@@ -19,6 +21,7 @@ namespace Nocturne.API.Tests.Controllers.V4.Identity;
 public sealed class ShareLinkControllerTests
 {
     private readonly Mock<IShareLinkService> _service = new();
+    private readonly Mock<IAuthAuditService> _audit = new();
 
     private ShareLinkController BuildController(params string[] grantedScopes)
     {
@@ -28,7 +31,7 @@ public sealed class ShareLinkControllerTests
         var httpContext = new DefaultHttpContext();
         httpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(grantedScopes);
 
-        return new ShareLinkController(_service.Object, tenantAccessor.Object)
+        return new ShareLinkController(_service.Object, tenantAccessor.Object, _audit.Object)
         {
             ControllerContext = new ControllerContext { HttpContext = httpContext },
         };
@@ -43,6 +46,44 @@ public sealed class ShareLinkControllerTests
 
         result.Result.Should().BeOfType<ForbidResult>();
         _service.Verify(s => s.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RevealShareLink_without_sharing_manage_is_forbidden_and_does_not_read_the_link()
+    {
+        var controller = BuildController(/* no scopes */);
+
+        var result = await controller.RevealShareLink(CancellationToken.None);
+
+        result.Result.Should().BeOfType<ForbidResult>();
+        _service.Verify(s => s.RevealAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RevealShareLink_records_who_was_handed_the_link()
+    {
+        _service.Setup(s => s.RevealAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ShareLinkDto { Enabled = true, Url = "https://abc.share.nocturne.run" });
+        var controller = BuildController(Scope.SharingManage);
+
+        await controller.RevealShareLink(CancellationToken.None);
+
+        _audit.Verify(a => a.LogAsync(
+            AuthAuditEventType.ShareLinkRevealed, It.IsAny<Guid?>(), true,
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<Guid?>(), It.IsAny<AuthAuditActor>(), It.IsAny<Guid?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RevealShareLink_records_nothing_when_there_was_no_link_to_hand_over()
+    {
+        _service.Setup(s => s.RevealAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ShareLinkDto { Enabled = true, Url = null, CanReveal = false });
+        var controller = BuildController(Scope.SharingManage);
+
+        await controller.RevealShareLink(CancellationToken.None);
+
+        _audit.VerifyNoOtherCalls();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
@@ -10,8 +10,12 @@ using Moq;
 using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Auth;
 using Nocturne.API.Tests.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Shared.Services;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Security;
@@ -26,10 +30,26 @@ public sealed class ShareLinkServiceTests : IDisposable
 
     private readonly NocturneDbContext _db;
     private readonly ShareLinkService _service;
+    private readonly string _dbName;
+
+    /// <summary>
+    /// The real AES-GCM service over a fixed instance key, so the reveal tests exercise an actual
+    /// round trip rather than a mock that would pass whatever it was handed.
+    /// </summary>
+    private static ISecretEncryptionService Encryption(string? instanceKey = "test-instance-key") =>
+        new SecretEncryptionService(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [ServiceNames.ConfigKeys.InstanceKey] = instanceKey,
+                })
+                .Build(),
+            NullLogger<SecretEncryptionService>.Instance);
 
     public ShareLinkServiceTests()
     {
         var dbName = $"sharelink_{Guid.NewGuid()}";
+        _dbName = dbName;
         _db = TestDbContextFactory.CreateInMemoryContext(dbName);
         TestDatabaseSeeder.Seed(_db);
 
@@ -48,17 +68,25 @@ public sealed class ShareLinkServiceTests : IDisposable
         });
         _db.SaveChanges();
 
+        _service = CreateService(_db, Encryption());
+    }
+
+    /// <summary>A service over <paramref name="db"/> with the given encryption available to it.</summary>
+    private ShareLinkService CreateService(NocturneDbContext db, ISecretEncryptionService secrets)
+    {
         var factory = new Mock<IDbContextFactory<NocturneDbContext>>();
         factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() => TestDbContextFactory.CreateInMemoryContext(dbName));
+            .ReturnsAsync(() => TestDbContextFactory.CreateInMemoryContext(_dbName));
 
-        _service = new ShareLinkService(
-            _db,
+        return new ShareLinkService(
+            db,
             new ShareTokenGenerator(),
             new ShareTokenCacheService(
                 new MemoryCache(new MemoryCacheOptions()), factory.Object, NullLogger<ShareTokenCacheService>.Instance),
             new PublicAccessCacheService(
                 new MemoryCache(new MemoryCacheOptions()), factory.Object, NullLogger<PublicAccessCacheService>.Instance),
+            secrets,
+            NullLogger<ShareLinkService>.Instance,
             Options.Create(new BaseDomainOptions { BaseDomain = "nocturne.run" }));
     }
 
@@ -103,7 +131,80 @@ public sealed class ShareLinkServiceTests : IDisposable
         var dto = await _service.GetAsync(TenantId);
 
         dto.Enabled.Should().BeTrue();
-        dto.Url.Should().BeNull("the token is not stored, so the URL cannot be reproduced");
+        dto.Url.Should().BeNull("the secret travels only when the owner asks for it");
+        dto.RedactedUrl.Should().Be("https://••••••••••••••••.share.nocturne.run");
+        dto.CanReveal.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Rotate_keeps_a_copy_the_owner_can_be_shown_again()
+    {
+        var url = (await _service.RotateAsync(TenantId)).Url;
+        var token = new Uri(url!).Host.Split('.')[0];
+
+        var tenant = await _db.Tenants.AsNoTracking().FirstAsync(t => t.Id == TenantId);
+        tenant.ShareTokenEncrypted.Should().NotBeNull().And.NotBe(token,
+            "the column holds ciphertext, not the token");
+        Encryption().Decrypt(tenant.ShareTokenEncrypted!).Should().Be(token);
+    }
+
+    [Fact]
+    public async Task Reveal_returns_the_live_url_rather_than_a_new_one()
+    {
+        var minted = (await _service.RotateAsync(TenantId)).Url;
+
+        var dto = await _service.RevealAsync(TenantId);
+
+        dto.Url.Should().Be(minted, "revealing must not invalidate the link people already hold");
+        dto.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Reveal_reports_a_link_it_cannot_reproduce_without_breaking_it()
+    {
+        await _service.RotateAsync(TenantId);
+
+        // What a link minted before the recoverable copy existed looks like.
+        var stored = await _db.Tenants.FirstAsync(t => t.Id == TenantId);
+        stored.ShareTokenEncrypted = null;
+        await _db.SaveChangesAsync();
+
+        var dto = await _service.RevealAsync(TenantId);
+
+        dto.Url.Should().BeNull();
+        dto.CanReveal.Should().BeFalse();
+        dto.Enabled.Should().BeTrue("the link still resolves; only showing it is impossible");
+    }
+
+    [Fact]
+    public async Task Reveal_survives_a_stored_copy_that_no_longer_decrypts()
+    {
+        await _service.RotateAsync(TenantId);
+
+        // What a changed instance key leaves behind.
+        var stored = await _db.Tenants.FirstAsync(t => t.Id == TenantId);
+        stored.ShareTokenEncrypted = Convert.ToBase64String(new byte[48]);
+        await _db.SaveChangesAsync();
+
+        var dto = await _service.RevealAsync(TenantId);
+
+        dto.Url.Should().BeNull();
+        dto.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Rotate_still_mints_a_link_on_an_instance_with_no_key()
+    {
+        var service = CreateService(_db, Encryption(instanceKey: null));
+
+        var dto = await service.RotateAsync(TenantId);
+
+        dto.Url.Should().NotBeNull("a missing key must not stop someone sharing");
+        dto.CanReveal.Should().BeFalse();
+
+        var tenant = await _db.Tenants.AsNoTracking().FirstAsync(t => t.Id == TenantId);
+        tenant.ShareToken.Should().NotBeNull();
+        tenant.ShareTokenEncrypted.Should().BeNull();
     }
 
     [Fact]
@@ -142,6 +243,7 @@ public sealed class ShareLinkServiceTests : IDisposable
 
         var tenant = await _db.Tenants.AsNoTracking().FirstAsync(t => t.Id == TenantId);
         tenant.ShareToken.Should().BeNull();
+        tenant.ShareTokenEncrypted.Should().BeNull("a turned-off link leaves nothing to decrypt");
 
         var member = await GetPublicMemberAsync();
         member.MemberRoles.Should().BeEmpty();

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
@@ -174,6 +174,7 @@ public sealed class ShareLinkServiceTests : IDisposable
         dto.Url.Should().BeNull();
         dto.CanReveal.Should().BeFalse();
         dto.Enabled.Should().BeTrue("the link still resolves; only showing it is impossible");
+        dto.RedactedUrl.Should().NotBeNull("the owner should still see that a link exists");
     }
 
     [Fact]
@@ -189,7 +190,22 @@ public sealed class ShareLinkServiceTests : IDisposable
         var dto = await _service.RevealAsync(TenantId);
 
         dto.Url.Should().BeNull();
+        dto.CanReveal.Should().BeFalse("only the attempt can tell this case from a healthy one");
         dto.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Get_cannot_tell_a_stale_ciphertext_from_a_good_one()
+    {
+        await _service.RotateAsync(TenantId);
+        var stored = await _db.Tenants.FirstAsync(t => t.Id == TenantId);
+        stored.ShareTokenEncrypted = Convert.ToBase64String(new byte[48]);
+        await _db.SaveChangesAsync();
+
+        // Pins the asymmetry the card is built around: the plain read sees a ciphertext and says
+        // so, and only the reveal that tries to use it can correct that.
+        (await _service.GetAsync(TenantId)).CanReveal.Should().BeTrue();
+        (await _service.RevealAsync(TenantId)).CanReveal.Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

A tenant's public share token is stored only as a SHA-256 digest (`20260726180135_HashTenantShareTokens`), so the link can be shown exactly once, at creation. Close the page, then want to send the link to a second relative, and the only option is **regenerate**, which breaks it for everyone already holding it. The card said as much:

> Your link is only shown when you create it

## Change

Keep the token recoverably as well, in a new `share_token_encrypted` column: AES-256-GCM under the instance key via `ISecretEncryptionService`, the same at-rest protection connector credentials and TOTP secrets already use.

`share_token` keeps the digest and stays the only thing an incoming request is resolved by. **Nothing authenticates against the new column.**

## The trade-off

This is a deliberate reversal of the July hardening, and it is not free. Before, a leaked database dump alone yielded no working link without searching 80 bits of entropy. After, a dump **plus the instance key** yields every tenant's live public link at once.

Worth being honest about how independent those two really are: `deploy/docker-compose/.env.example` puts `INSTANCE_KEY` in a file beside the Postgres volume on the same host, and the Helm chart injects it into three deployments. For the standard self-host topology this is closer to one host compromise than to two separate events.

Three things narrow the exposure:

1. **The plain URL never rides on the read that renders the card.** Reveal is its own endpoint (`POST /api/v4/share/reveal`), so the secret crosses the wire only when asked for.
2. **Every reveal that produced a URL is audit-logged** as `share_link_revealed`, with subject, IP and user-agent. Logged on the outcome, not the request.
3. **Copy fetches without displaying**, so the link never has to go on screen to be sent.

## UI

The card always shows the link, redacted to bullets (`https://••••••••••••••••.share.example.com`), with an eye toggle to reveal and a Copy button that works either way.

Three cases leave a live link unshowable, and all three keep the link itself working, because resolution reads the digest: it was minted before this column existed, the instance has no key, or the key changed since. They are enumerated once on `TenantEntity.ShareTokenEncrypted`. All three fall back to "regenerate to get a link you can send".

## Corrections after review

A hostile review found a real bug and three test gaps.

**`canReveal` was computed from the columns**, so the changed-key case reported `canReveal = true` with a null URL. Every tenant's card would offer Show and Copy after an instance-key rotation and **both would silently do nothing** — no error, no explanation. The reveal response already carried the correct answer and the component discarded it. The reveal path now reports what it actually found, and the card lets that outrank the columns.

The review traced this to prose duplication: the rationale was written out in five places, and only `DecryptToken`'s copy mentioned the third case, so the property that needed to handle it never learned about it. One home now, referenced from the rest.

**Two other places assumed the token was unrecoverable.** `DemoTenantService`'s hand-maintained preservation list dropped the new column, so a demo reset left a working link permanently unshowable. The legacy rotation pass in `CredentialAtRestStartupTask` replaces the token itself, so a copy kept for the old one would have decrypted to a link that no longer resolves — a *wrong* address handed over with no error, worse than refusing. It now clears the column.

**The card's explanation named one cause for all three**, which is plainly false on an instance with no key. Rewritten to describe the situation rather than guess at its origin.

**The anonymous-reachable controller had too wide a seam.** `ShareAppearanceController` answers unauthenticated requests on a share host and took `IShareLinkService`, which this branch gave a member that hands back the token in the clear. Nothing routed an anonymous caller there and the scope check would have stopped one, but it now takes `IShareAppearanceReader`, carrying only the presentation member. The test mocked the wide interface, so it would have kept compiling if the controller had taken something credential-dispensing; it mocks the narrow one now.

## Migration

`20260911232705_AddRecoverableShareToken`: one nullable column, EF-generated, no index, no data step.

## Tests

- `ShareLinkServiceTests` +8. Real AES-GCM round trip; reveal returns the *live* URL rather than minting a new one; null ciphertext, non-decrypting ciphertext and missing instance key each degrade without breaking the link; and the asymmetry itself is pinned — the plain read cannot tell a stale ciphertext from a good one, and only the reveal corrects it.
- `ShareLinkControllerTests` +3. The audit assertion matched `detailsJson` with `It.IsAny`, so writing the URL into the audit row passed the suite. Pinned to null.
- `PublicAccessCard.svelte.test.ts` +4, including copy-without-showing, which had no coverage, and the reveal that finds the link unreadable.
- Mutations verified red: URL into `detailsJson`; `canReveal` back to column-only; `plainVisible = true` in `copyLink`; discarding the reveal's `canReveal`.
- 60 backend tests pass, 5 browser tests pass, `pnpm check` clean in the changed files.

## Known gap

`vitest.config.ts` excludes `src/**/*.svelte.test.ts`, and `tests.yml`'s `web-typecheck` job does not run vitest for `@nocturne/app`. The four component tests here are local-only assurance; **nothing runs them in CI**. That is pre-existing and worth its own issue.

The `sharing-public-link` screenshot no longer mints a fresh link to photograph, so the image stops differing on every capture, but it still needs regenerating to show the new controls.

https://claude.ai/code/session_01Kr7oRsePv4LL2QFSuQdpNd