### PR TITLE
fix(trackers): advance trackers from device events again

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -585,8 +585,10 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IBodyWeightService, BodyWeightService>();
         services.AddScoped<IStepCountService, StepCountService>();
 
-        // Tracker services
-        services.AddScoped<ITrackerTriggerService, TrackerTriggerService>();
+        // Tracker services. The trigger is the IDeviceEventReactor adapter rather than a service any
+        // caller invokes: it runs from the V4 device-event write chokepoint, which is what makes a
+        // connector-ingested site change advance a tracker the same way a hand-entered one does.
+        services.AddScoped<IDeviceEventReactor, TrackerTriggerService>();
         // Tracker notifications ride the alert engine: thresholds are synthesised into
         // managed tracker_age alert rules, backfilled once at startup for pre-existing
         // definitions (and self-healing if a managed rule is ever lost).

--- a/src/API/Nocturne.API/Services/Monitoring/TrackerTriggerService.cs
+++ b/src/API/Nocturne.API/Services/Monitoring/TrackerTriggerService.cs
@@ -1,44 +1,27 @@
 using System.Text.Json;
 using Nocturne.API.Controllers.V4.Monitoring;
-using Nocturne.Core.Models;
-using Nocturne.Infrastructure.Data.Abstractions;
 using Nocturne.API.Services.Realtime;
+using Nocturne.Connectors.Core.Constants;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Abstractions;
+using Nocturne.Infrastructure.Data.Entities;
 
 namespace Nocturne.API.Services.Monitoring;
 
 /// <summary>
-/// Automatically starts tracker instances when matching treatments are created. When a treatment
-/// event type matches a tracker's configured trigger (e.g. a site change starts a cannula tracker),
-/// the implementation starts a new tracker instance and broadcasts the event over SignalR.
+/// Advances tracker instances when a matching <see cref="DeviceEvent"/> is written: a site change
+/// completes the running infusion-site instance and starts a new one, a sensor change does the same
+/// for the sensor tracker, and so on for whatever a definition lists in its trigger event types.
 /// </summary>
-public interface ITrackerTriggerService
-{
-    /// <summary>
-    /// Check if a treatment should trigger any tracker instances and start them
-    /// </summary>
-    Task ProcessTreatmentAsync(
-        Treatment treatment,
-        string? userId,
-        CancellationToken cancellationToken = default
-    );
-
-    /// <summary>
-    /// Process multiple treatments for tracker triggers
-    /// </summary>
-    Task ProcessTreatmentsAsync(
-        IEnumerable<Treatment> treatments,
-        string? userId,
-        CancellationToken cancellationToken = default
-    );
-}
-
-/// <summary>
-/// Default implementation of <see cref="ITrackerTriggerService"/>. Queries the tracker repository
-/// for definitions whose trigger event type matches the incoming treatment and starts instances
-/// accordingly, broadcasting state changes over SignalR.
-/// </summary>
-/// <seealso cref="ITrackerTriggerService"/>
-public class TrackerTriggerService : ITrackerTriggerService
+/// <remarks>
+/// Registered as the <see cref="IDeviceEventReactor"/> adapter, so it runs from the device-event write
+/// chokepoint and therefore fires for connector ingest and direct V4 writes alike.
+/// </remarks>
+/// <seealso cref="IDeviceEventReactor"/>
+/// <seealso cref="TrackerDefinitionEntity.TriggerEventTypes"/>
+public class TrackerTriggerService : IDeviceEventReactor
 {
     private readonly ITrackerRepository _trackerRepository;
     private readonly ISignalRBroadcastService _broadcast;
@@ -55,135 +38,174 @@ public class TrackerTriggerService : ITrackerTriggerService
         _logger = logger;
     }
 
-    public async Task ProcessTreatmentAsync(
-        Treatment treatment,
-        string? userId,
-        CancellationToken cancellationToken = default
-    )
+    /// <inheritdoc />
+    public async Task OnCreatedAsync(IReadOnlyList<DeviceEvent> created, CancellationToken ct = default)
     {
-        if (string.IsNullOrEmpty(treatment.EventType) || string.IsNullOrEmpty(userId))
+        if (created.Count == 0)
             return;
 
-        await ProcessTreatmentInternalAsync(treatment, userId, cancellationToken);
-    }
+        // Definitions are read tenant-wide rather than per-user: a device event is a fact about the
+        // tenant's hardware, so every tracker configured to follow that event advances, and the new
+        // instance is owned by whoever owns the definition. There is no user on a connector-ingested
+        // event to scope this by, and the managed alert rules trackers sync are already tenant-visible.
+        var definitions = await _trackerRepository.GetAllDefinitionsAsync(ct);
 
