### PR TITLE
fix(reports): color only the focused band in the year overview

### DIFF
--- a/src/Web/packages/app/src/app.css
+++ b/src/Web/packages/app/src/app.css
@@ -114,6 +114,7 @@
     --border: #d1d5db;
     --glucose-heatmap-1: #000;
     --glucose-heatmap-2: var(--glucose-heatmap-1);
+    --glucose-heatmap-outside: #e5e7eb;
     background: #fff;
     color: #111;
   }

--- a/src/Web/packages/app/src/app.css
+++ b/src/Web/packages/app/src/app.css
@@ -114,7 +114,7 @@
     --border: #d1d5db;
     --glucose-heatmap-1: #000;
     --glucose-heatmap-2: var(--glucose-heatmap-1);
-    --glucose-heatmap-outside: #e5e7eb;
+    --glucose-heatmap-outside: #cdc4de;
     background: #fff;
     color: #111;
   }

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.svelte
@@ -109,14 +109,22 @@
   const accessibleLabel = (index: number) =>
     `${metricLabel} ${labels[index]} color ${glucose ? "boundary" : "value"}`;
 
-  // On an automatic range `values` tracks the observed maximum, which every lazily loaded
-  // year can raise; rewriting an unchanged draft would discard an edit in progress.
+  // Every preference write re-derives `thresholds` into a fresh array holding the same
+  // numbers, and an automatic range tracks a maximum that rises as years load. Resync per
+  // field so neither discards an edit in a field whose committed value did not move.
   $effect(() => {
     const committed = values.map(display);
     untrack(() => {
-      if (committed.every((value, index) => value === drafts[index])) return;
-      drafts = committed;
-      invalidBound = null;
+      if (drafts.length !== committed.length) {
+        drafts = committed;
+        invalidBound = null;
+        return;
+      }
+      committed.forEach((value, index) => {
+        if (drafts[index] === value) return;
+        drafts[index] = value;
+        if (invalidBound === index) invalidBound = null;
+      });
     });
   });
 
@@ -150,14 +158,19 @@
       invalidBound = index;
       return;
     }
-    if (input.valueAsNumber === display(values[index])) {
+    const entered = glucose
+      ? convertFromDisplayUnits(input.valueAsNumber, units)
+      : input.valueAsNumber;
+    // A sub-step entry can round onto the boundary already held. Nothing is persisted, so
+    // `values` never moves and the effect above never fires: put the input back itself,
+    // or it keeps showing a number that was not stored.
+    if (entered === values[index]) {
+      drafts[index] = display(values[index]);
       invalidBound = null;
       return;
     }
     const next = [...values];
-    next[index] = glucose
-      ? convertFromDisplayUnits(input.valueAsNumber, units)
-      : input.valueAsNumber;
+    next[index] = entered;
     invalidBound = change(next) ? null : index;
   }
 
@@ -200,7 +213,7 @@
           class="h-3.5 w-full rounded-sm"
           style:background={gradient}
           role="img"
-          aria-label={`${metricLabel} color scale from ${formatted(minimum)} to ${formatted(maximum)} ${unitLabel}`}
+          aria-label={`${metricLabel} color scale over ${formatted(values[0])} to ${formatted(values[values.length - 1])} ${unitLabel}, one color outside it`}
           data-testid={glucose ? "glucose-color-track" : "color-focus-track"}
         ></span>
         {#each thumbItems as thumb (thumb.index)}

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.svelte
@@ -11,6 +11,7 @@
   } from "$lib/utils/formatting";
   import {
     colorFocusGradient,
+    glucoseColorFocusGradient,
     resolveColorFocusRange,
     resolveGlucoseColorThresholds,
     DEFAULT_GLUCOSE_COLOR_THRESHOLDS,
@@ -20,6 +21,8 @@
     type ColorFocusRange,
     type GlucoseColorThresholds,
   } from "$lib/utils/metric-color-focus";
