### PR TITLE
feat(glooko): ingest CGM sensor changes from the v3 graph

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
@@ -211,7 +211,7 @@ public static class GlookoConstants
     [
         "automaticBolus", "deliveredBolus", "injectionBolus",
         "gkInsulinBasal", "gkInsulinBolus",
-        "pumpAlarm", "reservoirChange", "setSiteChange",
+        "pumpAlarm", "reservoirChange", "setSiteChange", "cgmSensorChange",
         "carbAll", "scheduledBasal", "temporaryBasal",
         "suspendBasal", "lgsPlgs", "profileChange",
         "bgHigh", "bgNormal", "bgLow",

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoV4TreatmentMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoV4TreatmentMapper.cs
@@ -446,8 +446,8 @@ public class GlookoV4TreatmentMapper(string connectorSource, GlookoTimeMapper ti
     }
 
     /// <summary>
-    /// Maps V3 consumable change series (ReservoirChange, SetSiteChange) to DeviceEvent records.
-    /// PumpAlarms are skipped here — they are handled by GlookoSystemEventMapper.
+    /// Maps V3 consumable change series (ReservoirChange, SetSiteChange, CgmSensorChange) to DeviceEvent
+    /// records. PumpAlarms are skipped here — they are handled by GlookoSystemEventMapper.
     /// </summary>
     public List<DeviceEvent> MapV3DeviceEvents(GlookoV3GraphResponse graphData)
     {
@@ -458,71 +458,63 @@ public class GlookoV4TreatmentMapper(string connectorSource, GlookoTimeMapper ti
 
         var series = graphData.Series;
 
-        if (series.ReservoirChange != null)
-        {
-            foreach (var change in series.ReservoirChange)
-            {
-                try
-                {
-                    var rawTimestamp = DateTimeOffset.FromUnixTimeSeconds(change.X).UtcDateTime;
-                    var correctedTimestamp = _timeMapper.GetCorrectedGlookoTime(change.X);
-                    var now = DateTime.UtcNow;
-
-                    deviceEvents.Add(new DeviceEvent
-                    {
-                        Id = Guid.CreateVersion7(),
-                        Timestamp = correctedTimestamp,
-                        LegacyId = GenerateLegacyId("reservoir_change", rawTimestamp),
-                        Device = _connectorSource,
-                        DataSource = _connectorSource,
-                        EventType = DeviceEventType.ReservoirChange,
-                        Notes = change.Label,
-                        CreatedAt = now,
-                        ModifiedAt = now
-                    });
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "[{ConnectorSource}] Error mapping V3 reservoir change at X={X}", _connectorSource, change.X);
-                }
-            }
-        }
-
-        if (series.SetSiteChange != null)
-        {
-            foreach (var change in series.SetSiteChange)
-            {
-                try
-                {
-                    var rawTimestamp = DateTimeOffset.FromUnixTimeSeconds(change.X).UtcDateTime;
-                    var correctedTimestamp = _timeMapper.GetCorrectedGlookoTime(change.X);
-                    var now = DateTime.UtcNow;
-
-                    deviceEvents.Add(new DeviceEvent
-                    {
-                        Id = Guid.CreateVersion7(),
-                        Timestamp = correctedTimestamp,
-                        LegacyId = GenerateLegacyId("site_change", rawTimestamp),
-                        Device = _connectorSource,
-                        DataSource = _connectorSource,
-                        EventType = DeviceEventType.SiteChange,
-                        Notes = change.Label,
-                        CreatedAt = now,
-                        ModifiedAt = now
-                    });
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "[{ConnectorSource}] Error mapping V3 site change at X={X}", _connectorSource, change.X);
-                }
-            }
-        }
+        // The legacy-id kind is the series' own identity, not the DeviceEventType name: it is hashed into
+        // the dedup key, so changing it would orphan every event already stored under the old spelling.
+        MapV3ConsumableSeries(series.ReservoirChange, DeviceEventType.ReservoirChange, "reservoir_change", deviceEvents);
+        MapV3ConsumableSeries(series.SetSiteChange, DeviceEventType.SiteChange, "site_change", deviceEvents);
+        MapV3ConsumableSeries(series.CgmSensorChange, DeviceEventType.SensorChange, "sensor_change", deviceEvents);
 
         _logger.LogInformation(
             "[{ConnectorSource}] Transformed {Count} device events from v3 data",
             _connectorSource, deviceEvents.Count);
 
         return deviceEvents;
+    }
+
+    /// <summary>
+    /// Appends one <see cref="DeviceEvent"/> per point of a v3 consumable-change series. The three series
+    /// share a point shape and differ only in the event type they carry, so one pass covers all of them.
+    /// </summary>
+    /// <param name="points">The series' points, or <c>null</c> when Glooko returned no such series.</param>
+    /// <param name="eventType">The device event type the series represents.</param>
+    /// <param name="legacyKind">Series identity hashed into the dedup key — see the call site.</param>
+    /// <param name="into">Accumulator the mapped events are appended to.</param>
+    private void MapV3ConsumableSeries(
+        GlookoV3ConsumableDataPoint[]? points,
+        DeviceEventType eventType,
+        string legacyKind,
+        List<DeviceEvent> into)
+    {
+        if (points == null)
+            return;
+
+        foreach (var change in points)
+        {
+            try
+            {
+                var rawTimestamp = DateTimeOffset.FromUnixTimeSeconds(change.X).UtcDateTime;
+                var correctedTimestamp = _timeMapper.GetCorrectedGlookoTime(change.X);
+                var now = DateTime.UtcNow;
+
+                into.Add(new DeviceEvent
+                {
+                    Id = Guid.CreateVersion7(),
+                    Timestamp = correctedTimestamp,
+                    LegacyId = GenerateLegacyId(legacyKind, rawTimestamp),
+                    Device = _connectorSource,
+                    DataSource = _connectorSource,
+                    EventType = eventType,
+                    Notes = change.Label,
+                    CreatedAt = now,
+                    ModifiedAt = now
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[{ConnectorSource}] Error mapping V3 {EventType} at X={X}",
+                    _connectorSource, eventType, change.X);
+            }
+        }
     }
 
     // ── V3 Histories: Meals → CarbIntake + ConnectorFoodEntryImport ────

--- a/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3Models.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3Models.cs
@@ -82,6 +82,12 @@ public class GlookoV3Series
 
     [JsonPropertyName("setSiteChange")] public GlookoV3ConsumableDataPoint[]? SetSiteChange { get; set; }
 
+    /// <summary>
+    ///     CGM sensor changes. Glooko only carries these for uploaders that report sensor lifecycle;
+    ///     a CamAPS FX / Libre 3 account returns the series empty rather than omitting it.
+    /// </summary>
+    [JsonPropertyName("cgmSensorChange")] public GlookoV3ConsumableDataPoint[]? CgmSensorChange { get; set; }
+
     // LGS/PLGS events (Low Glucose Suspend / Predictive LGS)
     [JsonPropertyName("lgsPlgs")] public GlookoV3LgsPlgsDataPoint[]? LgsPlgs { get; set; }
 

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -1579,7 +1579,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                     + "GkInsulinBasal={GkBasal}, GkInsulinBolus={GkBolus}, "
                     + "CarbAll={Carbs}, "
                     + "ScheduledBasal={SchedBasal}, TemporaryBasal={TempBasal}, SuspendBasal={Suspend}, LgsPlgs={LgsPlgs}, "
-                    + "PumpAlarm={Alarms}, ReservoirChange={Reservoir}, SetSiteChange={SetSite}, ProfileChange={Profile}",
+                    + "PumpAlarm={Alarms}, ReservoirChange={Reservoir}, SetSiteChange={SetSite}, "
+                    + "CgmSensorChange={SensorChange}, ProfileChange={Profile}",
                     ConnectorSource,
                     (s.CgmHigh?.Length ?? 0) + (s.CgmNormal?.Length ?? 0) + (s.CgmLow?.Length ?? 0),
                     (s.BgHigh?.Length ?? 0) + (s.BgNormal?.Length ?? 0) + (s.BgLow?.Length ?? 0),
@@ -1596,6 +1597,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                     s.PumpAlarm?.Length ?? 0,
                     s.ReservoirChange?.Length ?? 0,
                     s.SetSiteChange?.Length ?? 0,
+                    s.CgmSensorChange?.Length ?? 0,
                     s.ProfileChange?.Length ?? 0);
             }
 

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoV4TreatmentMapperV3DeviceEventTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoV4TreatmentMapperV3DeviceEventTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Mappers;
+using Nocturne.Connectors.Glooko.Models;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Mappers;
+
+/// <summary>
+/// Covers the v3 consumable-change series, which share a point shape and one mapping pass. The
+/// sensor-change series is the one a tracker needs to advance a CGM tracker automatically; it is
+/// only populated for uploaders that report sensor lifecycle, so the empty and absent cases matter
+/// as much as the populated one.
+/// </summary>
+[Trait("Category", "Unit")]
+public class GlookoV4TreatmentMapperV3DeviceEventTests
+{
+    private readonly GlookoV4TreatmentMapper _mapper;
+
+    public GlookoV4TreatmentMapperV3DeviceEventTests()
+    {
+        var logger = Mock.Of<ILogger>();
+        var config = new GlookoConnectorConfiguration();
+        var timeMapper = new GlookoTimeMapper(config, logger);
+        _mapper = new GlookoV4TreatmentMapper("glooko-connector", timeMapper, logger);
+    }
+
+    private static GlookoV3GraphResponse BuildGraphData(
+        GlookoV3ConsumableDataPoint[]? reservoirChange = null,
+        GlookoV3ConsumableDataPoint[]? setSiteChange = null,
+        GlookoV3ConsumableDataPoint[]? cgmSensorChange = null) =>
+        new()
+        {
+            Series = new GlookoV3Series
+            {
+                ReservoirChange = reservoirChange,
+                SetSiteChange = setSiteChange,
+                CgmSensorChange = cgmSensorChange,
+            }
+        };
+
+    private static GlookoV3ConsumableDataPoint Point(long x, string? label = null) =>
+        new() { X = x, Label = label };
+
+    [Fact]
+    public void CgmSensorChange_MapsToSensorChangeDeviceEvent()
+    {
+        var graphData = BuildGraphData(cgmSensorChange: [Point(1781813092, "Sensor change")]);
+
+        var events = _mapper.MapV3DeviceEvents(graphData);
+
+        events.Should().ContainSingle();
+        events[0].EventType.Should().Be(DeviceEventType.SensorChange);
+        events[0].DataSource.Should().Be("glooko-connector");
+        events[0].Notes.Should().Be("Sensor change");
+        events[0].LegacyId.Should().StartWith("glooko_");
+    }
+
+    [Fact]
+    public void EachConsumableSeries_MapsToItsOwnEventType()
+    {
+        var graphData = BuildGraphData(
+            reservoirChange: [Point(1781813092)],
+            setSiteChange: [Point(1781813093)],
+            cgmSensorChange: [Point(1781813094)]);
+
+        var events = _mapper.MapV3DeviceEvents(graphData);
+
+        events.Select(e => e.EventType).Should().BeEquivalentTo([
+            DeviceEventType.ReservoirChange,
+            DeviceEventType.SiteChange,
+            DeviceEventType.SensorChange,
+        ]);
+    }
+
+    [Fact]
+    public void SeriesSharingAnInstant_GetDistinctLegacyIds()
+    {
+        // The legacy id is the dedup key, and it is hashed from the series kind plus the timestamp —
+        // so three changes logged at the same instant must not collapse into one stored event.
+        var graphData = BuildGraphData(
+            reservoirChange: [Point(1781813092)],
+            setSiteChange: [Point(1781813092)],
+            cgmSensorChange: [Point(1781813092)]);
+
+        var events = _mapper.MapV3DeviceEvents(graphData);
+
+        events.Select(e => e.LegacyId).Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void EmptySensorSeries_ProducesNoEvents()
+    {
+        // Glooko returns cgmSensorChange as an empty series for uploaders that never report sensor
+        // changes (CamAPS FX / Libre 3), rather than omitting it.
+        var graphData = BuildGraphData(cgmSensorChange: []);
+
+        _mapper.MapV3DeviceEvents(graphData).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AbsentSensorSeries_ProducesNoEvents()
+    {
+        var graphData = BuildGraphData(reservoirChange: [Point(1781813092)]);
+
+        var events = _mapper.MapV3DeviceEvents(graphData);
+
+        events.Should().ContainSingle().Which.EventType.Should().Be(DeviceEventType.ReservoirChange);
+    }
+
+    [Fact]
+    public void SensorChangeSeries_IsRequestedFromTheV3Graph()
+    {
+        // A mapping with no matching request is inert — the series has to be asked for by name.
+        GlookoConstants.V3GraphSeries.Should().Contain("cgmSensorChange");
+    }
+}


### PR DESCRIPTION
## What was missing

`GlookoConstants.V3GraphSeries` asked for `reservoirChange` and `setSiteChange` but nothing sensor-related, and `GlookoV4TreatmentMapper.MapV3DeviceEvents` had no sensor branch — so a Glooko account that does report sensor changes had them dropped before they became a `DeviceEvent`. `GlookoPumpEventMapper.MapEventType` (the SSV2 path) has no sensor kinds either, though SSV2's `pumps/events` is pump-only by design, so that one is correct as-is.

Checked against stored data rather than assumed: across 13 tenants and ~20 months, the Glooko connector has produced exactly two event types — `ReservoirChange` (1408) and `SiteChange` (1114) — and never a `Sensor*` event. Sensor events in the platform all arrive via the Nightscout and tconnectsync connectors.

## Why `cgmSensorChange`

The v3 graph endpoint silently drops series names it does not know, which makes it a usable oracle. Probing a live account with 18 candidate spellings returned exactly one — `cgmSensorChange` — alongside the `reservoirChange` control, and dropped the other 17 (`sensorChange`, `sensorStart`, `cgmSensorStart`, `sensorInsertion`, …). So the name is real and this is the series to ask for.

It is now requested and mapped to `DeviceEventType.SensorChange`, which lets a Sensor-category tracker advance on its own for uploaders that report sensor lifecycle.

## Shape of the change

The three consumable-change series share a point shape (`GlookoV3ConsumableDataPoint`) and differed only in the event type they carry. Rather than adding a third near-identical loop, the two existing ones are folded into a single `MapV3ConsumableSeries` pass — net fewer lines despite the added series.

One thing worth not getting wrong on review: the legacy-id kind string stays the series' own spelling (`"reservoir_change"`, `"site_change"`) rather than being derived from the `DeviceEventType` name. It is hashed into the dedup key, so changing it would orphan every event already stored under the old spelling.

## Honest limitation

**Not verified end-to-end against real sensor data.** The account probed uploads a FreeStyle Libre 3 through CamAPS FX, which reports glucose but no sensor lifecycle: `cgmSensorChange` comes back empty over 730 days while `reservoirChange` returns 233 points in the same window. So this is verified to be the correct series name and the correct request, but the populated-path mapping rests on the series sharing the consumable point shape its siblings use — which is why it reuses their model rather than introducing a new one.

If anyone has a Glooko account fed by Dexcom or Medtronic, a single sync would confirm the populated path.

## Tests

6 new in `GlookoV4TreatmentMapperV3DeviceEventTests`: the sensor mapping itself, each series landing on its own event type, distinct legacy ids when all three share an instant (the dedup-key case), the empty-series case (what a CamAPS account actually returns), the absent-series case, and that `cgmSensorChange` is actually in the requested series list — a mapping with no matching request would be inert.

Glooko suite green at 262; full solution builds clean.