-    public async Task ProcessTreatmentsAsync(
-        IEnumerable<Treatment> treatments,
-        string? userId,
-        CancellationToken cancellationToken = default
-    )
-    {
-        if (string.IsNullOrEmpty(userId))
+        var triggers = definitions
+            .Select(definition => (Definition: definition, EventTypes: ParseTriggerEventTypes(definition.TriggerEventTypes)))
+            // Event-mode trackers are scheduled against a calendar date and StartInstanceAsync needs a
+            // ScheduledAt no device event can supply, so only Duration trackers are triggerable.
+            .Where(t => t.EventTypes.Count > 0 && t.Definition.Mode == TrackerMode.Duration)
+            .ToList();
+
+        if (triggers.Count == 0)
             return;
 
-        foreach (var treatment in treatments)
+        // Oldest first: one batch can carry several changes for the same tracker, and each is what
+        // completes the instance the previous one started.
+        foreach (var deviceEvent in created.OrderBy(e => e.Timestamp))
         {
-            if (!string.IsNullOrEmpty(treatment.EventType))
+            foreach (var (definition, eventTypes) in triggers)
             {
-                await ProcessTreatmentInternalAsync(treatment, userId, cancellationToken);
+                if (!eventTypes.Contains(deviceEvent.EventType))
+                    continue;
+
+                if (!MatchesNotesFilter(definition, deviceEvent))
+                    continue;
+
+                await AdvanceAsync(definition, deviceEvent, ct);
             }
         }
     }
 