+  import { GLUCOSE_HEATMAP_LEGEND_STOPS } from "$lib/utils/chart-colors";
+  import { untrack } from "svelte";
 
   let {
     metricLabel = "Average glucose",
@@ -32,7 +35,7 @@
     glucose = false,
     units = "mg/dl",
     thresholds = DEFAULT_GLUCOSE_COLOR_THRESHOLDS,
-    stops = [],
+    stops = GLUCOSE_HEATMAP_LEGEND_STOPS,
     onThresholdsChange = () => {},
   }: {
     metricLabel?: string;
@@ -70,7 +73,7 @@
   const inputStep = $derived(glucose ? (units === "mmol" ? 0.1 : 1) : "any");
   const gradient = $derived(
     glucose
-      ? `linear-gradient(to right in srgb, ${stops.map((stop) => `${stop.color} ${((stop.mgdl - minimum) / (maximum - minimum)) * 100}%`).join(", ")})`
+      ? glucoseColorFocusGradient(stops, thresholds, minimum, maximum)
       : colorFocusGradient(resolveColorFocusRange(values)!, maximum, cssVar)
   );
   const baseSliderSteps = $derived.by(() => {
@@ -106,12 +109,26 @@
   const accessibleLabel = (index: number) =>
     `${metricLabel} ${labels[index]} color ${glucose ? "boundary" : "value"}`;
 
+  // On an automatic range `values` tracks the observed maximum, which every lazily loaded
+  // year can raise; rewriting an unchanged draft would discard an edit in progress.
   $effect(() => {
-    drafts = values.map(display);
-    invalidBound = null;
+    const committed = values.map(display);
+    untrack(() => {
+      if (committed.every((value, index) => value === drafts[index])) return;
+      drafts = committed;
+      invalidBound = null;
+    });
   });
 
   function change(candidate: number[]): boolean {
+    // Bits UI re-runs its snap check on every flush, because the getter below hands it a
+    // fresh array each read; its re-offer of the held value must not persist.
+    if (
+      candidate.length === values.length &&
+      candidate.every((value, index) => value === values[index])
+    ) {
+      return true;
+    }
     if (glucose) {
       const next = resolveGlucoseColorThresholds(candidate);
       if (!next) return false;
@@ -278,17 +295,19 @@
       class="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 tabular-nums"
       aria-label="Glucose color zones"
     >
-      <span>Very low color: &lt; {formatted(values[0])}</span>
       <span>Low color: {formatted(values[0])}–{formatted(values[1])}</span>
       <span>In range color: {formatted(values[1])}–{formatted(values[2])}</span>
       <span>High color: {formatted(values[2])}–{formatted(values[3])}</span>
-      <span>Very high color: &gt; {formatted(values[3])} {unitLabel}</span>
+      <span>
+        One color outside {formatted(values[0])}–{formatted(values[3])}
+        {unitLabel}
+      </span>
     </div>
   {/if}
   <p id={id + "-description"} class="mt-2">
     {glucose
-      ? "Color scale only; glucose targets and Time in Range are unchanged. Controls reshape the continuous gradient."
-      : "Values outside the selected range use the end colors."}
+      ? "Color scale only; glucose targets and Time in Range are unchanged. Days below the first boundary and above the last share one color, so moving the boundaries inward colors only the middle of the scale."
+      : "Values outside the selected range share one faint color, so only the range you select is colored."}
   </p>
 </div>
 

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.svelte
@@ -121,10 +121,14 @@
         return;
       }
       committed.forEach((value, index) => {
-        if (drafts[index] === value) return;
-        drafts[index] = value;
-        if (invalidBound === index) invalidBound = null;
+        if (drafts[index] !== value) drafts[index] = value;
       });
+      if (
+        invalidBound !== null &&
+        drafts[invalidBound] === committed[invalidBound]
+      ) {
+        invalidBound = null;
+      }
     });
   });
 
@@ -213,7 +217,7 @@
           class="h-3.5 w-full rounded-sm"
           style:background={gradient}
           role="img"
-          aria-label={`${metricLabel} color scale over ${formatted(values[0])} to ${formatted(values[values.length - 1])} ${unitLabel}, one color outside it`}
+          aria-label={`${metricLabel} color scale from ${formatted(minimum)} to ${formatted(maximum)} ${unitLabel}, one color outside ${formatted(values[0])} to ${formatted(values[values.length - 1])}`}
           data-testid={glucose ? "glucose-color-track" : "color-focus-track"}
         ></span>
         {#each thumbItems as thumb (thumb.index)}

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -150,6 +150,20 @@ export function registerPreferenceCookieDomain(
   syncLanguageCookie(preferredLanguage.current);
 }
 
+/**
+ * A rejected write leaves the cookie ahead of the backend, so the next load reverts to the
+ * stored value; unreported, that surfaces as the preference undoing itself.
+ */
+function writeThroughReporting(prefs: UserDisplayPreferences): void {
+  try {
+    void Promise.resolve(writeThrough?.(prefs)).catch((error: unknown) => {
+      console.error("Failed to save display preferences:", error);
+    });
+  } catch (error) {
+    console.error("Failed to save display preferences:", error);
+  }
+}
+
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** Mirror to cookie immediately and debounce the backend write-through. */
@@ -160,11 +174,7 @@ function schedulePersist(): void {
   if (persistTimer) clearTimeout(persistTimer);
   persistTimer = setTimeout(() => {
     persistTimer = null;
-    // A rejected write leaves the cookie ahead of the backend, so the next load reverts to
-    // the stored value; unhandled in a timer, that surfaces as nothing at all.
-    void Promise.resolve(writeThrough?.(prefs)).catch((error: unknown) => {
-      console.error("Failed to save display preferences:", error);
-    });
+    writeThroughReporting(prefs);
   }, 400);
 }
 
@@ -663,7 +673,7 @@ export function reconcilePreferences(serverPrefs: UserDisplayPreferences | null 
     // uncustomized device never seeds all-defaults over another device's real preferences.
     const prefs = collectPreferences();
     writePrefsCookie(prefs);
-    writeThrough?.(prefs);
+    writeThroughReporting(prefs);
   }
 }
 

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -160,7 +160,11 @@ function schedulePersist(): void {
   if (persistTimer) clearTimeout(persistTimer);
   persistTimer = setTimeout(() => {
     persistTimer = null;
-    writeThrough?.(prefs);
+    // A rejected write leaves the cookie ahead of the backend, so the next load reverts to
+    // the stored value; unhandled in a timer, that surfaces as nothing at all.
+    void Promise.resolve(writeThrough?.(prefs)).catch((error: unknown) => {
+      console.error("Failed to save display preferences:", error);
+    });
   }, 400);
 }
 