-    private async Task ProcessTreatmentInternalAsync(
-        Treatment treatment,
-        string userId,
-        CancellationToken cancellationToken
+    /// <summary>
+    /// Completes whatever is running for the definition and starts a fresh instance at the event's
+    /// timestamp, unless a guard says this event does not represent a new change.
+    /// </summary>
+    private async Task AdvanceAsync(
+        TrackerDefinitionEntity definition,
+        DeviceEvent deviceEvent,
+        CancellationToken ct
     )
     {
-        // Get all definitions for this user that might be triggered
-        var definitions = await _trackerRepository.GetDefinitionsForUserAsync(
-            userId,
-            cancellationToken
-        );
+        var startTreatmentId = deviceEvent.Id.ToString();
+        var activeInstances = await _trackerRepository.GetActiveInstancesForDefinitionAsync(definition.Id, ct);
 
-        foreach (var definition in definitions)
+        // Connectors re-publish a moving window, so the same change can reach the chokepoint more than
+        // once. An instance already started from this event means it has been handled.
+        if (activeInstances.Any(i => i.StartTreatmentId == startTreatmentId))
+            return;
+
+        // Connectors also backfill older events into that window. One dated at or before the running
+        // instance is history rather than a new change, and acting on it would rewind the tracker to
+        // an earlier consumable.
+        if (activeInstances.Any(i => i.StartedAt >= deviceEvent.Timestamp))
         {
-            var triggerEventTypes = ParseTriggerEventTypes(definition.TriggerEventTypes);
-            if (triggerEventTypes.Count == 0)
-                continue;
+            _logger.LogDebug(
+                "Skipping tracker {DefinitionName}: device event at {EventTime} is not newer than the active instance",
+                definition.Name,
+                deviceEvent.Timestamp
+            );
+            return;
+        }
 
-            // Check if this treatment's event type matches any trigger
-            if (!triggerEventTypes.Contains(treatment.EventType, StringComparer.OrdinalIgnoreCase))
-                continue;
-
-            // Check if there's already an active instance for this definition
-            var activeInstances = await _trackerRepository.GetActiveInstancesForDefinitionAsync(
-                definition.Id,
-                cancellationToken
+        foreach (var activeInstance in activeInstances)
+        {
+            var completed = await _trackerRepository.CompleteInstanceAsync(
+                activeInstance.Id,
+                ReasonFor(definition, activeInstance.StartedAt, deviceEvent.Timestamp),
+                completionNotes: $"Auto-completed by {deviceEvent.EventType}",
+                completeTreatmentId: startTreatmentId,
+                completedAt: deviceEvent.Timestamp,
+                cancellationToken: ct
             );
 
-            if (activeInstances.Count > 0)
-            {
-                // Complete the existing active instance(s) before starting a new one
-                foreach (var activeInstance in activeInstances)
-                {
-                    var completedAt = DateTimeOffset
-                        .FromUnixTimeMilliseconds(treatment.Mills)
-                        .UtcDateTime;
-
-                    await _trackerRepository.CompleteInstanceAsync(
-                        activeInstance.Id,
-                        CompletionReason.Completed,
-                        completionNotes: $"Auto-completed by new {treatment.EventType}",
-                        completeTreatmentId: treatment.Id,
-                        completedAt: completedAt,
-                        cancellationToken: cancellationToken
-                    );
-
-                    _logger.LogInformation(
-                        "Auto-completed tracker instance {InstanceId} for definition {DefinitionName} due to new treatment",
-                        activeInstance.Id,
-                        definition.Name
-                    );
-
-                    // Broadcast the completion
-                    await _broadcast.BroadcastTrackerUpdateAsync(
-                        "update",
-                        TrackerInstanceDto.FromEntity(activeInstance)
-                    );
-                }
-            }
-
-            // Start a new instance
-            var startedAt = DateTimeOffset.FromUnixTimeMilliseconds(treatment.Mills).UtcDateTime;
-
-            var newInstance = await _trackerRepository.StartInstanceAsync(
-                definition.Id,
-                userId,
-                startNotes: null,
-                startTreatmentId: treatment.Id,
-                startedAt: startedAt,
-                cancellationToken: cancellationToken
-            );
+            if (completed is null)
+                continue;
 
             _logger.LogInformation(
-                "Auto-started tracker instance {InstanceId} for definition {DefinitionName} from treatment {TreatmentEventType}",
-                newInstance.Id,
+                "Auto-completed tracker instance {InstanceId} for {DefinitionName} on {EventType}",
+                completed.Id,
                 definition.Name,
-                treatment.EventType
+                deviceEvent.EventType
             );
 
-            // Broadcast the new instance
-            await _broadcast.BroadcastTrackerUpdateAsync(
-                "create",
-                TrackerInstanceDto.FromEntity(newInstance)
-            );
+            await _broadcast.BroadcastTrackerUpdateAsync("complete", TrackerInstanceDto.FromEntity(completed));
         }
+
+        var newInstance = await _trackerRepository.StartInstanceAsync(
+            definition.Id,
+            definition.UserId,
+            startNotes: null,
+            startTreatmentId: startTreatmentId,
+            startedAt: deviceEvent.Timestamp,
+            cancellationToken: ct
+        );
+
+        _logger.LogInformation(
+            "Auto-started tracker instance {InstanceId} for {DefinitionName} on {EventType}",
+            newInstance.Id,
+            definition.Name,
+            deviceEvent.EventType
+        );
+
+        await _broadcast.BroadcastTrackerUpdateAsync("create", TrackerInstanceDto.FromEntity(newInstance));
     }
 
-    private static List<string> ParseTriggerEventTypes(string? json)
+    /// <summary>
+    /// Classifies an auto-completion the way the history surface reads it: a consumable that reached its
+    /// configured lifespan expired, one swapped before that was replaced early. A definition with no
+    /// lifespan has no term to have reached, so it is a plain completion.
+    /// </summary>
+    private static CompletionReason ReasonFor(TrackerDefinitionEntity definition, DateTime startedAt, DateTime completedAt)
+    {
+        if (definition.LifespanHours is not { } lifespanHours || lifespanHours <= 0)
+            return CompletionReason.Completed;
+
+        return completedAt - startedAt >= TimeSpan.FromHours(lifespanHours)
+            ? CompletionReason.Expired
+            : CompletionReason.ReplacedEarly;
+    }
+
+    /// <summary>
+    /// Applies the definition's optional notes substring filter, which distinguishes trackers that share
+    /// an event type (two pump sites logged as "Site Change" with different notes, say).
+    /// </summary>
+    private static bool MatchesNotesFilter(TrackerDefinitionEntity definition, DeviceEvent deviceEvent)
+    {
+        if (string.IsNullOrWhiteSpace(definition.TriggerNotesContains))
+            return true;
+
+        return deviceEvent.Notes is not null
+            && deviceEvent.Notes.Contains(definition.TriggerNotesContains, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Reads a definition's trigger list, which stores legacy Nightscout event-type strings, and resolves
+    /// them to the typed device event types they correspond to. Entries naming something that is not a
+    /// device event (a bolus type, say) map to nothing and are dropped.
+    /// </summary>
+    private static HashSet<DeviceEventType> ParseTriggerEventTypes(string? json)
     {
         if (string.IsNullOrEmpty(json))
             return [];
 
+        List<string>? eventTypes;
         try
         {
-            return JsonSerializer.Deserialize<List<string>>(json) ?? [];
+            eventTypes = JsonSerializer.Deserialize<List<string>>(json);
         }
-        catch
+        catch (JsonException)
         {
             return [];
         }
+
+        if (eventTypes is null)
+            return [];
+
+        return [.. eventTypes
+            .Select(name => TreatmentTypes.DeviceEventTypeMap.TryGetValue(name, out var parsed)
+                ? parsed
+                : (DeviceEventType?)null)
+            .OfType<DeviceEventType>()];
     }
 }

--- a/src/Core/Nocturne.Core.Contracts/Events/IDeviceEventReactor.cs
+++ b/src/Core/Nocturne.Core.Contracts/Events/IDeviceEventReactor.cs
@@ -1,0 +1,26 @@
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Core.Contracts.Events;
+
+/// <summary>
+/// Driven port for domain reactions to newly written <see cref="DeviceEvent"/> records — currently the
+/// tracker trigger, which advances tracker instances when a site or sensor change lands.
+/// </summary>
+/// <remarks>
+/// Fired from the V4 device-event write chokepoint for live writes only: the chokepoint gates on
+/// <see cref="Nocturne.Core.Contracts.V4.WriteOrigin"/>, so a migration or replay import never
+/// retroactively advances trackers.
+/// Sitting at the repository rather than at a controller is the point — connector ingest reaches
+/// device events through <c>ITreatmentDecomposer</c> and never touches the V4 REST surface, so a
+/// controller-level hook would fire for hand-entered events only.
+/// Implementations run after the write has committed and must not throw; the chokepoint does not
+/// roll the write back for them.
+/// </remarks>
+/// <seealso cref="IV4RecordBroadcaster{TModel}"/>
+public interface IDeviceEventReactor
+{
+    /// <summary>Reacts to device events that were just created.</summary>
+    /// <param name="created">The newly created events, in no particular order.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task OnCreatedAsync(IReadOnlyList<DeviceEvent> created, CancellationToken ct = default);
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -25,6 +25,7 @@ public class DeviceEventRepository : SyncKeyedRepositoryBase<DeviceEvent, Device
 {
     private readonly IDeduplicationService _deduplicationService;
     private readonly ILogger<DeviceEventRepository> _logger;
+    private readonly IDeviceEventReactor? _reactor;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DeviceEventRepository"/> class.
@@ -33,16 +34,43 @@ public class DeviceEventRepository : SyncKeyedRepositoryBase<DeviceEvent, Device
     /// <param name="deduplicationService">The deduplication service.</param>
     /// <param name="auditContext">The audit context for tracking mutations.</param>
     /// <param name="logger">The logger instance.</param>
+    /// <param name="broadcaster">Optional realtime broadcaster for native V4 record shapes.</param>
+    /// <param name="reactor">Optional domain reaction to live creates — the tracker trigger. Null when
+    /// the repository is constructed without DI, in which case creates simply run no reaction.</param>
     public DeviceEventRepository(
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
         ILogger<DeviceEventRepository> logger,
-        IV4RecordBroadcaster<DeviceEvent>? broadcaster = null)
+        IV4RecordBroadcaster<DeviceEvent>? broadcaster = null,
+        IDeviceEventReactor? reactor = null)
         : base(contextFactory, auditContext, broadcaster)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;
+        _reactor = reactor;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Device events are the one V4 type carrying a domain reaction: a site or sensor change advances
+    /// the tracker instances configured to trigger on it. Failures are logged and swallowed — the event
+    /// itself is already committed, and a tracker that misses a change is recoverable in a way that
+    /// failing the ingest of the underlying record is not.
+    /// </remarks>
+    protected override async Task OnLiveCreatedAsync(IReadOnlyList<DeviceEvent> created, CancellationToken ct)
+    {
+        if (_reactor is null)
+            return;
+
+        try
+        {
+            await _reactor.OnCreatedAsync(created, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Device event reaction failed for {Count} created event(s)", created.Count);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -100,7 +100,27 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         await V4RecordBroadcast.RaiseAsync(
             _broadcaster, created, updated, deleted.Select(m => m.Id).ToList(), origin, ct);
         await RaiseEntriesProjectionAsync(created, updated, deleted, origin, ct);
+        await RaiseLiveCreatedAsync(created, origin, ct);
     }
+
+    /// <summary>
+    /// Runs the type's domain reaction to just-created records, sharing the <see cref="WriteOrigin.Live"/>
+    /// gate with the broadcast and the legacy projection so backfill imports stay inert here too.
+    /// </summary>
+    private async Task RaiseLiveCreatedAsync(IReadOnlyList<TModel> created, WriteOrigin origin, CancellationToken ct)
+    {
+        if (origin != WriteOrigin.Live || created.Count == 0)
+            return;
+
+        await OnLiveCreatedAsync(created, ct);
+    }
+
+    /// <summary>
+    /// Hook for a post-commit domain reaction to live creates. Default is a no-op; only types that own a
+    /// reaction override it (device events advance tracker instances). Runs after the write has committed,
+    /// so an override that throws faults the caller on work the write itself no longer depends on.
+    /// </summary>
+    protected virtual Task OnLiveCreatedAsync(IReadOnlyList<TModel> created, CancellationToken ct) => Task.CompletedTask;
 
     /// <summary>
     /// The coarse substitute for per-record delete events when a delete matched more rows than

--- a/tests/Unit/Nocturne.API.Tests/Services/Monitoring/TrackerTriggerServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Monitoring/TrackerTriggerServiceTests.cs
@@ -1,0 +1,365 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Monitoring;
+using Nocturne.API.Extensions;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Abstractions;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Monitoring;
+
+/// <summary>
+/// Covers the device-event reaction that advances tracker instances. The behaviour these pin down is
+/// what the connector ingest path depends on: definitions are matched tenant-wide (a connector event
+/// carries no user), re-published and backdated events must not rewind a tracker, and a batch must
+/// chain in timestamp order.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TrackerTriggerServiceTests
+{
+    private readonly Mock<ITrackerRepository> _repository = new();
+    private readonly Mock<ISignalRBroadcastService> _broadcast = new();
+    private readonly TrackerTriggerService _sut;
+
+    private readonly List<TrackerDefinitionEntity> _definitions = [];
+    private readonly Dictionary<Guid, List<TrackerInstanceEntity>> _activeByDefinition = [];
+    private readonly List<TrackerInstanceEntity> _started = [];
+    private readonly List<(Guid InstanceId, CompletionReason Reason, DateTime? CompletedAt, string? CompleteTreatmentId)> _completed = [];
+
+    public TrackerTriggerServiceTests()
+    {
+        _repository
+            .Setup(r => r.GetAllDefinitionsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _definitions);
+
+        _repository
+            .Setup(r => r.GetActiveInstancesForDefinitionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid definitionId, CancellationToken _) =>
+                _activeByDefinition.TryGetValue(definitionId, out var list) ? list : []);
+
+        _repository
+            .Setup(r => r.StartInstanceAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid definitionId, string userId, string? startNotes, string? startTreatmentId,
+                DateTime? startedAt, DateTime? scheduledAt, CancellationToken _) =>
+            {
+                var instance = new TrackerInstanceEntity
+                {
+                    Id = Guid.NewGuid(),
+                    DefinitionId = definitionId,
+                    UserId = userId,
+                    StartNotes = startNotes,
+                    StartTreatmentId = startTreatmentId,
+                    StartedAt = startedAt ?? DateTime.UtcNow,
+                    ScheduledAt = scheduledAt,
+                };
+                _started.Add(instance);
+                // Mirror the repository: a started instance becomes the definition's active one, which is
+                // what lets a multi-event batch chain through this mock.
+                _activeByDefinition[definitionId] = [instance];
+                return instance;
+            });
+
+        _repository
+            .Setup(r => r.CompleteInstanceAsync(
+                It.IsAny<Guid>(), It.IsAny<CompletionReason>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid instanceId, CompletionReason reason, string? notes, string? completeTreatmentId,
+                DateTime? completedAt, CancellationToken _) =>
+            {
+                _completed.Add((instanceId, reason, completedAt, completeTreatmentId));
+
+                var instance = _activeByDefinition.Values
+                    .SelectMany(list => list)
+                    .First(i => i.Id == instanceId);
+
+                instance.CompletedAt = completedAt ?? DateTime.UtcNow;
+                instance.CompletionReason = reason;
+                _activeByDefinition[instance.DefinitionId] =
+                    [.. _activeByDefinition[instance.DefinitionId].Where(i => i.Id != instanceId)];
+                return instance;
+            });
+
+        _sut = new TrackerTriggerService(
+            _repository.Object,
+            _broadcast.Object,
+            NullLogger<TrackerTriggerService>.Instance);
+    }
+
+    private TrackerDefinitionEntity GivenDefinition(
+        string[]? triggerEventTypes = null,
+        int? lifespanHours = 72,
+        TrackerMode mode = TrackerMode.Duration,
+        string userId = "definition-owner",
+        string? triggerNotesContains = null)
+    {
+        var definition = new TrackerDefinitionEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = "Infusion Site",
+            UserId = userId,
+            LifespanHours = lifespanHours,
+            Mode = mode,
+            TriggerNotesContains = triggerNotesContains,
+            TriggerEventTypes = JsonSerializer.Serialize(triggerEventTypes ?? ["Site Change"]),
+        };
+        _definitions.Add(definition);
+        return definition;
+    }
+
+    private TrackerInstanceEntity GivenActiveInstance(
+        TrackerDefinitionEntity definition, DateTime startedAt, string? startTreatmentId = null)
+    {
+        var instance = new TrackerInstanceEntity
+        {
+            Id = Guid.NewGuid(),
+            DefinitionId = definition.Id,
+            UserId = definition.UserId,
+            StartedAt = startedAt,
+            StartTreatmentId = startTreatmentId,
+        };
+        _activeByDefinition[definition.Id] = [instance];
+        return instance;
+    }
+
+    private static DeviceEvent Event(
+        DateTime timestamp,
+        DeviceEventType eventType = DeviceEventType.SiteChange,
+        string? notes = null) =>
+        new() { Id = Guid.NewGuid(), Timestamp = timestamp, EventType = eventType, Notes = notes };
+
+    [Fact]
+    public async Task SiteChange_StartsAnInstance_WhenNoneIsRunning()
+    {
+        var definition = GivenDefinition();
+        var deviceEvent = Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc));
+
+        await _sut.OnCreatedAsync([deviceEvent]);
+
+        _started.Should().ContainSingle();
+        _started[0].DefinitionId.Should().Be(definition.Id);
+        _started[0].StartedAt.Should().Be(deviceEvent.Timestamp);
+        _started[0].StartTreatmentId.Should().Be(deviceEvent.Id.ToString());
+        _completed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SiteChange_CompletesTheRunningInstance_BeforeStartingTheNext()
+    {
+        var definition = GivenDefinition(lifespanHours: 72);
+        var running = GivenActiveInstance(definition, new DateTime(2026, 9, 7, 7, 11, 50, DateTimeKind.Utc));
+        var deviceEvent = Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc));
+
+        await _sut.OnCreatedAsync([deviceEvent]);
+
+        _completed.Should().ContainSingle();
+        _completed[0].InstanceId.Should().Be(running.Id);
+        _completed[0].CompletedAt.Should().Be(deviceEvent.Timestamp);
+        _completed[0].CompleteTreatmentId.Should().Be(deviceEvent.Id.ToString());
+        _started.Should().ContainSingle();
+        _started[0].StartedAt.Should().Be(deviceEvent.Timestamp);
+    }
+
+    [Fact]
+    public async Task RunningPastItsLifespan_CompletesAsExpired()
+    {
+        var definition = GivenDefinition(lifespanHours: 72);
+        GivenActiveInstance(definition, new DateTime(2026, 9, 7, 7, 11, 50, DateTimeKind.Utc));
+
+        // 99.5 hours later — past the 72h term.
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc))]);
+
+        _completed.Should().ContainSingle().Which.Reason.Should().Be(CompletionReason.Expired);
+    }
+
+    [Fact]
+    public async Task SwappedBeforeItsLifespan_CompletesAsReplacedEarly()
+    {
+        var definition = GivenDefinition(lifespanHours: 72);
+        GivenActiveInstance(definition, new DateTime(2026, 9, 1, 4, 14, 50, DateTimeKind.Utc));
+
+        // 50.3 hours later — short of the 72h term.
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 3, 6, 32, 50, DateTimeKind.Utc))]);
+
+        _completed.Should().ContainSingle().Which.Reason.Should().Be(CompletionReason.ReplacedEarly);
+    }
+
+    [Fact]
+    public async Task DefinitionWithoutALifespan_CompletesAsPlainCompleted()
+    {
+        var definition = GivenDefinition(lifespanHours: null);
+        GivenActiveInstance(definition, new DateTime(2026, 9, 1, 4, 14, 50, DateTimeKind.Utc));
+
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 3, 6, 32, 50, DateTimeKind.Utc))]);
+
+        _completed.Should().ContainSingle().Which.Reason.Should().Be(CompletionReason.Completed);
+    }
+
+    [Fact]
+    public async Task NewInstance_IsOwnedByTheDefinitionOwner()
+    {
+        GivenDefinition(userId: "someone-else");
+
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc))]);
+
+        // A connector-ingested event carries no user, so ownership can only come from the definition.
+        _started.Should().ContainSingle().Which.UserId.Should().Be("someone-else");
+    }
+
+    [Fact]
+    public async Task EventOlderThanTheRunningInstance_IsIgnored()
+    {
+        var definition = GivenDefinition();
+        GivenActiveInstance(definition, new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc));
+
+        // A connector backfilling its window re-delivers older changes; acting on one would rewind
+        // the tracker to a site that has already been replaced.
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 7, 7, 11, 50, DateTimeKind.Utc))]);
+
+        _started.Should().BeEmpty();
+        _completed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EventAlreadyStartedAnInstance_IsIgnoredOnRedelivery()
+    {
+        var definition = GivenDefinition();
+        var deviceEvent = Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc));
+        GivenActiveInstance(definition, deviceEvent.Timestamp, startTreatmentId: deviceEvent.Id.ToString());
+
+        await _sut.OnCreatedAsync([deviceEvent]);
+
+        _started.Should().BeEmpty();
+        _completed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BatchOfChanges_ChainsInTimestampOrder()
+    {
+        var definition = GivenDefinition(lifespanHours: 72);
+        var first = Event(new DateTime(2026, 9, 3, 6, 32, 50, DateTimeKind.Utc));
+        var second = Event(new DateTime(2026, 9, 7, 7, 11, 50, DateTimeKind.Utc));
+        var third = Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc));
+
+        // Delivered newest-first, as a connector page arrives.
+        await _sut.OnCreatedAsync([third, first, second]);
+
+        _started.Select(i => i.StartedAt).Should().Equal(first.Timestamp, second.Timestamp, third.Timestamp);
+        _completed.Select(c => c.CompletedAt).Should().Equal(second.Timestamp, third.Timestamp);
+        _activeByDefinition[definition.Id].Should().ContainSingle()
+            .Which.StartedAt.Should().Be(third.Timestamp);
+    }
+
+    [Fact]
+    public async Task EventTypeTheDefinitionDoesNotTrigger_On_IsIgnored()
+    {
+        GivenDefinition(triggerEventTypes: ["Site Change"]);
+
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc), DeviceEventType.SensorStart)]);
+
+        _started.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EventModeDefinition_IsNotTriggered()
+    {
+        // Event-mode instances need a ScheduledAt that a device event cannot supply.
+        GivenDefinition(mode: TrackerMode.Event);
+
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc))]);
+
+        _started.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TriggerNotesFilter_AdmitsOnlyMatchingEvents()
+    {
+        GivenDefinition(triggerNotesContains: "left arm");
+
+        await _sut.OnCreatedAsync([
+            Event(new DateTime(2026, 9, 7, 7, 11, 50, DateTimeKind.Utc), notes: "right thigh"),
+            Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc), notes: "Left Arm, no bleeding"),
+        ]);
+
+        _started.Should().ContainSingle()
+            .Which.StartedAt.Should().Be(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task SeveralDefinitionsTriggeringOnTheSameEvent_AllAdvance()
+    {
+        var site = GivenDefinition(triggerEventTypes: ["Site Change"], userId: "owner-a");
+        var cannula = GivenDefinition(triggerEventTypes: ["Site Change"], userId: "owner-b");
+
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc))]);
+
+        _started.Select(i => i.DefinitionId).Should().BeEquivalentTo([site.Id, cannula.Id]);
+    }
+
+    [Fact]
+    public async Task TriggerListNamingSomethingThatIsNotADeviceEvent_IsDropped()
+    {
+        GivenDefinition(triggerEventTypes: ["Meal Bolus", "Correction Bolus"]);
+
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc))]);
+
+        _started.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MalformedTriggerList_IsIgnoredWithoutThrowing()
+    {
+        var definition = GivenDefinition();
+        definition.TriggerEventTypes = "{not json";
+
+        var act = async () => await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc))]);
+
+        await act.Should().NotThrowAsync();
+        _started.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task NoDeviceEvents_TouchesNothing()
+    {
+        GivenDefinition();
+
+        await _sut.OnCreatedAsync([]);
+
+        _repository.Verify(r => r.GetAllDefinitionsAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _started.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TriggerIsRegisteredAsTheDeviceEventReactor()
+    {
+        // Nothing else resolves the trigger, so this registration is the whole mechanism by which it
+        // runs; unregistered, trackers stop advancing with no other symptom.
+        var services = new ServiceCollection().AddDomainServices();
+
+        var descriptor = services.Should()
+            .ContainSingle(d => d.ServiceType == typeof(IDeviceEventReactor)).Subject;
+
+        descriptor.ImplementationType.Should().Be<TrackerTriggerService>();
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public async Task AdvancingATracker_BroadcastsTheCompletionAndTheNewInstance()
+    {
+        var definition = GivenDefinition();
+        GivenActiveInstance(definition, new DateTime(2026, 9, 7, 7, 11, 50, DateTimeKind.Utc));
+
+        await _sut.OnCreatedAsync([Event(new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc))]);
+
+        _broadcast.Verify(b => b.BroadcastTrackerUpdateAsync("complete", It.IsAny<object>()), Times.Once);
+        _broadcast.Verify(b => b.BroadcastTrackerUpdateAsync("create", It.IsAny<object>()), Times.Once);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceEventRepositoryReactorTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceEventRepositoryReactorTests.cs
@@ -1,0 +1,160 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Covers the <see cref="IDeviceEventReactor"/> hook on the device-event write chokepoint, which is what
+/// makes a site or sensor change advance its tracker. Placing it at the repository rather than at a
+/// controller is the point: connector ingest reaches device events through the decomposer and never
+/// touches the V4 REST surface, so these tests pin the seam that both paths share.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+[Trait("Category", "DeviceEvent")]
+public class DeviceEventRepositoryReactorTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000004");
+
+    private readonly SqliteTestDatabase _db;
+    private readonly NocturneDbContext _context;
+    private readonly RecordingReactor _reactor = new();
+    private readonly DeviceEventRepository _repo;
+
+    public DeviceEventRepositoryReactorTests()
+    {
+        _db = TestDbContextFactory.CreateSqliteWithTenant(TestTenantId);
+        _context = _db.CreateContext();
+
+        _repo = new DeviceEventRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<DeviceEventRepository>.Instance,
+            broadcaster: null,
+            reactor: _reactor);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static DeviceEvent NewEvent(DeviceEventType eventType = DeviceEventType.SiteChange) => new()
+    {
+        Id = Guid.NewGuid(),
+        Timestamp = new DateTime(2026, 9, 11, 10, 43, 30, DateTimeKind.Utc),
+        EventType = eventType,
+    };
+
+    [Fact]
+    public async Task LiveCreate_FiresTheReactor()
+    {
+        var model = NewEvent();
+
+        await _repo.CreateAsync(model, WriteOrigin.Live);
+
+        _reactor.Created.Should().ContainSingle().Which.EventType.Should().Be(DeviceEventType.SiteChange);
+    }
+
+    [Fact]
+    public async Task BackfillCreate_DoesNotFireTheReactor()
+    {
+        // A Nightscout migration replays years of site changes; advancing a tracker for each would
+        // leave it on whichever one happened to land last.
+        await _repo.CreateAsync(NewEvent(), WriteOrigin.Backfill);
+
+        _reactor.Created.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BulkLiveCreate_FiresTheReactorOnceWithEveryEvent()
+    {
+        var events = new[]
+        {
+            NewEvent(),
+            NewEvent(DeviceEventType.SensorChange),
+        };
+
+        await _repo.BulkCreateAsync(events, WriteOrigin.Live);
+
+        _reactor.Invocations.Should().Be(1);
+        _reactor.Created.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task BulkBackfillCreate_DoesNotFireTheReactor()
+    {
+        await _repo.BulkCreateAsync([NewEvent(), NewEvent(DeviceEventType.SensorChange)], WriteOrigin.Backfill);
+
+        _reactor.Created.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReactorFailure_DoesNotFailTheWrite()
+    {
+        var repo = new DeviceEventRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<DeviceEventRepository>.Instance,
+            broadcaster: null,
+            reactor: new ThrowingReactor());
+
+        var model = NewEvent();
+
+        // The event is already committed by the time the reaction runs, so a tracker that fails to
+        // advance must not take the ingest of the underlying record down with it.
+        var act = async () => await repo.CreateAsync(model, WriteOrigin.Live);
+
+        await act.Should().NotThrowAsync();
+        (await repo.GetByIdAsync(model.Id)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task NoReactorWired_LeavesTheWritePathIntact()
+    {
+        var repo = new DeviceEventRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<DeviceEventRepository>.Instance);
+
+        var model = NewEvent();
+
+        await repo.CreateAsync(model, WriteOrigin.Live);
+
+        (await repo.GetByIdAsync(model.Id)).Should().NotBeNull();
+    }
+
+    private sealed class RecordingReactor : IDeviceEventReactor
+    {
+        public List<DeviceEvent> Created { get; } = [];
+        public int Invocations { get; private set; }
+
+        public Task OnCreatedAsync(IReadOnlyList<DeviceEvent> created, CancellationToken ct = default)
+        {
+            Invocations++;
+            Created.AddRange(created);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingReactor : IDeviceEventReactor
+    {
+        public Task OnCreatedAsync(IReadOnlyList<DeviceEvent> created, CancellationToken ct = default) =>
+            throw new InvalidOperationException("tracker repository unavailable");
+    }
+}


### PR DESCRIPTION
## What was wrong

Tracker instances stopped being created automatically when the monolithic V4 `TreatmentsController` was split into typed controllers. That controller injected `ITrackerTriggerService` and called it on create; the call was not carried over, leaving the service registered but resolved by nothing.

Since then a site or sensor change has left its tracker untouched. Nothing looked broken from the alert side: with no active instance the `tracker_age` leaf evaluates false by design, so the managed rules stayed correctly silent. `ITrackerSuggestionService.EvaluateTreatmentForTrackerSuggestionAsync` lost its caller in the same change and is still dead — deliberately left alone here, since auto-start and suggest-to-start would otherwise both fire on the same event.

## Why the fix is not just restoring the call

Connector ingest reaches device events through `ITreatmentDecomposer` and never touches the V4 REST surface, so a controller-level hook fires for hand-entered events only — which is the minority of them.

The trigger now runs from the V4 device-event write chokepoint through a new `IDeviceEventReactor` driven port, alongside the realtime broadcast and the legacy entry projection, and shares their `WriteOrigin.Live` gate so a migration or replay import never retroactively advances a tracker. That covers REST writes, connector ingest, and legacy v1/v3 uploads through one seam.

## Ownership

The trigger works from `DeviceEvent` rather than `Treatment`, which settles the other half of the problem. The old code took a `userId` from the caller and looked up that user's definitions — unusable on the connector path, which carries no user. It now matches definitions tenant-wide and attributes the new instance to the definition's owner. A device event is a fact about the tenant's hardware, and the managed alert rules trackers sync are already tenant-visible, so this is consistent with how the rest of the tracker/alert system already treats them.

## Behaviour the rewrite adds

All of it only reachable now that the trigger runs at all:

- **Redelivery and backfill guards.** Connectors re-publish a moving window, so an event that already started an instance is skipped, and one dated at or before the running instance is treated as history rather than rewinding the tracker to a consumable already replaced.
- **Completion reasons** are classified `Expired` or `ReplacedEarly` against the definition's lifespan instead of always `Completed`, matching how the history surface reads them.
- **`TriggerNotesContains`** is honoured; it was parsed off the definition but never applied.
- **Event-mode definitions are skipped**, since `StartInstanceAsync` requires a `ScheduledAt` no device event can supply.
- **The completion broadcast** carries the completed instance under the `complete` action; it previously sent the stale pre-completion entity as an `update`, so subscribers saw a completion with `completedAt` still null.

A batch is processed oldest-first, so several changes for one tracker arriving together chain correctly rather than racing.

## Tests

- `TrackerTriggerServiceTests` (18) — matching, ownership, both guards, batch chaining, reason classification, the notes filter, event-mode exclusion, malformed trigger JSON, and that the trigger is registered as the reactor. That last one is the mechanism the original bug removed.
- `DeviceEventRepositoryReactorTests` (6) — the chokepoint itself: single and bulk live creates fire the reaction, backfill creates do not, a throwing reaction does not fail the committed write, and an unwired reactor leaves the write path intact.

Full unit suites green: 6830 API, 1033 Infrastructure. No new project references, and `tilth check_boundaries` reports no violations.

## Note for review

The reaction runs post-commit on the ambient scoped context, not in the write's transaction. A tracker that fails to advance is logged and swallowed rather than failing ingest of the underlying device event — derived state that can be rebuilt is not worth losing a reading over. Worth a second opinion on whether that is the tradeoff you want.