--- a/src/Web/packages/app/src/lib/utils/chart-colors.ts
+++ b/src/Web/packages/app/src/lib/utils/chart-colors.ts
@@ -129,6 +129,13 @@ export const GLUCOSE_HEATMAP_LEGEND_STOPS: ReadonlyArray<{ mgdl: number; color: 
 	GLUCOSE_HEATMAP_STOPS.map(([mgdl, cssVar]) => ({ mgdl, color: `var(${cssVar})` }));
 
 /**
+ * Days outside the focused band. Not a ramp anchor: it recedes in both schemes, where
+ * `--glucose-heatmap-1` inverts to contrast with them, and drawing hyperglycaemia in the
+ * ramp's hypo colour would contradict the reading shown on the same cell.
+ */
+export const GLUCOSE_HEATMAP_OUTSIDE_COLOR = "var(--glucose-heatmap-outside)";
+
+/**
  * Blend the two heatmap stops bracketing `mgdl`, clamping outside the anchors.
  *
  * Mixes in sRGB rather than interpolating in JS so the stops can stay theme
@@ -144,6 +151,8 @@ export function getGlucoseHeatmapFill(
 	// Above every anchor (no match) or at/below the first one — clamp to an end stop.
 	if (upper === -1) return stops[stops.length - 1].color;
 	if (upper === 0) return stops[0].color;
+	// An exact anchor is its own colour; blending would nest a 0%-weighted mix of it.
+	if (stops[upper].mgdl === mgdl) return stops[upper].color;
 
 	const { mgdl: loAnchor, color: loColor } = stops[upper - 1];
 	const { mgdl: hiAnchor, color: hiColor } = stops[upper];

--- a/src/Web/packages/app/src/lib/utils/metric-color-focus.test.ts
+++ b/src/Web/packages/app/src/lib/utils/metric-color-focus.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   GLUCOSE_HEATMAP_LEGEND_STOPS,
+  GLUCOSE_HEATMAP_OUTSIDE_COLOR,
   getGlucoseHeatmapFill,
 } from "./chart-colors";
 import {
@@ -10,7 +11,6 @@ import {
   getFocusedGlucoseFill,
   insertSliderSteps,
   getFocusedIntensityFill,
-  outsideBandColor,
   resolveColorFocusRange,
   resolveGlucoseColorThresholds,
   glucoseColorFocusStops,
@@ -124,9 +124,11 @@ describe("getFocusedIntensityFill", () => {
     expect(colorShare(high)).toBe(100);
   });
 
-  it("keeps the range itself inclusive at both boundaries", () => {
-    expect(colorShare(getFocusedIntensityFill(10, focus, cssVar))).toBe(15);
+  it("keeps the maximum itself inside the range", () => {
     expect(colorShare(getFocusedIntensityFill(70, focus, cssVar))).toBe(100);
+    expect(colorShare(getFocusedIntensityFill(70.000001, focus, cssVar))).toBe(
+      15
+    );
   });
 
   it("leaves a day with no value at the faintest color", () => {
@@ -191,11 +193,15 @@ describe("colorFocusGradient", () => {
 
 describe("glucose focus band", () => {
   const stops = GLUCOSE_HEATMAP_LEGEND_STOPS;
-  const outside = "var(--glucose-heatmap-1)";
+  const outside = GLUCOSE_HEATMAP_OUTSIDE_COLOR;
 
   it("spans the outermost two boundaries", () => {
     expect(glucoseColorFocusBand([60, 100, 200, 280])).toEqual([60, 280]);
-    expect(outsideBandColor(stops)).toBe(outside);
+  });
+
+  it("takes its outside color from the theme, not from either end of the ramp", () => {
+    expect(outside).toBe(GLUCOSE_HEATMAP_OUTSIDE_COLOR);
+    expect(stops.map((stop) => stop.color)).not.toContain(outside);
   });
 
   it("falls back to the defaults for an unusable saved value", () => {
@@ -246,6 +252,38 @@ describe("glucose focus band", () => {
     expect(gradient).toContain(`${outside} 0%, ${outside} ${at(100)}%`);
     expect(gradient).toContain(`${outside} ${at(180)}%, ${outside} 100%)`);
     expect(gradient).not.toContain("var(--glucose-heatmap-9)");
+  });
+
+  it("carries the ramp all the way to both boundaries", () => {
+    const thresholds = [100, 120, 160, 180] as const;
+    const focused = glucoseColorFocusStops(thresholds);
+    const gradient = glucoseColorFocusGradient(focused, thresholds);
+
+    for (const boundary of [thresholds[0], thresholds[3]]) {
+      const position = ((boundary - 40) / (350 - 40)) * 100;
+      const atBoundary = gradient
+        .split(", ")
+        .filter((stop) => stop.endsWith(`${position}%`));
+      // One stop closes the flat block, one opens or closes the ramp: a hard cut.
+      expect(atBoundary).toHaveLength(2);
+      expect(
+        atBoundary.filter((stop) => stop.startsWith(outside))
+      ).toHaveLength(1);
+      expect(gradient).toContain(
+        `${getFocusedGlucoseFill(boundary, thresholds, focused)} ${position}%`
+      );
+    }
+  });
+
+  it("never re-blends an anchor that already sits on a boundary", () => {
+    const thresholds = [54, 72, 180, 250] as const;
+    const gradient = glucoseColorFocusGradient(
+      glucoseColorFocusStops(thresholds),
+      thresholds
+    );
+
+    expect(gradient).not.toContain("color-mix(in srgb, color-mix");
+    expect(gradient).not.toContain(" 0.00%,");
   });
 });
 

--- a/src/Web/packages/app/src/lib/utils/metric-color-focus.test.ts
+++ b/src/Web/packages/app/src/lib/utils/metric-color-focus.test.ts
@@ -5,8 +5,12 @@ import {
 } from "./chart-colors";
 import {
   colorFocusGradient,
+  glucoseColorFocusBand,
+  glucoseColorFocusGradient,
+  getFocusedGlucoseFill,
   insertSliderSteps,
   getFocusedIntensityFill,
+  outsideBandColor,
   resolveColorFocusRange,
   resolveGlucoseColorThresholds,
   glucoseColorFocusStops,
@@ -108,14 +112,27 @@ describe("glucoseColorFocusStops", () => {
 });
 
 describe("getFocusedIntensityFill", () => {
-  it("clamps outliers to the selected endpoint colors", () => {
+  it("gives both ends outside the range the same faint color", () => {
     const low = getFocusedIntensityFill(10, focus, cssVar);
     const high = getFocusedIntensityFill(70, focus, cssVar);
 
     expect(getFocusedIntensityFill(0, focus, cssVar)).toBe(low);
-    expect(getFocusedIntensityFill(500, focus, cssVar)).toBe(high);
+    expect(getFocusedIntensityFill(500, focus, cssVar)).toBe(low);
+    expect(getFocusedIntensityFill(9.99, focus, cssVar)).toBe(low);
+    expect(getFocusedIntensityFill(70.01, focus, cssVar)).toBe(low);
     expect(colorShare(low)).toBe(15);
     expect(colorShare(high)).toBe(100);
+  });
+
+  it("keeps the range itself inclusive at both boundaries", () => {
+    expect(colorShare(getFocusedIntensityFill(10, focus, cssVar))).toBe(15);
+    expect(colorShare(getFocusedIntensityFill(70, focus, cssVar))).toBe(100);
+  });
+
+  it("leaves a day with no value at the faintest color", () => {
+    expect(getFocusedIntensityFill(NaN, focus, cssVar)).toBe(
+      getFocusedIntensityFill(10, focus, cssVar)
+    );
   });
 
   it("makes 20, 40 and 60 distinguishable despite an observed outlier of 500", () => {
@@ -144,33 +161,100 @@ describe("getFocusedIntensityFill", () => {
 });
 
 describe("colorFocusGradient", () => {
-  it("uses the cell endpoint colors with flat ends outside the selected focus", () => {
-    const low = getFocusedIntensityFill(0, focus, cssVar);
-    const high = getFocusedIntensityFill(500, focus, cssVar);
+  it("ramps across the focus and cuts back to the same color at both ends", () => {
+    const outside = getFocusedIntensityFill(10, focus, cssVar);
+    const peak = getFocusedIntensityFill(70, focus, cssVar);
     const gradient = colorFocusGradient(focus, 500, cssVar);
 
-    expect(gradient).toContain(`${low} 0%, ${low} 2%`);
-    const highStop = gradient
-      .slice(gradient.indexOf(high) + high.length)
-      .match(/^ ([\d.]+)%/);
-    expect(Number(highStop?.[1])).toBeCloseTo(14);
-    expect(gradient).toContain(`${high} 100%)`);
     expect(gradient).toMatch(/^linear-gradient\(to right,/);
+    expect(gradient).toContain(`${outside} 0%, ${outside} 2%`);
+    const stops = gradient
+      .slice("linear-gradient(to right, ".length, -1)
+      .split(", color-mix")
+      .map((stop, index) => (index === 0 ? stop : `color-mix${stop}`));
+    const [peakStop, cutStop] = stops.slice(2, 4);
+    expect(peakStop.startsWith(peak)).toBe(true);
+    expect(cutStop.startsWith(outside)).toBe(true);
+    expect(peakStop.slice(peak.length)).toBe(cutStop.slice(outside.length));
+    expect(gradient).toContain(`${outside} 100%)`);
   });
 
   it("keeps the selected maximum in the legend when observed values decrease", () => {
-    const high = getFocusedIntensityFill(70, focus, cssVar);
+    const outside = getFocusedIntensityFill(10, focus, cssVar);
+    const peak = getFocusedIntensityFill(70, focus, cssVar);
 
     expect(colorFocusGradient(focus, 20, cssVar)).toContain(
-      `${high} 100%, ${high} 100%`
+      `${peak} 100%, ${outside} 100%`
     );
+  });
+});
+
+describe("glucose focus band", () => {
+  const stops = GLUCOSE_HEATMAP_LEGEND_STOPS;
+  const outside = "var(--glucose-heatmap-1)";
+
+  it("spans the outermost two boundaries", () => {
+    expect(glucoseColorFocusBand([60, 100, 200, 280])).toEqual([60, 280]);
+    expect(outsideBandColor(stops)).toBe(outside);
+  });
+
+  it("falls back to the defaults for an unusable saved value", () => {
+    expect(glucoseColorFocusBand([250, 180, 72, 54])).toEqual([54, 250]);
+  });
+
+  it("gives days on either side of the band the same color", () => {
+    const thresholds = [100, 120, 160, 180] as const;
+    const focused = glucoseColorFocusStops(thresholds);
+
+    expect(getFocusedGlucoseFill(60, thresholds, focused)).toBe(outside);
+    expect(getFocusedGlucoseFill(300, thresholds, focused)).toBe(outside);
+    expect(getFocusedGlucoseFill(300, thresholds, focused)).toBe(
+      getFocusedGlucoseFill(60, thresholds, focused)
+    );
+  });
+
+  it("colors the middle of the band from the ramp", () => {
+    const thresholds = [100, 120, 160, 180] as const;
+    const focused = glucoseColorFocusStops(thresholds);
+    const middle = getFocusedGlucoseFill(140, thresholds, focused);
+
+    expect(middle).not.toBe(outside);
+    expect(middle).toBe(getGlucoseHeatmapFill(140, focused));
+  });
+
+  it("includes both boundaries in the band", () => {
+    const thresholds = [100, 120, 160, 180] as const;
+    const focused = glucoseColorFocusStops(thresholds);
+
+    expect(getFocusedGlucoseFill(100, thresholds, focused)).toBe(
+      getGlucoseHeatmapFill(100, focused)
+    );
+    expect(getFocusedGlucoseFill(180, thresholds, focused)).toBe(
+      getGlucoseHeatmapFill(180, focused)
+    );
+    expect(getFocusedGlucoseFill(99, thresholds, focused)).toBe(outside);
+    expect(getFocusedGlucoseFill(181, thresholds, focused)).toBe(outside);
+  });
+
+  it("draws the legend as a flat block, the ramp, then the same flat block", () => {
+    const thresholds = [100, 120, 160, 180] as const;
+    const focused = glucoseColorFocusStops(thresholds);
+    const gradient = glucoseColorFocusGradient(focused, thresholds);
+    const at = (mgdl: number) => ((mgdl - 40) / (350 - 40)) * 100;
+
+    expect(gradient).toMatch(/^linear-gradient\(to right in srgb,/);
+    expect(gradient).toContain(`${outside} 0%, ${outside} ${at(100)}%`);
+    expect(gradient).toContain(`${outside} ${at(180)}%, ${outside} 100%)`);
+    expect(gradient).not.toContain("var(--glucose-heatmap-9)");
   });
 });
 
 describe("insertSliderSteps", () => {
   it("inserts exact bounds without mutating or sorting the base again", () => {
     const base = Object.freeze([0, 0.1, 0.2, 1]);
-    expect(insertSliderSteps(base, [0.15, 0.1, 2, 0.15])).toEqual([0, 0.1, 0.15, 0.2, 1, 2]);
+    expect(insertSliderSteps(base, [0.15, 0.1, 2, 0.15])).toEqual([
+      0, 0.1, 0.15, 0.2, 1, 2,
+    ]);
     expect(base).toEqual([0, 0.1, 0.2, 1]);
   });
 });

--- a/src/Web/packages/app/src/lib/utils/metric-color-focus.test.ts
+++ b/src/Web/packages/app/src/lib/utils/metric-color-focus.test.ts
@@ -200,7 +200,6 @@ describe("glucose focus band", () => {
   });
 
   it("takes its outside color from the theme, not from either end of the ramp", () => {
-    expect(outside).toBe(GLUCOSE_HEATMAP_OUTSIDE_COLOR);
     expect(stops.map((stop) => stop.color)).not.toContain(outside);
   });
 
@@ -276,12 +275,11 @@ describe("glucose focus band", () => {
   });
 
   it("never re-blends an anchor that already sits on a boundary", () => {
-    const thresholds = [54, 72, 180, 250] as const;
-    const gradient = glucoseColorFocusGradient(
-      glucoseColorFocusStops(thresholds),
-      thresholds
-    );
+    const thresholds = [60, 100, 200, 280] as const;
+    const stops = glucoseColorFocusStops(thresholds);
 
+    expect(stops.some((stop) => stop.color.startsWith("color-mix"))).toBe(true);
+    const gradient = glucoseColorFocusGradient(stops, thresholds);
     expect(gradient).not.toContain("color-mix(in srgb, color-mix");
     expect(gradient).not.toContain(" 0.00%,");
   });

--- a/src/Web/packages/app/src/lib/utils/metric-color-focus.ts
+++ b/src/Web/packages/app/src/lib/utils/metric-color-focus.ts
@@ -1,5 +1,6 @@
 import {
   GLUCOSE_HEATMAP_LEGEND_STOPS,
+  GLUCOSE_HEATMAP_OUTSIDE_COLOR,
   getGlucoseHeatmapFill,
 } from "./chart-colors";
 
@@ -80,15 +81,6 @@ export function glucoseColorFocusBand(
   return [thresholds[0], thresholds[3]];
 }
 
-export function outsideBandColor(
-  stops: ReadonlyArray<{
-    mgdl: number;
-    color: string;
-  }> = GLUCOSE_HEATMAP_LEGEND_STOPS
-): string {
-  return stops[0].color;
-}
-
 export function getFocusedGlucoseFill(
   mgdl: number,
   thresholds: GlucoseColorThresholds,
@@ -99,7 +91,7 @@ export function getFocusedGlucoseFill(
 ): string {
   const [low, high] = glucoseColorFocusBand(thresholds);
   if (!Number.isFinite(mgdl) || mgdl < low || mgdl > high) {
-    return outsideBandColor(stops);
+    return GLUCOSE_HEATMAP_OUTSIDE_COLOR;
   }
   return getGlucoseHeatmapFill(mgdl, stops);
 }
@@ -111,7 +103,7 @@ export function glucoseColorFocusGradient(
   max: number = GLUCOSE_COLOR_MAX
 ): string {
   const [low, high] = glucoseColorFocusBand(thresholds);
-  const outside = outsideBandColor(stops);
+  const outside = GLUCOSE_HEATMAP_OUTSIDE_COLOR;
   const at = (mgdl: number) => ((mgdl - min) / (max - min)) * 100;
   const ramp = stops
     .filter((stop) => stop.mgdl > low && stop.mgdl < high)

--- a/src/Web/packages/app/src/lib/utils/metric-color-focus.ts
+++ b/src/Web/packages/app/src/lib/utils/metric-color-focus.ts
@@ -71,6 +71,63 @@ export function glucoseColorFocusStops(candidate: GlucoseColorThresholds) {
   });
 }
 
+export function glucoseColorFocusBand(
+  candidate: GlucoseColorThresholds
+): ColorFocusRange {
+  const thresholds =
+    resolveGlucoseColorThresholds(candidate) ??
+    DEFAULT_GLUCOSE_COLOR_THRESHOLDS;
+  return [thresholds[0], thresholds[3]];
+}
+
+export function outsideBandColor(
+  stops: ReadonlyArray<{
+    mgdl: number;
+    color: string;
+  }> = GLUCOSE_HEATMAP_LEGEND_STOPS
+): string {
+  return stops[0].color;
+}
+
+export function getFocusedGlucoseFill(
+  mgdl: number,
+  thresholds: GlucoseColorThresholds,
+  stops: ReadonlyArray<{
+    mgdl: number;
+    color: string;
+  }> = GLUCOSE_HEATMAP_LEGEND_STOPS
+): string {
+  const [low, high] = glucoseColorFocusBand(thresholds);
+  if (!Number.isFinite(mgdl) || mgdl < low || mgdl > high) {
+    return outsideBandColor(stops);
+  }
+  return getGlucoseHeatmapFill(mgdl, stops);
+}
+
+export function glucoseColorFocusGradient(
+  stops: ReadonlyArray<{ mgdl: number; color: string }>,
+  thresholds: GlucoseColorThresholds,
+  min: number = GLUCOSE_COLOR_MIN,
+  max: number = GLUCOSE_COLOR_MAX
+): string {
+  const [low, high] = glucoseColorFocusBand(thresholds);
+  const outside = outsideBandColor(stops);
+  const at = (mgdl: number) => ((mgdl - min) / (max - min)) * 100;
+  const ramp = stops
+    .filter((stop) => stop.mgdl > low && stop.mgdl < high)
+    .map((stop) => `${stop.color} ${at(stop.mgdl)}%`);
+  const positions = [
+    `${outside} 0%`,
+    `${outside} ${at(low)}%`,
+    `${getGlucoseHeatmapFill(low, stops)} ${at(low)}%`,
+    ...ramp,
+    `${getGlucoseHeatmapFill(high, stops)} ${at(high)}%`,
+    `${outside} ${at(high)}%`,
+    `${outside} 100%`,
+  ];
+  return `linear-gradient(to right in srgb, ${positions.join(", ")})`;
+}
+
 export function resolveColorFocusRange(
   candidate: unknown
 ): ColorFocusRange | null {
@@ -86,15 +143,18 @@ export function resolveColorFocusRange(
     : null;
 }
 
+// Clamping the top to full strength instead would leave the largest values permanently
+// at the loudest colour, so a narrowed range could only highlight a band and everything
+// above it.
 export function getFocusedIntensityFill(
   value: number,
   range: ColorFocusRange,
   cssVar: string
 ): string {
   const [min, max] = resolveColorFocusRange(range) ?? [0, 1];
-  const intensity = Number.isFinite(value)
-    ? Math.max(0, Math.min((value - min) / (max - min), 1))
-    : 0;
+  const position = (value - min) / (max - min);
+  const intensity =
+    Number.isFinite(value) && position >= 0 && position <= 1 ? position : 0;
   return `color-mix(in srgb, var(${cssVar}) ${Math.round(15 + intensity * 85)}%, transparent)`;
 }
 
@@ -108,9 +168,11 @@ export function colorFocusGradient(
     Number.isFinite(domainMax) ? domainMax : 1,
     validRange[1]
   );
-  const low = getFocusedIntensityFill(validRange[0], validRange, cssVar);
-  const high = getFocusedIntensityFill(validRange[1], validRange, cssVar);
-  return `linear-gradient(to right, ${low} 0%, ${low} ${(validRange[0] / domain) * 100}%, ${high} ${(validRange[1] / domain) * 100}%, ${high} 100%)`;
+  const outside = getFocusedIntensityFill(validRange[0], validRange, cssVar);
+  const peak = getFocusedIntensityFill(validRange[1], validRange, cssVar);
+  const start = (validRange[0] / domain) * 100;
+  const end = (validRange[1] / domain) * 100;
+  return `linear-gradient(to right, ${outside} 0%, ${outside} ${start}%, ${peak} ${end}%, ${outside} ${end}%, ${outside} 100%)`;
 }
 
 export function insertSliderSteps(base: readonly number[], extra: readonly number[]): number[] {

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
@@ -19,9 +19,12 @@
     GriTimelinePeriod,
   } from "$api/generated/nocturne-api-client";
   import { formatLongDate, getUnitLabel } from "$lib/utils/formatting";
-  import { getGlucoseHeatmapFill } from "$lib/utils/chart-colors";
-  import { glucoseUnits, yearOverviewColors } from "$lib/stores/appearance-store.svelte";
   import {
+    glucoseUnits,
+    yearOverviewColors,
+  } from "$lib/stores/appearance-store.svelte";
+  import {
+    getFocusedGlucoseFill,
     getFocusedIntensityFill,
     resolveColorFocusRange,
     resolveGlucoseColorThresholds,
@@ -77,7 +80,8 @@
       : resolveColorFocusRange(colorFocusPreferences[selectedMetric])
   );
   const glucoseThresholds = $derived(
-    resolveGlucoseColorThresholds(colorFocusPreferences.avgGlucose) ?? DEFAULT_GLUCOSE_COLOR_THRESHOLDS
+    resolveGlucoseColorThresholds(colorFocusPreferences.avgGlucose) ??
+      DEFAULT_GLUCOSE_COLOR_THRESHOLDS
   );
   const glucoseLegendStops = $derived(
     glucoseColorFocusStops(glucoseThresholds)
@@ -218,7 +222,11 @@
 
     if (selectedMetric === "avgGlucose") {
       if (data.value != null && Number.isFinite(data.value))
-        return getGlucoseHeatmapFill(data.value, glucoseLegendStops);
+        return getFocusedGlucoseFill(
+          data.value,
+          glucoseThresholds,
+          glucoseLegendStops
+        );
       if (data.filteredCount > 0) return "var(--muted)";
       return "rgb(0 0 0 / 5%)";
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/year-color-focus.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/year-color-focus.svelte.test.ts
@@ -191,7 +191,7 @@ describe("year overview page color focus integration", () => {
     olderYear.resolve({ days: [day("2025-01-01", 1000)] });
     await expect
       .element(cell("2025-01-01"))
-      .toHaveTextContent("var(--chart-4) 100%");
+      .toHaveTextContent("var(--chart-4) 15%");
     await expect
       .element(cell("2026-01-01"))
       .toHaveTextContent("var(--chart-4) 58%");
@@ -210,7 +210,7 @@ describe("year overview page color focus integration", () => {
       .toHaveTextContent("var(--chart-4) 18%");
   });
 
-  it("saturates outliers without treating missing readings as zero or changing glucose colors", async () => {
+  it("dims outliers on both sides without treating missing readings as zero or changing glucose colors", async () => {
     yearOverviewMocks.days.mockResolvedValue({
       days: [
         day("2026-01-01", null),
@@ -239,7 +239,7 @@ describe("year overview page color focus integration", () => {
       .toHaveTextContent("var(--chart-4) 100%");
     await expect
       .element(cell("2026-01-05"))
-      .toHaveTextContent("var(--chart-4) 100%");
+      .toHaveTextContent("var(--chart-4) 15%");
 
     await selectMetric("Avg Glucose");
     expect(page.getByRole("slider").elements()).toHaveLength(4);

--- a/src/Web/packages/ui/src/styles/nocturne-theme.css
+++ b/src/Web/packages/ui/src/styles/nocturne-theme.css
@@ -21,6 +21,11 @@
   --glucose-heatmap-8: #ef4444; /* red-500 */
   --glucose-heatmap-9: #b91c1c; /* red-700 */
 
+  /* Days outside the focused band. Deliberately not a ramp anchor: it must recede into
+     the page in both schemes, where --glucose-heatmap-1 inverts to contrast with it.
+     Kept clear of --muted (0.92-0.95 light, 0.22-0.25 dark), which means "no reading". */
+  --glucose-heatmap-outside: oklch(0.86 0.01 250);
+
   /* Day-of-week series (week-to-week comparison). Qualitative: the hues separate
      one weekday from another and say nothing about the readings. Okabe-Ito
      derived, so the seven stay distinguishable under common colour vision
@@ -111,6 +116,7 @@
 
 .dark {
   --glucose-heatmap-1: #ffffff;
+  --glucose-heatmap-outside: oklch(0.32 0.015 250);
   /* Insulin Types - Dark Mode - need higher opacity for visibility */
   --insulin-basal: rgba(100, 180, 255, 0.35);
   --insulin-temp-basal: rgba(140, 200, 255, 0.5);

--- a/src/Web/packages/ui/src/styles/nocturne-theme.css
+++ b/src/Web/packages/ui/src/styles/nocturne-theme.css
@@ -23,8 +23,10 @@
 
   /* Days outside the focused band. Deliberately not a ramp anchor: it must recede into
      the page in both schemes, where --glucose-heatmap-1 inverts to contrast with it.
-     Kept clear of --muted (0.92-0.95 light, 0.22-0.25 dark), which means "no reading". */
-  --glucose-heatmap-outside: oklch(0.86 0.01 250);
+     Tinted rather than grey, and held at least 1.6:1 (light) / 2.7:1 (dark) against every
+     theme's --muted, which is the near-neutral already meaning "no reading" on this
+     heatmap: two greys separable only by luminance read as the same tile. */
+  --glucose-heatmap-outside: oklch(0.78 0.05 300);
 
   /* Day-of-week series (week-to-week comparison). Qualitative: the hues separate
      one weekday from another and say nothing about the readings. Okabe-Ito
@@ -116,7 +118,7 @@
 
 .dark {
   --glucose-heatmap-1: #ffffff;
-  --glucose-heatmap-outside: oklch(0.32 0.015 250);
+  --glucose-heatmap-outside: oklch(0.53 0.06 300);
   /* Insulin Types - Dark Mode - need higher opacity for visibility */
   --insulin-basal: rgba(100, 180, 255, 0.35);
   --insulin-temp-basal: rgba(140, 200, 255, 0.5);


### PR DESCRIPTION
## What

The year-overview color controls clamped values above the focus maximum to the strongest color. However far you narrowed the range, the largest values stayed fully highlighted, so picking out a middle band was impossible.

Both ends outside the range now share one color.

- **Metric sliders** (Bolus, Basal, TDD, Carbs, Time in Range) — the ramp runs inside Min–Max and cuts hard back at Max rather than fading to it. Both boundaries are inclusive. On the automatic range nothing falls outside, so the default view is unchanged.
- **Avg Glucose** — the band is the outermost two boundaries. Inside it the ramp is as before; beyond either end both sides take a new `--glucose-heatmap-outside` token.

## The outside-band color

It is deliberately **not** a ramp anchor. `--glucose-heatmap-1` inverts by scheme (black on light, white on dark) because it is the very-low anchor and is meant to contrast with the page; reusing it drew out-of-band days as glaring white tiles in dark mode, and drew a 300 mg/dL day in the hypo color while the same cell's tooltip printed the reading in red. The new token recedes in both schemes and is kept clear of `--muted` (0.92–0.95 light, 0.22–0.25 dark), which on this heatmap already means "no reading" and has its own legend swatch. `@media print` gets a pale override, since that block otherwise forces `--glucose-heatmap-1: #000`.

Glucose targets, Time in Range and every stored threshold are untouched; this is presentation only.

## Also fixes: the control undoing an edit

1. `ColorFocusRange.svelte` — the effect syncing the number inputs rewrote the whole draft array whenever `values` changed, so a change to one bound discarded an edit in another. It now compares per field. The trigger is `glucoseThresholds` re-deriving into a fresh array of identical numbers on every preference write.
2. `ColorFocusRange.svelte` — `change()` persisted unconditionally. Bits UI re-runs its snap check on *every* reactive flush here, because the binding getter `() => [...values]` hands it a new array identity on each read; its re-offer of the value already held rewrote the preference cookie and re-armed the 400 ms backend PATCH. No-op candidates are now dropped — and `changeBound` puts the input back itself, because a dropped write leaves `values` unmoved and so nothing else would.

Neither could be reproduced live (no browser on the authoring machine, and the vitest browser harness would not start), so these are traced rather than observed. Both write-through call sites therefore now report failures through one helper that also catches a synchronous throw; `reconcilePreferences` had been swallowing them entirely.

## Ruled out while tracing

`reconcilePreferences` runs once per document; SvelteKit commands neither invalidate loads nor refresh any query on this page; the generated client sends `yearOverviewColors` verbatim; and the server's merge and validation both accept it.

## Behaviour changes worth calling out

- Days outside the glucose band no longer ramp toward deep red / the very-low anchor; at the default boundaries (54 / 250) that changes the out-of-the-box view.
- `getGlucoseHeatmapFill` now returns an exact anchor's own color instead of a 0%-weighted mix of it. Same rendered color, shorter string; it also stops the legend nesting one `color-mix` inside another.
- `ColorFocusRange`'s `stops` prop default changed from `[]` to `GLUCOSE_HEATMAP_LEGEND_STOPS`. No caller relies on the old default.
- The slider's `aria-label` now names the band rather than the full 40–350 scale.

## Testing

- `vitest run src/lib/utils src/lib/stores` — **357 pass**.
- Full unit suite: 1206 pass, 1 skipped. One unrelated failure (`alerts/types.test.ts`) comes from concurrent uncommitted work in the same tree, not from this branch.
- Mutation-checked: deleting the legend's top-boundary ramp stop, and duplicating a boundary anchor into the ramp, both now fail. (`position >= 0` → `> 0` is an equivalent mutant — both sides yield intensity 0 — so it is deliberately not pinned.)
- `pnpm run check`: no error in any file this branch touches. `+page.svelte:40` carries a pre-existing unused-variable error unrelated to the diff.
- ESLint: no new errors. Two new `security/detect-object-injection` warnings in `ColorFocusRange.svelte`, consistent with the file's existing indexed access.
- Two browser assertions in `year-color-focus.svelte.test.ts` that asserted the old saturate-the-top behaviour are corrected, and the test whose name promised it is renamed. Note `@nocturne/app` vitest runs in no CI job, so these were verified by hand.
